### PR TITLE
Further tweaks to geocodejson output

### DIFF
--- a/lib/AddressDetails.php
+++ b/lib/AddressDetails.php
@@ -9,10 +9,13 @@ require_once(CONST_BasePath.'/lib/ClassTypes.php');
  */
 class AddressDetails
 {
+    private $iPlaceID;
     private $aAddressLines;
 
     public function __construct(&$oDB, $iPlaceID, $sHousenumber, $mLangPref)
     {
+        $this->iPlaceID = $iPlaceID;
+
         if (is_array($mLangPref)) {
             $mLangPref = $oDB->getArraySQL($oDB->getDBQuotedList($mLangPref));
         }
@@ -115,7 +118,7 @@ class AddressDetails
      */
     public function addGeocodeJsonAddressParts(&$aJson)
     {
-        foreach ($this->aAddressLines as $aLine) {
+        foreach (array_reverse($this->aAddressLines) as $aLine) {
             if (!$aLine['isaddress']) {
                 continue;
             }
@@ -124,13 +127,19 @@ class AddressDetails
                 continue;
             }
 
-            $iRank = (int)$aLine['rank_address'];
-
             if ($aLine['type'] == 'postcode' || $aLine['type'] == 'postal_code') {
                 $aJson['postcode'] = $aLine['localname'];
             } elseif ($aLine['type'] == 'house_number') {
                 $aJson['housenumber'] = $aLine['localname'];
-            } elseif ($iRank > 25 && $iRank < 28) {
+            }
+
+            if ($this->iPlaceID == $aLine['place_id']) {
+                continue;
+            }
+
+            $iRank = (int)$aLine['rank_address'];
+
+            if ($iRank > 25 && $iRank < 28) {
                 $aJson['street'] = $aLine['localname'];
             } elseif ($iRank >= 22 && $iRank <= 25) {
                 $aJson['locality'] = $aLine['localname'];

--- a/lib/template/address-geocodejson.php
+++ b/lib/template/address-geocodejson.php
@@ -30,7 +30,9 @@ if (empty($aPlace)) {
 
     $aFilteredPlaces['properties']['geocoding']['label'] = $aPlace['langaddress'];
 
-    $aFilteredPlaces['properties']['geocoding']['name'] = $aPlace['placename'];
+    if ($aPlace['placename'] !== null) {
+        $aFilteredPlaces['properties']['geocoding']['name'] = $aPlace['placename'];
+    }
 
     if (isset($aPlace['address'])) {
         $aPlace['address']->addGeocodeJsonAddressParts(

--- a/lib/template/search-geocodejson.php
+++ b/lib/template/search-geocodejson.php
@@ -20,7 +20,9 @@ foreach ($aSearchResults as $iResNum => $aPointDetails) {
 
     $aPlace['properties']['geocoding']['label'] = $aPointDetails['langaddress'];
 
-    $aPlace['properties']['geocoding']['name'] = $aPointDetails['placename'];
+    if ($aPointDetails['placename'] !== null) {
+        $aPlace['properties']['geocoding']['name'] = $aPointDetails['placename'];
+    }
 
     if (isset($aPointDetails['address'])) {
         $aPointDetails['address']->addGeocodeJsonAddressParts(

--- a/test/bdd/api/reverse/geocodejson.feature
+++ b/test/bdd/api/reverse/geocodejson.feature
@@ -11,10 +11,10 @@ Feature: Parameters for Reverse API
     Scenario: Town street-level address with street
         When sending geocodejson reverse coordinates 47.066,9.504
         Then results contain
-          | street  | city    | postcode | country |
+          | name    | city    | postcode | country |
           | Gnetsch | Balzers | 9496     | Liechtenstein |
 
-    Scenario: Town street-level address with footway
+    Scenario: Poi street-level address with footway
         When sending geocodejson reverse coordinates 47.0653,9.5007
         Then results contain
           | street  | city    | postcode | country |

--- a/test/bdd/api/search/geocodejson.feature
+++ b/test/bdd/api/search/geocodejson.feature
@@ -11,7 +11,7 @@ Feature: Parameters for Search API
     Scenario: Town street-level address with street
         When sending geocodejson search query "Gnetsch, Balzers" with address
         Then results contain
-          | street  | city    | postcode | country |
+          | name    | city    | postcode | country |
           | Gnetsch | Balzers | 9496     | Liechtenstein |
 
     Scenario: Town street-level address with footway


### PR DESCRIPTION
* remove 'name' if none is there (was 'null' until now)
* do not add object itself to address details except house number and postcode
* always have the lowest ranking address part win for naming a feature instead of highest