### PR TITLE
use osmosis --read-replication-lag to determine if there are changes

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -16,8 +16,12 @@
 	@define('CONST_Path_Postgresql_Postgis', CONST_Path_Postgresql_Contrib.'/postgis-'.CONST_Postgis_Version);
 	@define('CONST_Osm2pgsql_Binary', CONST_BasePath.'/osm2pgsql/osm2pgsql');
 	@define('CONST_Osmosis_Binary', '/usr/bin/osmosis');
+
+	// Replication settings
 	@define('CONST_Replication_Url', 'http://planet.openstreetmap.org/replication/minute');
 	@define('CONST_Replication_MaxInterval', '3600');
+	@define('CONST_Replication_Update_Interval', '60');  // How often upstream publishes diffs
+	@define('CONST_Replication_Recheck_Interval', '60'); // How long to sleep if no update found yet
 
 	// Connection buckets to rate limit people being nasty
 	@define('CONST_ConnectionBucket_MemcacheServerAddress', false);

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -505,7 +505,7 @@
 			
 			passthru(CONST_Osmosis_Binary.' --read-replication-interval-init '.CONST_BasePath.'/settings');
 			// update osmosis configuration.txt with our settings
-			passthru("sed -i 's!baseUrl=.*!baseUrL=".CONST_Replication_Url."!' ".CONST_BasePath.'/settings/configuration.txt');
+			passthru("sed -i 's!baseUrl=.*!baseUrl=".CONST_Replication_Url."!' ".CONST_BasePath.'/settings/configuration.txt');
 			passthru("sed -i 's:maxInterval = .*:maxInterval = ".CONST_Replication_MaxInterval.":' ".CONST_BasePath.'/settings/configuration.txt');
 		}
 


### PR DESCRIPTION
use osmosis --read-replication-lag to determine if there are changes before trying to process updates.

This is more applicable when we are tracking hourly or daily replication updates - otherwise osmosis is needlessly processing empty updates every minute
