### PR TITLE
Added a serial-threads options to have control over the memory used in the load-data part

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -1,14 +1,3 @@
-$registry = Zend_Registry::getInstance();
-        if (!isset($registry[__CLASS__])) {
-            require_once 'ZendX/JQuery/View/Helper/JQuery/Container.php';
-            $container = new ZendX_JQuery_View_Helper_JQuery_Container();
-            $registry[__CLASS__] = $container;
-        }
-        $this->_container = $registry[__CLASS__];
-
-
-
-
 #!/usr/bin/php -Cq
 <?php
 


### PR DESCRIPTION
In some cases of postgres-configuration the different threads in the load-data part require much working memory and when it comes to swap, the process becomes endless slow. With the serial-threads option you can scale the amount of RAM that will be used at the same time.
