### PR TITLE
Updated TIGER database link in documentation

### DIFF
--- a/data-sources/us-tiger/README.md
+++ b/data-sources/us-tiger/README.md
@@ -1,6 +1,6 @@
 # US TIGER address data
 
-Convert [TIGER](https://www.census.gov/geo/maps-data/data/tiger.html)/Line dataset of the US Census Bureau to SQL files which can be imported by Nominatim. The created tables in the Nominatim database are separate from OpenStreetMap tables and get queried at search time separately.
+Convert [TIGER](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html)/Line dataset of the US Census Bureau to SQL files which can be imported by Nominatim. The created tables in the Nominatim database are separate from OpenStreetMap tables and get queried at search time separately.
 
 The dataset gets updated once per year. Downloading is prone to be slow (can take a full day) and converting them can take hours as well.
 

--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -224,7 +224,7 @@ need internet access for the step.
 
 ## Installing Tiger housenumber data for the US
 
-Nominatim is able to use the official [TIGER](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-geodatabase-file.html)
+Nominatim is able to use the official [TIGER](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html)
 address set to complement the OSM house number data in the US. You can add
 TIGER data to your own Nominatim instance by following these steps. The
 entire US adds about 10GB to your database.

--- a/docs/admin/Import-and-Update.md
+++ b/docs/admin/Import-and-Update.md
@@ -224,7 +224,7 @@ need internet access for the step.
 
 ## Installing Tiger housenumber data for the US
 
-Nominatim is able to use the official [TIGER](https://www.census.gov/geo/maps-data/data/tiger.html)
+Nominatim is able to use the official [TIGER](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-geodatabase-file.html)
 address set to complement the OSM house number data in the US. You can add
 TIGER data to your own Nominatim instance by following these steps. The
 entire US adds about 10GB to your database.


### PR DESCRIPTION
The previous link for Tiger databases in the documentation (https://www.census.gov/geo/maps-data/data/tiger.html) is outdated (the page is no longer available). So, I have added an updated link that gives information about the same. @lonvia I request you to review the same