### PR TITLE
Fix details link for boundaries

### DIFF
--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -6,6 +6,13 @@ function getInfo($aPlace)
 {
     $aClassType = getList();
 
+    if ($aPlace['type'] == 'administrative' && isset($aPlace['place_type'])) {
+        $sName = 'place:'.$aPlace['place_type'];
+        if (isset($aClassType[$sName])) {
+            return $aClassType[$sName];
+        }
+    }
+
     if (isset($aPlace['admin_level'])) {
         $sName = $aPlace['class'].':'.$aPlace['type'].':'.$aPlace['admin_level'];
         if (isset($aClassType[$sName])) {

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -70,7 +70,13 @@
 
         echo '<tr class="' . ($bNotUsed?'notused':'') . '">'."\n";
         echo '  <td class="name">'.(trim($aAddressLine['localname'])!==null?$aAddressLine['localname']:'<span class="noname">No Name</span>')."</td>\n";
-        echo '  <td>' . $aAddressLine['class'].':'.$aAddressLine['type'] . "</td>\n";
+        echo '  <td>' . $aAddressLine['class'].':'.$aAddressLine['type'];
+        if ($aAddressLine['type'] == 'administrative'
+            && isset($aAddressLine['place_type']))
+        {
+            echo '('.$aAddressLine['place_type'].')';
+        }
+        echo "</td>\n";
         echo '  <td>' . osmLink($aAddressLine) . "</td>\n";
         echo '  <td>' . (isset($aAddressLine['rank_address']) ? $aAddressLine['rank_address'] : '') . "</td>\n";
         echo '  <td>' . ($aAddressLine['admin_level'] < 15 ? $aAddressLine['admin_level'] : '') . "</td>\n";

--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -47,6 +47,7 @@ $funcMapAddressLine = function ($aFull) {
                 'place_id' => isset($aFull['place_id']) ? (int) $aFull['place_id'] : null,
                 'osm_id' => isset($aFull['osm_id']) ? (int) $aFull['osm_id'] : null,
                 'osm_type' => isset($aFull['osm_type']) ? $aFull['osm_type'] : null,
+                'place_type' => isset($aFull['place_type']) ? $aFull['place_type'] : null,
                 'class' => $aFull['class'],
                 'type' => $aFull['type'],
                 'admin_level' => isset($aFull['admin_level']) ? (int) $aFull['admin_level'] : null,


### PR DESCRIPTION
Removes the special casing for boundaries with a place
type in get_addressdata(). Instead the place type is now
returned as an extra field, so that the caller has to
handle the situation.

This fixes the details link next to the address in the details
view, which previously would go to a place class instead of the
original boundary class.

@mtmail I think this needs porting to nominatim-ui as well. I added a new place_type attribute to details json for that.