### PR TITLE
Add vagrant machine for Ubuntu 20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,15 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "ubuntu", primary: true do |sub|
+      sub.vm.box = "bento/ubuntu-20.04"
+      sub.vm.provision :shell do |s|
+        s.path = "vagrant/Install-on-Ubuntu-20.sh"
+        s.privileged = false
+        s.args = [checkout]
+      end
+  end
+
+  config.vm.define "ubuntu18", primary: true do |sub|
       sub.vm.box = "bento/ubuntu-18.04"
       sub.vm.provision :shell do |s|
         s.path = "vagrant/Install-on-Ubuntu-18.sh"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -43,6 +43,7 @@ ADD_CUSTOM_TARGET(doc
    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bash2md.sh ${PROJECT_SOURCE_DIR}/vagrant/Install-on-Centos-7.sh ${CMAKE_CURRENT_BINARY_DIR}/appendix/Install-on-Centos-7.md
    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bash2md.sh ${PROJECT_SOURCE_DIR}/vagrant/Install-on-Ubuntu-16.sh ${CMAKE_CURRENT_BINARY_DIR}/appendix/Install-on-Ubuntu-16.md
    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bash2md.sh ${PROJECT_SOURCE_DIR}/vagrant/Install-on-Ubuntu-18.sh ${CMAKE_CURRENT_BINARY_DIR}/appendix/Install-on-Ubuntu-18.md
+   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bash2md.sh ${PROJECT_SOURCE_DIR}/vagrant/Install-on-Ubuntu-20.sh ${CMAKE_CURRENT_BINARY_DIR}/appendix/Install-on-Ubuntu-20.md
    COMMAND mkdocs build -d ${CMAKE_CURRENT_BINARY_DIR}/../site-html -f ${CMAKE_CURRENT_BINARY_DIR}/../mkdocs.yml
 )
 

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -4,6 +4,7 @@ This page contains generic installation instructions for Nominatim and its
 prerequisites. There are also step-by-step instructions available for
 the following operating systems:
 
+  * [Ubuntu 20.04](../appendix/Install-on-Ubuntu-20.md)
   * [Ubuntu 18.04](../appendix/Install-on-Ubuntu-18.md)
   * [Ubuntu 16.04](../appendix/Install-on-Ubuntu-16.md)
   * [CentOS 7.2](../appendix/Install-on-Centos-7.md)

--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -7,6 +7,11 @@ export APT_LISTCHANGES_FRONTEND=none #DOCS:
 export DEBIAN_FRONTEND=noninteractive #DOCS:
 
 #
+# !!! danger "Important"
+#     Ubuntu 20.04 uses Postgresql 12 and Postgis 3, which are known to cause
+#     performance issues. They are not recommended for a production
+#     installation at the moment.
+#
 # *Note:* these installation instructions are also available in executable
 #         form for use with vagrant under vagrant/Install-on-Ubuntu-20.sh.
 #
@@ -19,9 +24,9 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
 #
 
 #DOCS:    :::sh
-    sudo apt-get \
-        -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" \
-        --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+    sudo apt-get \ #DOCS:
+        -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" \ #DOCS:
+        --allow-downgrades --allow-remove-essential --allow-change-held-packages \ #DOCS:
         -fuy install grub-pc #DOCS:
     sudo apt-get update -qq
 

