### PR TITLE
Logging output changes for diff updates

### DIFF
--- a/utils/update.php
+++ b/utils/update.php
@@ -419,6 +419,7 @@
 						// There are new replication files - use osmosis to download the file
 						echo "\n".date('Y-m-d H:i:s')." Replication Delay is ".$aReplicationLag[0]."\n";
 					}
+					$fStartTime = time();
 					$fCMDStartTime = time();
 					echo $sCMDDownload."\n";
 					exec($sCMDDownload, $sJunk, $iErrorLevel);
@@ -434,7 +435,7 @@
 					$sSQL = "INSERT INTO import_osmosis_log values ('$sBatchEnd',$iFileSize,'".date('Y-m-d H:i:s',$fCMDStartTime)."','".date('Y-m-d H:i:s')."','osmosis')";
 					var_Dump($sSQL);
 					$oDB->query($sSQL);
-					echo date('Y-m-d H:i:s')." Completed for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
+					echo date('Y-m-d H:i:s')." Completed osmosis step for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
 				}
 
 				$iFileSize = filesize($sImportFile);
@@ -449,11 +450,10 @@
 					echo "Error: $iErrorLevel\n";
 					exit($iErrorLevel);
 				}
-				echo date('Y-m-d H:i:s')." Completed for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
 				$sSQL = "INSERT INTO import_osmosis_log values ('$sBatchEnd',$iFileSize,'".date('Y-m-d H:i:s',$fCMDStartTime)."','".date('Y-m-d H:i:s')."','osm2pgsql')";
 				var_Dump($sSQL);
 				$oDB->query($sSQL);
-				echo date('Y-m-d H:i:s')." Completed for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
+				echo date('Y-m-d H:i:s')." Completed osm2pgsql step for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
 
 				// Archive for debug?
 				unlink($sImportFile);
@@ -523,13 +523,13 @@
 			$sSQL = "INSERT INTO import_osmosis_log values ('$sBatchEnd',$iFileSize,'".date('Y-m-d H:i:s',$fCMDStartTime)."','".date('Y-m-d H:i:s')."','index')";
 			var_Dump($sSQL);
 			$oDB->query($sSQL);
-			echo date('Y-m-d H:i:s')." Completed for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
+			echo date('Y-m-d H:i:s')." Completed index step for $sBatchEnd in ".round((time()-$fCMDStartTime)/60,2)." minutes\n";
 
 			$sSQL = "update import_status set lastimportdate = '$sBatchEnd'";
 			$oDB->query($sSQL);
 
 			$fDuration = time() - $fStartTime;
-			echo date('Y-m-d H:i:s')." Completed for $sBatchEnd in ".round($fDuration/60,2)."\n";
+			echo date('Y-m-d H:i:s')." Completed all for $sBatchEnd in ".round($fDuration/60,2)." minutes\n";
 			if (!$aResult['import-osmosis-all']) exit;
 
 			if ( CONST_Replication_Update_Interval > 60 )


### PR DESCRIPTION
Minor changes to output during   import-osmosis
1.  start time for indexing step wasn't set
2.  add dateline to output lines

example output:

................................................................
2013-10-03 01:53:18 Replication Delay is 86399
/usr/local/bin/osmosis --read-replication-interval workingDirectory=/home/roles/nominatim/app/Nominatim/settings --simplify-change --write-xml-change /home/roles/nominatim/app/Nominatim/data/osmosischange.osc
string(124) "INSERT INTO import_osmosis_log values ('2013-10-02T19:15:01Z',6613411,'2013-10-03 01:53:18','2013-10-03 01:53:31','osmosis')"
2013-10-03 01:53:31 Completed osmosis step for 2013-10-02T19:15:01Z in 0.22 minutes
/home/roles/nominatim/app/Nominatim/osm2pgsql/osm2pgsql -klas -C 2000 -O gazetteer -d nominatim /home/roles/nominatim/app/Nominatim/data/osmosischange.osc
string(126) "INSERT INTO import_osmosis_log values ('2013-10-02T19:15:01Z',6613411,'2013-10-03 01:53:31','2013-10-03 01:54:41','osm2pgsql')"
2013-10-03 01:54:41 Completed osm2pgsql step for 2013-10-02T19:15:01Z in 1.17 minutes
/home/roles/nominatim/app/Nominatim/nominatim/nominatim -i -d nominatim -t 1
string(122) "INSERT INTO import_osmosis_log values ('2013-10-02T19:15:01Z',6613411,'2013-10-03 01:54:41','2013-10-03 01:55:28','index')"
2013-10-03 01:55:28 Completed index step for 2013-10-02T19:15:01Z in 0.78 minutes
2013-10-03 01:55:28 Completed all for 2013-10-02T19:15:01Z in 2.17 minutes
2013-10-03 01:55:28 Sleeping 62373 seconds
