### PR TITLE
Update setup.php

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -607,7 +607,7 @@
 			}
 			if ($aPrevRepMatch) $aRepMatch = $aPrevRepMatch;
 
-			$sRepURL .= $aRepMatch[1].'.state.txt';
+			$sRepURL .= $aRepMatch[1].'state.txt';
 			echo "Getting state file: $sRepURL\n";
 			$sStateFile = file_get_contents($sRepURL);
 			if (!$sStateFile || strlen($sStateFile) > 1000) fail("unable to obtain state file");


### PR DESCRIPTION
typo of . before filename cause setup to fail with following error:
PHP Warning:  file_get_contents(http://planet.openstreetmap.org/replication/minute/.state.txt): failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found
 in /usr/src/Nominatim/utils/setup.php on line 604
