### PR TITLE
prefer place tag for address details

### DIFF
--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -124,7 +124,7 @@
 				{
 					$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
 					$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-					if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]))
+					if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
 					{
 						$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
 					}

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -788,7 +788,7 @@
 			{
 				$sTypeLabel = strtolower(isset($aTypeLabel['simplelabel'])?$aTypeLabel['simplelabel']:$aTypeLabel['label']);
 				$sTypeLabel = str_replace(' ','_',$sTypeLabel);
-				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]))
+				if (!isset($aAddress[$sTypeLabel]) || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel]) || $aLine['class'] == 'place')
 				{
 					$aAddress[$sTypeLabel] = $aLine['localname']?$aLine['localname']:$aLine['housenumber'];
 				}

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -2501,7 +2501,9 @@ BEGIN
   FOR location IN 
     select placex.place_id, osm_type, osm_id,
       CASE WHEN class = 'place' and type = 'postcode' THEN hstore('name', postcode) ELSE name END as name,
-      class, type, admin_level, fromarea, isaddress,
+      CASE WHEN extratags ? 'place' THEN 'place' ELSE class END as class,
+      CASE WHEN extratags ? 'place' THEN extratags->'place' ELSE type END as type,
+      admin_level, fromarea, isaddress,
       CASE WHEN address_place_id = for_place_id AND rank_address = 0 THEN 100 WHEN rank_address = 11 THEN 5 ELSE rank_address END as rank_address,
       distance,calculated_country_code,postcode
       from place_addressline join placex on (address_place_id = placex.place_id) 


### PR DESCRIPTION
This is an attempt to fix problems with the labels of boundaries in the address details (a) when unusual admin levels are used (e.g. #51) or (b) when boundaries span multiple admin levels (e.g. German city-counties like [Frankfurt](http://www.openstreetmap.org/relation/62400)). The idea is that if a place tag is found in extratags then this is preferred for determining the label for the address details.

There are currently around 54k boundaries with place tags, so this change might have a rather noticeable effect on the output.
