### PR TITLE
Nominatim::DB tests against separate postgresql database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/
   - if [[ $TEST_SUITE == "tests" ]]; then phpcs --report-width=120 . ; fi
   - cd $TRAVIS_BUILD_DIR/test/php
-  - if [[ $TEST_SUITE == "tests" ]]; then UNIT_TEST_DSN='pgsql:dbname=nominatim_unit_tests' /usr/bin/phpunit ./ ; fi
+  - if [[ $TEST_SUITE == "tests" ]]; then /usr/bin/phpunit ./ ; fi
   - cd $TRAVIS_BUILD_DIR/test/bdd
   - # behave --format=progress3 api
   - if [[ $TEST_SUITE == "tests" ]]; then behave -DREMOVE_TEMPLATE=1 --format=progress3 db ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/
   - if [[ $TEST_SUITE == "tests" ]]; then phpcs --report-width=120 . ; fi
   - cd $TRAVIS_BUILD_DIR/test/php
-  - if [[ $TEST_SUITE == "tests" ]]; then /usr/bin/phpunit ./ ; fi
+  - if [[ $TEST_SUITE == "tests" ]]; then UNIT_TEST_DSN='pgsql:dbname=nominatim_unit_tests' /usr/bin/phpunit ./ ; fi
   - cd $TRAVIS_BUILD_DIR/test/bdd
   - # behave --format=progress3 api
   - if [[ $TEST_SUITE == "tests" ]]; then behave -DREMOVE_TEMPLATE=1 --format=progress3 db ; fi

--- a/lib/DB.php
+++ b/lib/DB.php
@@ -241,6 +241,28 @@ class DB
     }
 
     /**
+    * Returns a list of table names in the database
+    *
+    * @return array[]
+    */
+    public function getListOfTables()
+    {
+        return $this->getCol("SELECT tablename FROM pg_tables WHERE schemaname='public'");
+    }
+
+    /**
+     * Deletes a table. Returns true on success. Returns true if the table didn't exist.
+     *
+     * @param string  $sTableName
+     *
+     * @return boolean
+     */
+    public function deleteTable($sTableName)
+    {
+        return $this->exec('DROP TABLE IF EXISTS '.$sTableName.' CASCADE') == 0;
+    }
+
+    /**
     * Check if an index exists in the database. Optional filtered by tablename
     *
     * @param string  $sTableName
@@ -311,11 +333,11 @@ END;
     }
 
     /**
-     * Since the DSN includes the database name, checks if the connection works.
+     * Tries to connect to the database but on failure doesn't throw an exception.
      *
      * @return boolean
      */
-    public function databaseExists()
+    public function checkConnection()
     {
         $bExists = true;
         try {
@@ -350,6 +372,13 @@ END;
         return (float) ($aMatches[1].'.'.$aMatches[2]);
     }
 
+    /**
+     * Returns an associate array of postgresql database connection settings. Keys can
+     * be 'database', 'hostspec', 'port', 'username', 'password'.
+     * Returns empty array on failure, thus check if at least 'database' is set.
+     *
+     * @return array[]
+     */
     public static function parseDSN($sDSN)
     {
         // https://secure.php.net/manual/en/ref.pdo-pgsql.connection.php
@@ -364,5 +393,42 @@ END;
             }
         }
         return $aInfo;
+    }
+
+    /**
+     * Takes an array of settings and return the DNS string. Key names can be
+     * 'database', 'hostspec', 'port', 'username', 'password' but aliases
+     * 'dbname', 'host' and 'user' are also supported.
+     *
+     * @return string
+     *
+     */
+    public static function generateDSN($aInfo)
+    {
+        $sDSN = 'pgsql:';
+        if (isset($aInfo['host'])) {
+            $sDSN .= 'host=' . $aInfo['host'] . ';';
+        } elseif (isset($aInfo['hostspec'])) {
+            $sDSN .= 'host=' . $aInfo['hostspec'] . ';';
+        }
+        if (isset($aInfo['port'])) {
+            $sDSN .= 'port=' . $aInfo['port'] . ';';
+        }
+        if (isset($aInfo['dbname'])) {
+            $sDSN .= 'dbname=' . $aInfo['dbname'] . ';';
+        } elseif (isset($aInfo['database'])) {
+            $sDSN .= 'dbname=' . $aInfo['database'] . ';';
+        }
+        if (isset($aInfo['user'])) {
+            $sDSN .= 'user=' . $aInfo['user'] . ';';
+        } elseif (isset($aInfo['username'])) {
+            $sDSN .= 'user=' . $aInfo['username'] . ';';
+        }
+        if (isset($aInfo['password'])) {
+            $sDSN .= 'password=' . $aInfo['password'] . ';';
+        }
+        $sDSN = preg_replace('/;$/', '', $sDSN);
+
+        return $sDSN;
     }
 }

