### PR TITLE
Support for partial matching of US ZIP+4 codes

### DIFF
--- a/website/search.php
+++ b/website/search.php
@@ -447,6 +447,28 @@
 							$aValidTokens[$sToken] = $aGBPostcodeLocation;
 						}
 					}
+					// US ZIP+4 codes - if there is no token,
+					// 	merge in the 5-digit ZIP code
+					else if (!isset($aValidTokens[$sToken]) && preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData))
+					{
+						if (isset($aValidTokens[$aData[1]]))
+						{
+							foreach($aValidTokens[$aData[1]] as $aToken)
+							{
+								if (!$aToken['class'])
+								{
+									if (isset($aValidTokens[$sToken]))
+									{
+										$aValidTokens[$sToken][] = $aToken;
+									}
+									else
+									{
+										$aValidTokens[$sToken] = array($aToken);
+									}
+								}
+							}
+						}
+					}
 				}
 
 				foreach($aTokens as $sToken)


### PR DESCRIPTION
Checks for ZIP+4 like tokens and adds the short 5-digit ZIP if the ZIP+4 code cannot be found in the DB.
