### PR TITLE
Travis-Ci configuration: remove -sudo-, add -os-

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-sudo: required
+os: linux
 dist: xenial
 language: python
 python:


### PR DESCRIPTION
Takes care of two Travis-CI deprecation warnings, see screenshot

![image](https://user-images.githubusercontent.com/3727288/78949042-a6e17f80-7aca-11ea-8f53-7964b12ecda1.png)
