### PR TITLE
fix Travis-CI badge in README output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/openstreetmap/Nominatim.svg?branch=master)](https://travis-ci.org/openstreetmap/Nominatim)
+[![Build Status](https://travis-ci.org/osm-search/Nominatim.svg?branch=master)](https://travis-ci.org/osm-search/Nominatim)
 
 Nominatim
 =========


### PR DESCRIPTION
Badge was showing `build: unknown`

![image](https://user-images.githubusercontent.com/3727288/79135686-06cc7480-7db0-11ea-979d-47e417bacdf3.png)
