### PR TITLE
Do not swallow PEAR error.

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -124,7 +124,10 @@
 
 		$oDB =& getDB();
 		$x = $oDB->getRow('select * from place limit 1');
-		if (!$x || PEAR::isError($x)) fail('No Data');
+		if (PEAR::isError($x)) {
+			fail($x->getMessage());
+		}
+		if (!$x) fail('No Data');
 	}
 
 	if ($aCMDResult['create-functions'] || $aCMDResult['all'])


### PR DESCRIPTION
I found the simple "No Data" error message not helpful when there possibly is a more detailed one. This fails with the PEAR error message, in case there is one.
