### PR TITLE
Moved license text to a constant. 

### DIFF
--- a/lib/template/address-json.php
+++ b/lib/template/address-json.php
@@ -11,7 +11,7 @@
 	else
 	{
 		if ($aPlace['place_id']) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
-		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
+		$aFilteredPlaces['licence'] = CONST_License;
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
                 if ($sOSMType)
                 {

--- a/lib/template/address-jsonv2.php
+++ b/lib/template/address-jsonv2.php
@@ -11,7 +11,7 @@
 	else
 	{
 		if ($aPlace['place_id']) $aFilteredPlaces['place_id'] = $aPlace['place_id'];
-		$aFilteredPlaces['licence'] = "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright";
+		$aFilteredPlaces['licence'] = CONST_License;
 		$sOSMType = ($aPlace['osm_type'] == 'N'?'node':($aPlace['osm_type'] == 'W'?'way':($aPlace['osm_type'] == 'R'?'relation':'')));
                 if ($sOSMType)
                 {

--- a/lib/template/address-xml.php
+++ b/lib/template/address-xml.php
@@ -7,7 +7,7 @@
 
 	echo "<reversegeocode";
 	echo " timestamp='".date(DATE_RFC822)."'";
-	echo " attribution='Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright'";
+	echo " attribution='".CONST_License."'";
 	echo " querystring='".htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES)."'";
 	echo ">\n";
 

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -6,7 +6,7 @@
 	{
 		$aPlace = array(
 				'place_id'=>$aPointDetails['place_id'],
-				'licence'=>"Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+				'licence'=>CONST_License,
 			);
 
 		$sOSMType = ($aPointDetails['osm_type'] == 'N'?'node':($aPointDetails['osm_type'] == 'W'?'way':($aPointDetails['osm_type'] == 'R'?'relation':'')));

--- a/lib/template/search-jsonv2.php
+++ b/lib/template/search-jsonv2.php
@@ -4,7 +4,7 @@
 	{
 		$aPlace = array(
 				'place_id'=>$aPointDetails['place_id'],
-				'licence'=>"Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+				'licence'=> CONST_License,
 			);
 
 		$sOSMType = ($aPointDetails['osm_type'] == 'N'?'node':($aPointDetails['osm_type'] == 'W'?'way':($aPointDetails['osm_type'] == 'R'?'relation':'')));

--- a/lib/template/search-xml.php
+++ b/lib/template/search-xml.php
@@ -7,7 +7,7 @@
 
 	echo "<searchresults";
 	echo " timestamp='".date(DATE_RFC822)."'";
-	echo " attribution='Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright'";
+	echo " attribution='".CONST_License."'";
 	echo " querystring='".htmlspecialchars($sQuery, ENT_QUOTES)."'";
 	if (isset($_GET['viewbox']) && $_GET['viewbox']) echo " viewbox='".htmlspecialchars($_GET['viewbox'], ENT_QUOTES)."'";
 	echo " polygon='".($bShowPolygons?'true':'false')."'";
@@ -120,5 +120,5 @@
 			echo "/>";
 		}
 	}
-	
+
 	echo "</searchresults>";

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -69,6 +69,7 @@
 
 	@define('CONST_Search_TryDroppedAddressTerms', false);
 	@define('CONST_Search_NameOnlySearchFrequencyThreshold', false);
+	@define('CONST_License', utf8_encode('Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright'));
 
 	// Set to zero to disable polygon output
 	@define('CONST_PolygonOutput_MaximumTypes', 1);

--- a/website/js/tiles.js
+++ b/website/js/tiles.js
@@ -49,7 +49,7 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
             "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
         ];
         options = OpenLayers.Util.extend({ numZoomLevels: 19, buffer: 0,
-           attribution : '© <a target="_parent" href="http://www.openstreetmap.org">OpenStreetMap</a> and contributors, under an <a target="_parent" href="http://www.openstreetmap.org/copyright">open license</a>' }, options);
+           attribution : '&copy; <a target="_parent" href="http://www.openstreetmap.org">OpenStreetMap</a> and contributors, under an <a target="_parent" href="http://www.openstreetmap.org/copyright">open license</a>' }, options);
         var newArguments = [name, url, options];
         OpenLayers.Layer.OSM.prototype.initialize.apply(this, newArguments);
     },


### PR DESCRIPTION
Use `utf8_encode` before sending copyright character to json_encode.
Also moved the license attribution to a constant.
