### PR TITLE
 Ensure that result object name is always first in display_name

### DIFF
--- a/sql/functions/address_lookup.sql
+++ b/sql/functions/address_lookup.sql
@@ -60,7 +60,9 @@ BEGIN
   prevresult := '';
 
   FOR location IN
-    SELECT * FROM get_addressdata(for_place_id, housenumber)
+    SELECT name,
+       CASE WHEN place_id = for_place_id THEN 99 ELSE rank_address END as rank_address
+    FROM get_addressdata(for_place_id, housenumber)
     WHERE isaddress order by rank_address desc
   LOOP
     currresult := trim(get_name_by_language(location.name, languagepref));

--- a/sql/functions/address_lookup.sql
+++ b/sql/functions/address_lookup.sql
@@ -69,7 +69,7 @@ BEGIN
     IF currresult != prevresult AND currresult IS NOT NULL
        AND result[(100 - location.rank_address)] IS NULL
     THEN
-      result[(100 - location.rank_address)] := trim(get_name_by_language(location.name, languagepref));
+      result[(100 - location.rank_address)] := currresult;
       prevresult := currresult;
     END IF;
   END LOOP;


### PR DESCRIPTION
The display name might be mixed up if the result object has a lower
rank_address than its address members. See for example the result
when searching for [Sandkrug, Aurich](https://nominatim.openstreetmap.org/search.php?q=sandkrug%2C+aurich).