### PR TITLE
details JSON: also print isaddress addressline field

### DIFF
--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -52,7 +52,8 @@ $funcMapAddressLine = function ($aFull) {
                 'type' => $aFull['type'],
                 'admin_level' => isset($aFull['admin_level']) ? (int) $aFull['admin_level'] : null,
                 'rank_address' => $aFull['rank_address'] ? (int) $aFull['rank_address'] : null,
-                'distance' => (float) $aFull['distance']
+                'distance' => (float) $aFull['distance'],
+                'isaddress' => (bool) $aFull['isaddress']
                );
 
     return $aMapped;


### PR DESCRIPTION
`details-html.php` uses `$aAddressLine['isaddress']` to set colour in the HTML table. This PR adds the field to the JSON output so nominatim-ui frontend can do the same.

![image](https://user-images.githubusercontent.com/3727288/78671982-4d1d6180-78e0-11ea-85d9-2fb6372061c7.png)
