### PR TITLE
new PHP Nominatim\Shell class to wrap shell escaping

### DIFF
--- a/lib/Shell.php
+++ b/lib/Shell.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Nominatim;
+
+class Shell
+{
+    public function escapeFromArray($aCmd)
+    {
+        $aArgs = array_map(function ($sArg) {
+            if (preg_match('/^-*\w+$/', $sArg)) return $sArg;
+            return escapeshellarg($sArg);
+        }, $aCmd);
+
+        return join(' ', $aArgs);
+    }
+}

--- a/test/php/Nominatim/ShellTest.php
+++ b/test/php/Nominatim/ShellTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Nominatim;
+
+require_once(CONST_BasePath.'/lib/lib.php');
+require_once(CONST_BasePath.'/lib/Shell.php');
+
+class ShellTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testEscapeFromArray()
+    {
+        $oShell = new \Nominatim\Shell;
+
+        $this->assertSame(
+            'do -a abc 9',
+            $oShell->escapeFromArray(array('do', '-a', 'abc', 9)),
+            'no escaping needed'
+        );
+        $this->assertSame(
+            "do -a ' b ' --flag 'two words' 'v=1'",
+            $oShell->escapeFromArray(array('do', '-a', ' b ', '--flag', 'two words', 'v=1')),
+            'escape whitespace'
+        );
+        $this->assertSame(
+            "do ';' '|more&' '2>&1'",
+            $oShell->escapeFromArray(array('do', ';', '|more&', '2>&1')),
+            'escape'
+        );
+    }
+}


### PR DESCRIPTION
First part of https://github.com/openstreetmap/Nominatim/issues/1559

Not super happy with all the `array_push` and `array_merge` but that's just how PHP syntax is. I didn't want to mix in `array[] = 'new element';`

Test setup was having a build directory `build with space`, database user `Te&t*ser!` with password `&:*_{()}` and a database name `nominatim!x`. Postgresql allows `$` as part of database names but adding any in the DSN confused the PHP database abstraction library (PDO). Because of the DSN syntax as single string `;`, `'` and `=` also can't be used. When using username and password in the DSN you also have to specify host and port (otherwise socket connection is used and `pg_hba.conf` usually only allows peer authentication).

```
sudo -u postgres createuser -s 'Te&t*ser!'
sudo -u postgres psql
ALTER USER "Te&t*ser!" WITH PASSWORD '&:*_{()}';
```

`build with space/settings/local.php`:
```
@define('CONST_Website_BaseURL', '/nominatim/');
@define('CONST_Database_DSN', 'pgsql:host=localhost;port=5432;user=Te&t*ser!;password=&:*_{()};dbname=nominatim!x');
@define('CONST_Pyosmium_Binary', '/home/vagrant/.local/bin/pyosmium-get-changes');
@define('CONST_Replication_Url', 'https://download.geofabrik.de/europe/monaco-updates');
@define('CONST_Replication_Update_Interval', '86400');
@define('CONST_Replication_Recheck_Interval', '900');
```

```
./utils/setup.php --osm-file /tmp/monaco\ with\ space.pbf --osm2pgsql-cache 1000 --all
./utils/update.php --init-updates
./utils/update.php --import-osmosis
```

This brought to light more follow-up tasks:
* move `runWithEnv` from `lib/cmd.php` into the new class, add tests
* move `runWithPgEnv` from `lib/setup/SetupClass.php` into the new class
* in several places the parsed DSN (a method in `lib/DB.php` does that) gets converted into command-line options. That should move into `DB.php` or `Shell.php` to avoid duplicate code.
* convert all remaining `exec()` and `system()` calls. There's several in `utils/update.php`
* In several places we print the command pre-execution, e.g. `echo join(' ', $aCmd)."\n";` but ideally we'd print the escaped command string
* maybe: add exception handling
* maybe: use long parameters, e.g. `--port` instead of `-P` when calling osm2pgsql to make the code easier for users to understand