--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# hacks for broken vagrant box      #DOCS:
+sudo rm -f /var/lib/dpkg/lock       #DOCS:
+sudo update-locale LANG=en_US.UTF-8 #DOCS:
+export APT_LISTCHANGES_FRONTEND=none #DOCS:
+export DEBIAN_FRONTEND=noninteractive #DOCS:
+
+#
+# *Note:* these installation instructions are also available in executable
+#         form for use with vagrant under vagrant/Install-on-Ubuntu-20.sh.
+#
+# Installing the Required Software
+# ================================
+#
+# These instructions expect that you have a freshly installed Ubuntu 20.04.
+#
+# Make sure all packages are are up-to-date by running:
+#
+
+#DOCS:    :::sh
+    sudo apt-get \
+        -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" \
+        --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+        -fuy install grub-pc #DOCS:
+    sudo apt-get update -qq
+
+# Now you can install all packages needed for Nominatim:
+
+    sudo apt-get install -y build-essential cmake g++ libboost-dev libboost-system-dev \
+                            libboost-filesystem-dev libexpat1-dev zlib1g-dev \
+                            libbz2-dev libpq-dev libproj-dev \
+                            postgresql-server-dev-12 postgresql-12-postgis-3 \
+                            postgresql-contrib postgresql-12-postgis-3-scripts \
+                            apache2 php php-pgsql libapache2-mod-php \
+                            php-intl python3-setuptools python3-dev python3-pip \
+                            python3-psycopg2 python3-tidylib git
+
+# If you want to run the test suite, you need to install the following
+# additional packages:
+
+    sudo apt-get install -y phpunit php-codesniffer php-cgi
+
+    pip3 install --user behave nose
+#
+# System Configuration
+# ====================
+#
+# The following steps are meant to configure a fresh Ubuntu installation
+# for use with Nominatim. You may skip some of the steps if you have your
+# OS already configured.
+#
+# Creating Dedicated User Accounts
+# --------------------------------
+#
+# Nominatim will run as a global service on your machine. It is therefore
+# best to install it under its own separate user account. In the following
+# we assume this user is called nominatim and the installation will be in
+# /srv/nominatim. To create the user and directory run:
+#
+#     sudo useradd -d /srv/nominatim -s /bin/bash -m nominatim
+#
+# You may find a more suitable location if you wish.
+#
+# To be able to copy and paste instructions from this manual, export
+# user name and home directory now like this:
+#
+    export USERNAME=vagrant        #DOCS:    export USERNAME=nominatim
+    export USERHOME=/home/vagrant  #DOCS:    export USERHOME=/srv/nominatim
+#
+# **Never, ever run the installation as a root user.** You have been warned.
+#
+# Make sure that system servers can read from the home directory:
+
+    chmod a+x $USERHOME
+
+# Setting up PostgreSQL
+# ---------------------
+#
+# Tune the postgresql configuration, which is located in 
+# `/etc/postgresql/12/main/postgresql.conf`. See section *Postgres Tuning* in
+# [the installation page](../admin/Installation.md#postgresql-tuning)
+# for the parameters to change.
+#
+# Restart the postgresql service after updating this config file.
+
+    sudo systemctl restart postgresql
+
+#
+# Finally, we need to add two postgres users: one for the user that does
+# the import and another for the webserver which should access the database
+# for reading only:
+#
+
+    sudo -u postgres createuser -s $USERNAME
+    sudo -u postgres createuser www-data
+
+#
+# Setting up the Apache Webserver
+# -------------------------------
+#
+# You need to create an alias to the website directory in your apache
+# configuration. Add a separate nominatim configuration to your webserver:
+
+#DOCS:```sh
+sudo tee /etc/apache2/conf-available/nominatim.conf << EOFAPACHECONF
+<Directory "$USERHOME/build/website"> #DOCS:<Directory "$USERHOME/Nominatim/build/website">
+  Options FollowSymLinks MultiViews
+  AddType text/html   .php
+  DirectoryIndex search.php
+  Require all granted
+</Directory>
+
+Alias /nominatim $USERHOME/build/website  #DOCS:Alias /nominatim $USERHOME/Nominatim/build/website
+EOFAPACHECONF
+#DOCS:```
+
+sudo sed -i 's:#.*::' /etc/apache2/conf-available/nominatim.conf #DOCS:
+
+#
+# Then enable the configuration and restart apache
+#
+
+    sudo a2enconf nominatim
+    sudo systemctl restart apache2
+
+#
+# Installing Nominatim
+# ====================
+#
+# Building and Configuration
+# --------------------------
+#
+# Get the source code from Github and change into the source directory
+#
+if [ "x$1" == "xyes" ]; then  #DOCS:    :::sh
+    cd $USERHOME
+    git clone --recursive git://github.com/openstreetmap/Nominatim.git
+    cd Nominatim
+else                               #DOCS:
+    cd $USERHOME/Nominatim         #DOCS:
+fi                                 #DOCS:
+
+# When installing the latest source from github, you also need to
+# download the country grid:
+
+if [ ! -f data/country_osm_grid.sql.gz ]; then       #DOCS:    :::sh
+    wget -O data/country_osm_grid.sql.gz https://www.nominatim.org/data/country_grid.sql.gz
+fi                                 #DOCS:
+
+# The code must be built in a separate directory. Create this directory,
+# then configure and build Nominatim in there:
+
+    cd $USERHOME                   #DOCS:    :::sh
+    mkdir build
+    cd build
+    cmake $USERHOME/Nominatim
+    make
+
+# You need to create a minimal configuration file that tells nominatim
+# where it is located on the webserver:
+
+#DOCS:```sh
+tee settings/local.php << EOF
+<?php
+ @define('CONST_Website_BaseURL', '/nominatim/');
+EOF
+#DOCS:```
+
+
+# Nominatim is now ready to use. Continue with
+# [importing a database from OSM data](../admin/Import-and-Update.md).


### PR DESCRIPTION
The instructions in
[`VAGRANT.md`](https://github.com/osm-search/Nominatim/blob/42c80893cb1038e21c05c2d0d30e3a7a20f0fa26/VAGRANT.md)
still work as before. The names of the Vagrant machines are updated so
that Ubuntu 18.04 (previously called `ubuntu`) is now called `ubuntu18`
and Ubuntu 20.04 is now called `ubuntu20`.

The version changes from Ubuntu 18.04 to Ubuntu 20.04 are:

  - Python: 3.6 to 3.8
  - Postgres: 10 to 12
  - PHP: 7.2 to 7.4

In the `apt-get`, I changed `--force` to `--allow-downgrades --allow-remove-essential --allow-change-held-packages`, because the former is deprecated. Cf. the [manpage of apt-get](http://manpages.ubuntu.com/manpages/focal/man8/apt-get.8.html)

The php module `codesniffer` was previously installed via Composer, but it is available via the Ubuntu repository, so I installed it via `apt-get` now.