--- a/lib/DB.php
+++ b/lib/DB.php
@@ -251,7 +251,7 @@ class DB
     }
 
     /**
-     * Deletes a table. Returns true on success. Returns true if the table didn't exist.
+     * Deletes a table. Returns true if deleted or didn't exist.
      *
      * @param string  $sTableName
      *
@@ -405,29 +405,16 @@ END;
      */
     public static function generateDSN($aInfo)
     {
-        $sDSN = 'pgsql:';
-        if (isset($aInfo['host'])) {
-            $sDSN .= 'host=' . $aInfo['host'] . ';';
-        } elseif (isset($aInfo['hostspec'])) {
-            $sDSN .= 'host=' . $aInfo['hostspec'] . ';';
-        }
-        if (isset($aInfo['port'])) {
-            $sDSN .= 'port=' . $aInfo['port'] . ';';
-        }
-        if (isset($aInfo['dbname'])) {
-            $sDSN .= 'dbname=' . $aInfo['dbname'] . ';';
-        } elseif (isset($aInfo['database'])) {
-            $sDSN .= 'dbname=' . $aInfo['database'] . ';';
-        }
-        if (isset($aInfo['user'])) {
-            $sDSN .= 'user=' . $aInfo['user'] . ';';
-        } elseif (isset($aInfo['username'])) {
-            $sDSN .= 'user=' . $aInfo['username'] . ';';
-        }
-        if (isset($aInfo['password'])) {
-            $sDSN .= 'password=' . $aInfo['password'] . ';';
-        }
-        $sDSN = preg_replace('/;$/', '', $sDSN);
+        $sDSN = sprintf(
+            'pgsql:host=%s;port=%s;dbname=%s;user=%s;password=%s;',
+            $aInfo['host'] ?? $aInfo['hostspec'] ?? '',
+            $aInfo['port'] ?? '',
+            $aInfo['dbname'] ?? $aInfo['database'] ?? '',
+            $aInfo['user'] ?? '',
+            $aInfo['password'] ?? ''
+        );
+        $sDSN = preg_replace('/\b\w+=;/', '', $sDSN);
+        $sDSN = preg_replace('/;\Z/', '', $sDSN);
 
         return $sDSN;
     }

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -84,7 +84,7 @@ class SetupFunctions
         info('Create DB');
         $oDB = new \Nominatim\DB;
 
-        if ($oDB->databaseExists()) {
+        if ($oDB->checkConnection()) {
             fail('database already exists ('.CONST_Database_DSN.')');
         }
 
@@ -651,7 +651,7 @@ class SetupFunctions
                        );
 
         $aDropTables = array();
-        $aHaveTables = $this->oDB->getCol("SELECT tablename FROM pg_tables WHERE schemaname='public'");
+        $aHaveTables = $this->oDB->getListOfTables();
 
         foreach ($aHaveTables as $sTable) {
             $bFound = false;
@@ -858,7 +858,7 @@ class SetupFunctions
     private function dropTable($sName)
     {
         if ($this->bVerbose) echo "Dropping table $sName\n";
-        $this->oDB->exec('DROP TABLE IF EXISTS '.$sName.' CASCADE');
+        $this->oDB->deleteTable($sName);
     }
 
     /**

--- a/test/README.md
+++ b/test/README.md
@@ -51,8 +51,8 @@ To execute the test suite run
 It will read phpunit.xml which points to the library, test path, bootstrap
 strip and set other parameters.
 
-The database set by `UNIT_TEST_DSN` will be deleted and recreated. Not setting
-it will skip some tests as pending, but not fail the tests.
+It will use (and destroy) a local database 'nominatim_unit_tests'. You can set
+a different connection string with e.g. UNIT_TEST_DSN='pgsql:dbname=foo_unit_tests'.
 
 BDD Functional Tests
 ====================

--- a/test/README.md
+++ b/test/README.md
@@ -46,11 +46,13 @@ Very low coverage.
 To execute the test suite run
 
     cd test/php
-    phpunit ../
+    UNIT_TEST_DSN='pgsql:dbname=nominatim_unit_tests' phpunit ../
 
 It will read phpunit.xml which points to the library, test path, bootstrap
 strip and set other parameters.
 
+The database set by `UNIT_TEST_DSN` will be deleted and recreated. Not setting
+it will skip some tests as pending, but not fail the tests.
 
 BDD Functional Tests
 ====================

--- a/test/php/Nominatim/DBTest.php
+++ b/test/php/Nominatim/DBTest.php
@@ -128,11 +128,19 @@ class DBTest extends \PHPUnit\Framework\TestCase
 
     public function testAgainstDatabase()
     {
-        if (getenv('UNIT_TEST_DSN') == false) $this->markTestSkipped('UNIT_TEST_DSN not set');
+        $unit_test_dsn = getenv('UNIT_TEST_DSN') != false ?
+                            getenv('UNIT_TEST_DSN') :
+                            'pgsql:dbname=nominatim_unit_tests';
+
+        $this->assertRegExp(
+            '/unit_test/',
+            $unit_test_dsn,
+            'Test database will get destroyed, thus should have a name like unit_test to be safe'
+        );
 
         ## Create the database.
         {
-            $aDSNParsed = \Nominatim\DB::parseDSN(getenv('UNIT_TEST_DSN'));
+            $aDSNParsed = \Nominatim\DB::parseDSN($unit_test_dsn);
             $sDbname = $aDSNParsed['database'];
             $aDSNParsed['database'] = 'postgres';
 
@@ -142,7 +150,7 @@ class DBTest extends \PHPUnit\Framework\TestCase
             $oDB->exec('CREATE DATABASE ' . $sDbname);
         }
 
-        $oDB = new \Nominatim\DB(getenv('UNIT_TEST_DSN'));
+        $oDB = new \Nominatim\DB($unit_test_dsn);
         $oDB->connect();
 
         $this->assertTrue(

--- a/utils/check_import_finished.php
+++ b/utils/check_import_finished.php
@@ -28,7 +28,7 @@ function isReverseOnlyInstallation()
 
 
 echo 'Checking database got created ... ';
-if ($oDB->databaseExists()) {
+if ($oDB->checkConnection()) {
     $print_success();
 } else {
     $print_fail();


### PR DESCRIPTION
Nominatim::DB

- setting an environment variable allows running against a real (separate) database.
- new methods `getListOfTables` and `deleteTable`.
- rename `databaseExists` to `checkConnection` to better reflect what it does.