### PR TITLE
Use wikidata tags for improving linking of places with boundaries

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -253,7 +253,8 @@ BEGIN
     FOR linked_placex IN
       SELECT placex.* from placex
       WHERE make_standard_name(name->'name') = bnd_name
-        AND placex.rank_address = bnd.rank_address
+        AND ((bnd.rank_address > 0 and placex.rank_address = bnd.rank_address)
+             OR (bnd.rank_address = 0 and placex.rank_search = bnd.rank_search))
         AND placex.osm_type = 'N'
         AND placex.rank_search < 26 -- needed to select the right index
         AND _st_covers(bnd.geometry, placex.geometry)

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -220,33 +220,6 @@ BEGIN
     END LOOP;
   END IF;
 
-  -- Search for relation members with role admin_center.
-  IF bnd.osm_type = 'R' and bnd_name is not null
-     and relation_members is not null
-  THEN
-    FOR rel_member IN
-      SELECT get_rel_node_members(relation_members,
-                                ARRAY['admin_center','admin_centre']) as member
-    LOOP
-    --DEBUG: RAISE WARNING 'Found admin_center member %', rel_member.member;
-      FOR linked_placex IN
-        SELECT * from placex
-        WHERE osm_type = 'N' and osm_id = rel_member.member
-          and class = 'place'
-      LOOP
-        -- For an admin centre we also want a name match - still not perfect,
-        -- for example 'new york, new york'
-        -- But that can be fixed by explicitly setting the label in the data
-        IF bnd_name = make_standard_name(linked_placex.name->'name')
-           AND bnd.rank_address = linked_placex.rank_address
-        THEN
-          RETURN linked_placex;
-        END IF;
-          --DEBUG: RAISE WARNING 'Linked admin_center';
-      END LOOP;
-    END LOOP;
-  END IF;
-
   -- Name searches can be done for ways as well as relations
   IF bnd_name is not null THEN
     --DEBUG: RAISE WARNING 'Looking for nodes with matching names';

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -220,6 +220,21 @@ BEGIN
     END LOOP;
   END IF;
 
+  IF bnd.extratags ? 'wikidata' THEN
+    FOR linked_placex IN
+      SELECT * FROM placex
+      WHERE placex.class = 'place' AND placex.osm_type = 'N'
+        AND placex.extratags ? 'wikidata' -- needed to select right index
+        AND placex.extratags->'wikidata' = bnd.extratags->'wikidata'
+        AND placex.rank_search < 26
+        AND _st_covers(bnd.geometry, placex.geometry)
+      ORDER BY make_standard_name(name->'name') = bnd_name desc
+    LOOP
+      --DEBUG: RAISE WARNING 'Found wikidata-matching place node %', linked_placex.osm_id;
+      RETURN linked_placex;
+    END LOOP;
+  END IF;
+
   -- Name searches can be done for ways as well as relations
   IF bnd_name is not null THEN
     --DEBUG: RAISE WARNING 'Looking for nodes with matching names';

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -177,6 +177,7 @@ CREATE INDEX idx_placex_linked_place_id ON placex USING BTREE (linked_place_id) 
 CREATE INDEX idx_placex_rank_search ON placex USING BTREE (rank_search, geometry_sector) {ts:address-index};
 CREATE INDEX idx_placex_geometry ON placex USING GIST (geometry) {ts:search-index};
 CREATE INDEX idx_placex_adminname on placex USING BTREE (make_standard_name(name->'name')) {ts:address-index} WHERE osm_type='N' and rank_search < 26;
+CREATE INDEX idx_placex_wikidata on placex USING BTREE ((extratags -> 'wikidata')) {ts:address-index} WHERE extratags ? 'wikidata' and class = 'place' and osm_type = 'N' and rank_search < 26;
 
 DROP SEQUENCE IF EXISTS seq_place;
 CREATE SEQUENCE seq_place start 1;

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -26,7 +26,6 @@ Feature: Search queries
           | neighbourhood | Auenviertel |
           | suburb        | Eilbek |
           | postcode      | 22089 |
-          | city_district | Wandsbek |
           | city          | Hamburg |
           | country       | Deutschland |
           | country_code  | de |
@@ -42,7 +41,6 @@ Feature: Search queries
           | neighbourhood | Auenviertel |
           | suburb        | Eilbek |
           | postcode      | 22089 |
-          | city_district | Wandsbek |
           | city          | Hamburg |
           | country       | Deutschland |
           | country_code  | de |


### PR DESCRIPTION
Looking for common wikidata tags in admin boundaries and place nodes, it is possible to link another 70k objects. There are some false positives because the wikidata item points to an including object (e.g. suburb in a town) but they are few and they are worth fixing in OSM.

The PR adds two more changes to linking:
* Linking by role 'admin_centre' has been removed. This only works reliably when the rank_address of places is chosen correctly. Given that the majority of links points to a higher admin level anyway, it's better to ignore.
* Linking by name should also work for place types that have been removed from the address hierarchy (for example country and state nodes).