### PR TITLE
Add osm2pgsql flat node support via settings.php

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -17,7 +17,7 @@
 	@define('CONST_Osm2pgsql_Binary', CONST_BasePath.'/osm2pgsql/osm2pgsql');
 	@define('CONST_Osmosis_Binary', '/usr/bin/osmosis');
 
-    // osm2pgsql settings
+	// osm2pgsql settings
 	@define('CONST_Osm2pgsql_Flatnode_File', null);
 
 	// Replication settings

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -155,10 +155,10 @@
 			fail("osm2pgsql not found in '$osm2pgsql'");
 		}
 
-        if (!is_null(CONST_Osm2pgsql_Flatnode_File))
-        {
-            $osm2pgsql .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
-        }
+		if (!is_null(CONST_Osm2pgsql_Flatnode_File))
+		{
+			$osm2pgsql .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
+		}
 		$osm2pgsql .= ' -lsc -O gazetteer --hstore';
 		$osm2pgsql .= ' -C '.$iCacheMemory;
 		$osm2pgsql .= ' -P '.$aDSNInfo['port'];

--- a/utils/update.php
+++ b/utils/update.php
@@ -115,10 +115,10 @@
 		{
 			// Import the file
 			$sCMD = CONST_Osm2pgsql_Binary.' -klas -C 2000 -O gazetteer -d '.$aDSNInfo['database'].' '.$sNextFile;
-            if (!is_null(CONST_Osm2pgsql_Flatnode_File))
-            {
-                $sCMD .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
-            }
+			if (!is_null(CONST_Osm2pgsql_Flatnode_File))
+			{
+				$sCMD .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
+			}
 			echo $sCMD."\n";
 			exec($sCMD, $sJunk, $iErrorLevel);
 
@@ -230,10 +230,10 @@
 
 		// import generated change file
 		$sCMD = CONST_Osm2pgsql_Binary.' -klas -C 2000 -O gazetteer -d '.$aDSNInfo['database'].' '.$sTemporaryFile;
-        if (!is_null(CONST_Osm2pgsql_Flatnode_File))
-        {
-            $sCMD .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
-        }
+		if (!is_null(CONST_Osm2pgsql_Flatnode_File))
+		{
+			$sCMD .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
+		}
 		echo $sCMD."\n";
 		exec($sCMD, $sJunk, $iErrorLevel);
 		if ($iErrorLevel)
@@ -363,10 +363,10 @@
 		$sCMDDownload = $sOsmosisCMD.' --read-replication-interval workingDirectory='.$sOsmosisConfigDirectory.' --simplify-change --write-xml-change '.$sImportFile;
 		$sCMDCheckReplicationLag = $sOsmosisCMD.' -q --read-replication-lag workingDirectory='.$sOsmosisConfigDirectory;
 		$sCMDImport = CONST_Osm2pgsql_Binary.' -klas -C 2000 -O gazetteer -d '.$aDSNInfo['database'].' '.$sImportFile;
-        if (!is_null(CONST_Osm2pgsql_Flatnode_File))
-        {
-            $sCMDImport .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
-        }
+		if (!is_null(CONST_Osm2pgsql_Flatnode_File))
+		{
+			$sCMDImport .= ' --flat-nodes '.CONST_Osm2pgsql_Flatnode_File;
+		}
 		$sCMDIndex = $sBasePath.'/nominatim/nominatim -i -d '.$aDSNInfo['database'].' -t '.$aResult['index-instances'];
 		if (!$aResult['no-npi']) {
 			$sCMDIndex .= '-F ';


### PR DESCRIPTION
New configuration option CONST_Osm2pgsql_Flatnode_File will cause Nominatim to set the --flat-nodes option on all calls to osm2pgsql. The value of the option must be a full path name accessible to the user running setup.php/update.php, ideally pointing to SSD storage. The flatnode option Improves performance and reduces disk usage for full planet operation.
