### PR TITLE
remove polygon=1 (polypoints) feature

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -245,7 +245,6 @@ class Geocode
         }
 
         $this->oPlaceLookup->loadParamArray($oParams, $sForceGeometryType);
-        $this->oPlaceLookup->setIncludePolygonAsPoints($oParams->getBool('polygon'));
         $this->oPlaceLookup->setIncludeAddressDetails($oParams->getBool('addressdetails', false));
     }
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -15,7 +15,6 @@ class PlaceLookup
     protected $bExtraTags = false;
     protected $bNameDetails = false;
 
-    protected $bIncludePolygonAsPoints = false;
     protected $bIncludePolygonAsText = false;
     protected $bIncludePolygonAsGeoJSON = false;
     protected $bIncludePolygonAsKML = false;
@@ -38,11 +37,6 @@ class PlaceLookup
         return $this->bDeDupe;
     }
 
-    public function setIncludePolygonAsPoints($b = true)
-    {
-        $this->bIncludePolygonAsPoints = $b;
-    }
-
     public function setIncludeAddressDetails($b)
     {
         $this->bAddressDetails = $b;
@@ -61,7 +55,6 @@ class PlaceLookup
 
         if ($sGeomType === null || $sGeomType == 'geojson') {
             $this->bIncludePolygonAsGeoJSON = $oParams->getBool('polygon_geojson');
-            $this->bIncludePolygonAsPoints = false;
         }
 
         if ($oParams->getString('format', '') !== 'geojson') {
@@ -100,7 +93,6 @@ class PlaceLookup
         if ($this->bExtraTags) $aParams['extratags'] = '1';
         if ($this->bNameDetails) $aParams['namedetails'] = '1';
 
-        if ($this->bIncludePolygonAsPoints) $aParams['polygon'] = '1';
         if ($this->bIncludePolygonAsText) $aParams['polygon_text'] = '1';
         if ($this->bIncludePolygonAsGeoJSON) $aParams['polygon_geojson'] = '1';
         if ($this->bIncludePolygonAsKML) $aParams['polygon_kml'] = '1';
@@ -499,7 +491,7 @@ class PlaceLookup
             if ($this->bIncludePolygonAsGeoJSON) $sSQL .= ',ST_AsGeoJSON(geometry) as asgeojson';
             if ($this->bIncludePolygonAsKML) $sSQL .= ',ST_AsKML(geometry) as askml';
             if ($this->bIncludePolygonAsSVG) $sSQL .= ',ST_AsSVG(geometry) as assvg';
-            if ($this->bIncludePolygonAsText || $this->bIncludePolygonAsPoints) $sSQL .= ',ST_AsText(geometry) as astext';
+            if ($this->bIncludePolygonAsText) $sSQL .= ',ST_AsText(geometry) as astext';
             if ($fLonReverse != null && $fLatReverse != null) {
                 $sFrom = ' from (SELECT * , CASE WHEN (class = \'highway\') AND (ST_GeometryType(geometry) = \'ST_LineString\') THEN ';
                 $sFrom .=' ST_ClosestPoint(geometry, ST_SetSRID(ST_Point('.$fLatReverse.','.$fLonReverse.'),4326))';
@@ -526,8 +518,6 @@ class PlaceLookup
                 if ($this->bIncludePolygonAsKML) $aOutlineResult['askml'] = $aPointPolygon['askml'];
                 if ($this->bIncludePolygonAsSVG) $aOutlineResult['assvg'] = $aPointPolygon['assvg'];
                 if ($this->bIncludePolygonAsText) $aOutlineResult['astext'] = $aPointPolygon['astext'];
-                if ($this->bIncludePolygonAsPoints) $aOutlineResult['aPolyPoints'] = geometryText2Points($aPointPolygon['astext'], $fRadius);
-
 
                 if (abs($aPointPolygon['minlat'] - $aPointPolygon['maxlat']) < 0.0000001) {
                     $aPointPolygon['minlat'] = $aPointPolygon['minlat'] - $fRadius;
@@ -550,17 +540,12 @@ class PlaceLookup
 
         // as a fallback we generate a bounding box without knowing the size of the geometry
         if ((!isset($aOutlineResult['aBoundingBox'])) && isset($fLon)) {
-            //
-            if ($this->bIncludePolygonAsPoints) {
-                $sGeometryText = 'POINT('.$fLon.','.$fLat.')';
-                $aOutlineResult['aPolyPoints'] = geometryText2Points($sGeometryText, $fRadius);
-            }
-
-            $aBounds = array();
-            $aBounds['minlat'] = $fLat - $fRadius;
-            $aBounds['maxlat'] = $fLat + $fRadius;
-            $aBounds['minlon'] = $fLon - $fRadius;
-            $aBounds['maxlon'] = $fLon + $fRadius;
+            $aBounds = array(
+                        'minlat' => $fLat - $fRadius,
+                        'maxlat' => $fLat + $fRadius,
+                        'minlon' => $fLon - $fRadius,
+                        'maxlon' => $fLon + $fRadius
+                       );
 
             $aOutlineResult['aBoundingBox'] = array(
                                                (string)$aBounds['minlat'],

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -165,39 +165,6 @@ function parseLatLon($sQuery)
     return array($sFound, $fQueryLat, $fQueryLon);
 }
 
-
-function geometryText2Points($geometry_as_text, $fRadius)
-{
-    $aPolyPoints = null;
-    if (preg_match('#POLYGON\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
-        //
-        preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-        //
-    } elseif (preg_match('#LINESTRING\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
-        //
-        preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-        //
-    } elseif (preg_match('#MULTIPOLYGON\\(\\(\\(([- 0-9.,]+)#', $geometry_as_text, $aMatch)) {
-        //
-        preg_match_all('/(-?[0-9.]+) (-?[0-9.]+)/', $aMatch[1], $aPolyPoints, PREG_SET_ORDER);
-        //
-    } elseif (preg_match('#POINT\\((-?[0-9.]+) (-?[0-9.]+)\\)#', $geometry_as_text, $aMatch)) {
-        //
-        $aPolyPoints = createPointsAroundCenter($aMatch[1], $aMatch[2], $fRadius);
-        //
-    }
-
-    if (isset($aPolyPoints)) {
-        $aResultPoints = array();
-        foreach ($aPolyPoints as $aPoint) {
-            $aResultPoints[] = array($aPoint[1], $aPoint[2]);
-        }
-        return $aResultPoints;
-    }
-
-    return;
-}
-
 function createPointsAroundCenter($fLon, $fLat, $fRadius)
 {
     $iSteps = max(8, min(100, ($fRadius * 40000)^2));

--- a/lib/template/search-batch-json.php
+++ b/lib/template/search-batch-json.php
@@ -25,10 +25,6 @@ foreach ($aBatchResults as $aSearchResults) {
                                       $aPointDetails['aBoundingBox'][2],
                 $aPointDetails['aBoundingBox'][3]
                                      );
-
-            if (isset($aPointDetails['aPolyPoints']) && $bShowPolygons) {
-                $aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
-            }
         }
 
         if (isset($aPointDetails['zoom'])) {

--- a/lib/template/search-json.php
+++ b/lib/template/search-json.php
@@ -15,10 +15,6 @@ foreach ($aSearchResults as $iResNum => $aPointDetails) {
 
     if (isset($aPointDetails['aBoundingBox'])) {
         $aPlace['boundingbox'] = $aPointDetails['aBoundingBox'];
-
-        if (isset($aPointDetails['aPolyPoints'])) {
-            $aPlace['polygonpoints'] = $aPointDetails['aPolyPoints'];
-        }
     }
 
     if (isset($aPointDetails['zoom'])) {

--- a/lib/template/search-xml.php
+++ b/lib/template/search-xml.php
@@ -11,7 +11,6 @@ echo " timestamp='".date(DATE_RFC822)."'";
 echo " attribution='Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright'";
 echo " querystring='".htmlspecialchars($sQuery, ENT_QUOTES)."'";
 if (isset($aMoreParams['viewbox'])) echo " viewbox='".htmlspecialchars($aMoreParams['viewbox'], ENT_QUOTES)."'";
-echo " polygon='".(isset($aMoreParams['polygon'])?'true':'false')."'";
 if (isset($aMoreParams['exclude_place_ids'])) {
     echo " exclude_place_ids='".htmlspecialchars($aMoreParams['exclude_place_ids'])."'";
 }
@@ -31,12 +30,6 @@ foreach ($aSearchResults as $iResNum => $aResult) {
         echo ' boundingbox="';
         echo join(',', $aResult['aBoundingBox']);
         echo '"';
-
-        if (isset($aResult['aPolyPoints'])) {
-            echo ' polygonpoints=\'';
-            echo json_encode($aResult['aPolyPoints']);
-            echo '\'';
-        }
     }
 
     if (isset($aResult['asgeojson'])) {

--- a/test/bdd/api/reverse/params.feature
+++ b/test/bdd/api/reverse/params.feature
@@ -63,18 +63,6 @@ Feature: Parameters for Reverse API
         | json     | geotext |
         | jsonv2   | geotext |
 
-    Scenario Outline: Reverse Geocoding contains polygon-as-points geometry
-        When sending <format> reverse coordinates 47.165989816710066,9.515774846076965
-          | polygon |
-          | 1 |
-        Then result 0 has not attributes <response_attribute>
-
-    Examples:
-        | format   | response_attribute |
-        | xml      | polygonpoints |
-        | json     | polygonpoints |
-        | jsonv2   | polygonpoints |
-
     Scenario Outline: Reverse Geocoding contains SVG geometry
         When sending <format> reverse coordinates 47.165989816710066,9.515774846076965
           | polygon_svg |
@@ -114,8 +102,8 @@ Feature: Parameters for Reverse API
 
     Scenario Outline: Reverse Geocoding in geojson format contains no non-geojson geometry
         When sending geojson reverse coordinates 47.165989816710066,9.515774846076965
-          | polygon_text | polygon | polygon_svg | polygon_geokml |
-          | 1            | 1       | 1           | 1              |
+          | polygon_text | polygon_svg | polygon_geokml |
+          | 1            | 1           | 1              |
         Then result 0 has not attributes <response_attribute>
 
     Examples:
@@ -125,3 +113,15 @@ Feature: Parameters for Reverse API
         | svg                |
         | geokml             |
 
+    Scenario Outline: Reverse Geocoding with old deprecated polygon type
+        When sending <format> reverse coordinates 47.165989816710066,9.515774846076965
+          | polygon |
+          | 1       |
+        Then a HTTP 400 is returned
+
+    Examples:
+        | format   |
+        | xml      |
+        | json     |
+        | jsonv2   |
+        | geojson  |

--- a/test/bdd/api/reverse/simple.feature
+++ b/test/bdd/api/reverse/simple.feature
@@ -55,8 +55,6 @@ Feature: Simple Reverse Tests
 
     Examples:
      | parameter        | value |
-     | polygon          | 1 |
-     | polygon          | 0 |
      | polygon_text     | 1 |
      | polygon_text     | 0 |
      | polygon_kml      | 1 |

--- a/test/bdd/api/search/params.feature
+++ b/test/bdd/api/search/params.feature
@@ -303,18 +303,6 @@ Feature: Search queries
         | json     | geotext |
         | jsonv2   | geotext |
 
-    Scenario Outline: Search result contains polygon-as-points geometry
-        When sending <format> search query "Highmore"
-          | polygon |
-          | 1 |
-        Then result has attributes <response_attribute>
-
-    Examples:
-        | format   | response_attribute |
-        | xml      | polygonpoints |
-        | json     | polygonpoints |
-        | jsonv2   | polygonpoints |
-
     Scenario Outline: Search result contains SVG geometry
         When sending <format> search query "Highmore"
           | polygon_svg |
@@ -354,8 +342,8 @@ Feature: Search queries
 
     Scenario Outline: Search result in geojson format contains no non-geojson geometry
         When sending geojson search query "Highmore"
-          | polygon_text | polygon | polygon_svg | polygon_geokml |
-          | 1            | 1       | 1           | 1              |
+          | polygon_text | polygon_svg | polygon_geokml |
+          | 1            | 1           | 1              |
         Then result 0 has not attributes <response_attribute>
 
     Examples:
@@ -364,6 +352,19 @@ Feature: Search queries
         | polygonpoints      |
         | svg                |
         | geokml             |
+
+    Scenario Outline: Search with old deprecated polygon type
+        When sending <format> search query "Highmore"
+          | polygon |
+          | 1       |
+        Then a HTTP 400 is returned
+
+    Examples:
+        | format   |
+        | xml      |
+        | json     |
+        | jsonv2   |
+        | geojson  |
 
     Scenario: Search along a route
         When sending json search query "restaurant" with address

--- a/test/bdd/api/search/simple.feature
+++ b/test/bdd/api/search/simple.feature
@@ -36,8 +36,6 @@ Feature: Simple Tests
      | parameter        | value |
      | addressdetails   | 1 |
      | addressdetails   | 0 |
-     | polygon          | 1 |
-     | polygon          | 0 |
      | polygon_text     | 1 |
      | polygon_text     | 0 |
      | polygon_kml      | 1 |
@@ -98,7 +96,6 @@ Feature: Simple Tests
         Then result header contains
           | attr        | value |
           | querystring | xnznxvcx |
-          | polygon     | false |
           | more_url    | .*q=xnznxvcx.*format=xml |
 
     Scenario: Empty XML search with special XML characters
@@ -106,7 +103,6 @@ Feature: Simple Tests
         Then result header contains
           | attr        | value |
           | querystring | xfdghn&zxn"xvbyx<vxx>cssdex |
-          | polygon     | false |
           | more_url    | .*q=xfdghn%26zxn%22xvbyx%3Cvxx%3Ecssdex.*format=xml |
 
     Scenario: Empty XML search with viewbox
@@ -116,7 +112,6 @@ Feature: Simple Tests
         Then result header contains
           | attr        | value |
           | querystring | xnznxvcx |
-          | polygon     | false |
           | viewbox     | 12,33,77,45.13 |
 
     Scenario: Empty XML search with viewboxlbrt
@@ -126,7 +121,6 @@ Feature: Simple Tests
         Then result header contains
           | attr        | value |
           | querystring | xnznxvcx |
-          | polygon     | false |
           | viewbox     | 12,34.13,77,45 |
 
     Scenario: Empty XML search with viewboxlbrt and viewbox
@@ -136,28 +130,7 @@ Feature: Simple Tests
         Then result header contains
           | attr        | value |
           | querystring | pub |
-          | polygon     | false |
           | viewbox     | 12,33,77,45.13 |
-
-    Scenario Outline: Empty XML search with polygon values
-        When sending xml search query "xnznxvcx"
-          | param   | value |
-          | polygon | <polyval> |
-        Then result header contains
-          | attr        | value |
-          | polygon     | <result> |
-
-    Examples:
-     | result | polyval |
-     | false  | 0 |
-     | true   | 1 |
-     | true   | True |
-     | true   | true |
-     | true   | false |
-     | true   | FALSE |
-     | true   | yes |
-     | true   | no |
-     | true   | '; delete from foobar; select ' |
 
     Scenario: Empty XML search with exluded place ids
         When sending xml search query "jghrleoxsbwjer"

--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -35,55 +35,6 @@ class LibTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-
-    public function testGeometryText2Points()
-    {
-        $fRadius = 1;
-        // invalid value
-        $this->assertEquals(
-            null,
-            geometryText2Points('', $fRadius)
-        );
-
-        // POINT
-        $aPoints = geometryText2Points('POINT(10 20)', $fRadius);
-        $this->assertEquals(
-            101,
-            count($aPoints)
-        );
-        $this->assertEquals(
-            array(
-             array(10, 21),
-             array(10.062790519529, 20.998026728428),
-             array(10.125333233564, 20.992114701314)
-            ),
-            array_splice($aPoints, 0, 3)
-        );
-
-        // POLYGON
-        $this->assertEquals(
-            array(
-             array('30', '10'),
-             array('40', '40'),
-             array('20', '40'),
-             array('10', '20'),
-             array('30', '10')
-            ),
-            geometryText2Points('POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))', $fRadius)
-        );
-
-        // MULTIPOLYGON
-        $this->assertEquals(
-            array(
-             array('30', '20'), // first polygon only
-             array('45', '40'),
-             array('10', '40'),
-             array('30', '20'),
-            ),
-            geometryText2Points('MULTIPOLYGON(((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))', $fRadius)
-        );
-    }
-
     public function testParseLatLon()
     {
         // no coordinates expected

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -16,6 +16,10 @@ set_exception_handler_by_format($sOutputFormat);
 // Preferred language
 $aLangPrefOrder = $oParams->getPreferredLanguages();
 
+if ($oParams->getBool('polygon') === true) {
+    throw new Exception('Polygon parameter no longer supported.', 400);
+}
+
 $oDB = new Nominatim\DB();
 $oDB->connect();
 

--- a/website/search.php
+++ b/website/search.php
@@ -12,6 +12,10 @@ $oParams = new Nominatim\ParameterParser();
 
 $oGeocode = new Nominatim\Geocode($oDB);
 
+if ($oParams->getBool('polygon') === true) {
+    throw new Exception('Polygon parameter no longer supported.', 400);
+}
+
 $aLangPrefOrder = $oParams->getPreferredLanguages();
 $oGeocode->setLanguagePreference($aLangPrefOrder);
 


### PR DESCRIPTION
Removes the `&polygon=1` output feature.

Documentation on https://wiki.openstreetmap.org/wiki/Nominatim#Parameters says 'deprecated' since 6 August 2013‎.