### PR TITLE
Order search results by importance of address parts

### DIFF
--- a/website/search.php
+++ b/website/search.php
@@ -957,20 +957,16 @@
 							if ($sNearPointSQL) $aOrder[] = "ST_Distance($sNearPointSQL, centroid) asc";
 
 							$sImportanceSQL = '(case when importance = 0 OR importance IS NULL then 0.75-(search_rank::float/40) else importance end)';
-							if (sizeof($aSearch['aFullNameAddress']))
-								$sImportanceSQL .= '*(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s)';
-
 							if ($sViewboxSmallSQL) $sImportanceSQL .= " * case when ST_Contains($sViewboxSmallSQL, centroid) THEN 1 ELSE 0.5 END";
 							if ($sViewboxLargeSQL) $sImportanceSQL .= " * case when ST_Contains($sViewboxLargeSQL, centroid) THEN 1 ELSE 0.5 END";
 							$aOrder[] = "$sImportanceSQL DESC";
+							if (sizeof($aSearch['aFullNameAddress']))
+								$aOrder[] = '(select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s) DESC';
+
 						
 							if (sizeof($aTerms))
 							{
 								$sSQL = "select place_id";
-								if (sizeof($aSearch['aFullNameAddress']))
-									$sSQL .= ', (select count(*) from (select unnest(ARRAY['.join($aSearch['aFullNameAddress'],",").']) INTERSECT select unnest(nameaddress_vector))s) as fullwords'; 
-								else
-									$sSQL .= ', 0';
 								$sSQL .= " from search_name";
 								$sSQL .= " where ".join(' and ',$aTerms);
 								$sSQL .= " order by ".join(', ',$aOrder);


### PR DESCRIPTION
This is an attempt to resolve the issue with result ordering when administrative entities of different levels share the same name.

This has two parts:
- make sure that results with exact name matches float on top when scanning search_name
- compute a combined importance from the address parts of each result and use that as secondary feature for result ordering

It can be tested here: http://poldi.osm.org/lonvia/search

Second part seems to work fairly well for the problematic results I know of, e.g
http://nominatim.osm.org/search.php?q=dlouh%C3%A1%2C+praha vs.
http://poldi.osm.org/lonvia/search.php?q=dlouh%C3%A1%2C+praha

It also helps for boosting the better known city in cases like this:
http://nominatim.osm.org/search.php?q=james+st%2C+london vs.
http://poldi.osm.org/lonvia/search.php?q=james+st%2C+london

The first part (exact name matches) gets mixed results because it depends on the fact that the name of the less important entity gets prefixed. Works here:

http://nominatim.osm.org/search?q=lessingstr%2C+stuttgart vs. 
http://poldi.osm.org/lonvia/search?q=lessingstr%2C+stuttgart

but doesn't help here (because the county node is called 'Karlsruhe' not the usual 'Landkreis Karlsruhe':

http://nominatim.osm.org/search?q=lessingstr%2C+karlsruhe vs. 
http://poldi.osm.org/lonvia/search?q=lessingstr%2C+karlsruhe

I couldn't find too many examples where it helps, so I'm not convinced it is worth the trouble.

Any thoughts?
