### PR TITLE
Make tests work with phpunit 8

### DIFF
--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -56,7 +56,7 @@ For running tests:
 
   * [behave](http://pythonhosted.org/behave/)
   * [nose](https://nose.readthedocs.io)
-  * [phpunit](https://phpunit.de)
+  * [phpunit](https://phpunit.de) >= 7.3
 
 ### Hardware
 

--- a/test/php/Nominatim/AddressDetailsTest.php
+++ b/test/php/Nominatim/AddressDetailsTest.php
@@ -9,7 +9,7 @@ require_once(CONST_BasePath.'/lib/AddressDetails.php');
 class AddressDetailsTest extends \PHPUnit\Framework\TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // How the fixture got created
         //

--- a/test/php/Nominatim/DebugTest.php
+++ b/test/php/Nominatim/DebugTest.php
@@ -7,7 +7,7 @@ require_once(CONST_BasePath.'/lib/DebugHtml.php');
 class DebugTest extends \PHPUnit\Framework\TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oWithDebuginfo = $this->getMockBuilder(\GeococdeMock::class)
                                     ->setMethods(array('debugInfo'))

--- a/test/php/Nominatim/LibTest.php
+++ b/test/php/Nominatim/LibTest.php
@@ -98,8 +98,8 @@ class LibTest extends \PHPUnit\Framework\TestCase
 
         foreach ($aQueries as $sQuery) {
             $aRes = parseLatLon($sQuery);
-            $this->assertEquals(40.446, $aRes[1], 'degrees decimal ' . $sQuery, 0.01);
-            $this->assertEquals(-79.982, $aRes[2], 'degrees decimal ' . $sQuery, 0.01);
+            $this->assertEqualsWithDelta(40.446, $aRes[1], 0.01, 'degrees decimal ' . $sQuery);
+            $this->assertEqualsWithDelta(-79.982, $aRes[2], 0.01, 'degrees decimal ' . $sQuery);
             $this->assertEquals($sQuery, $aRes[0]);
         }
     }

--- a/test/php/Nominatim/SearchContextTest.php
+++ b/test/php/Nominatim/SearchContextTest.php
@@ -9,7 +9,7 @@ class SearchContextTest extends \PHPUnit\Framework\TestCase
     private $oCtx;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oCtx = new SearchContext();
     }

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -7,7 +7,7 @@ require_once(CONST_BasePath.'/lib/TokenList.php');
 
 class TokenTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oNormalizer = $this->getMockBuilder(\MockNormalizer::class)
                                   ->setMethods(array('transliterate'))

--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -38,21 +38,13 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
 
     pip3 install --user behave nose
 
-    sudo apt-get install -y php-cgi php-cli php-mbstring php-xml zip unzip
+    sudo apt-get install -y composer php-cgi php-cli php-mbstring php-xml zip unzip
 
-    curl -Ss 'https://raw.githubusercontent.com/composer/getcomposer.org/99312bc6306564ac1f0ad2c6207c129b3aff58d6/web/installer' -o /tmp/composer-setup.php
-    if echo 'e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a /tmp/composer-setup.php' | sha384sum --check --strict --status; then
-        mkdir -p ~/.local/bin
-        php /tmp/composer-setup.php --install-dir ~/.local/bin --filename composer
+    composer global require "squizlabs/php_codesniffer=*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
 
-        ~/.local/bin/composer global require "squizlabs/php_codesniffer=*"
-        sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
-
-        ~/.local/bin/composer global require "phpunit/phpunit=8.*"
-        sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
-    else
-        echo 'Installer corrupt. Cannot install composer, php_codesniffer and phpunit.' >&2
-    fi
+    composer global require "phpunit/phpunit=8.*"
+    sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
 
 #
 # System Configuration

--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -34,14 +34,25 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                             python3-psycopg2 python3-tidylib git
 
 # If you want to run the test suite, you need to install the following
-# additional packages:
-
-    sudo apt-get install -y phpunit php-cgi
+# additional packages including the PHP package manager composer:
 
     pip3 install --user behave nose
 
-    composer global require "squizlabs/php_codesniffer=*"
-    sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+    sudo apt-get install -y php-cgi php-cli php-mbstring php-xml zip unzip
+
+    curl -Ss 'https://raw.githubusercontent.com/composer/getcomposer.org/99312bc6306564ac1f0ad2c6207c129b3aff58d6/web/installer' -o /tmp/composer-setup.php
+    if echo 'e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a /tmp/composer-setup.php' | sha384sum --check --strict --status; then
+        mkdir -p ~/.local/bin
+        php /tmp/composer-setup.php --install-dir ~/.local/bin --filename composer
+
+        ~/.local/bin/composer global require "squizlabs/php_codesniffer=*"
+        sudo ln -s ~/.config/composer/vendor/bin/phpcs /usr/bin/
+
+        ~/.local/bin/composer global require "phpunit/phpunit=8.*"
+        sudo ln -s ~/.config/composer/vendor/bin/phpunit /usr/bin/
+    else
+        echo 'Installer corrupt. Cannot install composer, php_codesniffer and phpunit.' >&2
+    fi
 
 #
 # System Configuration


### PR DESCRIPTION
This pull request has two commits. The first one directly addresses the issue in #1781, so PHPUnit 8 is running now.

The second commit updates the tests to use `assertEqualsWithDelta` which is deprecated in PHPUnit 8 and removed in PHPUnit 7.

As a result, merging this pull request will mean that PHPUnit < 7.3 will no longer work. The Vagrant machine of Ubuntu 18.04 uses PHPUnit 6, so tests will fail there.