### PR TITLE
Rework ClassTypes helper functions

### DIFF
--- a/lib/AddressDetails.php
+++ b/lib/AddressDetails.php
@@ -64,21 +64,13 @@ class AddressDetails
     public function getAddressNames($sCountry = null)
     {
         $aAddress = array();
-        $aFallback = array();
 
         foreach ($this->aAddressLines as $aLine) {
             if (!self::isAddress($aLine)) {
                 continue;
             }
 
-            $bFallback = false;
-            $sTypeLabel = ClassTypes\getSimpleLabel($aLine);
-
-            if ($sTypeLabel === false) {
-                $aTypeLabel = ClassTypes\getFallbackLabel($aLine['rank_address'],
-                                                          $sCountry);
-                $bFallback = true;
-            }
+            $sTypeLabel = ClassTypes\getLabelTag($aLine);
 
             $sName = null;
             if (isset($aLine['localname']) && $aLine['localname']!=='') {
@@ -90,11 +82,9 @@ class AddressDetails
             if (isset($sName)) {
                 $sTypeLabel = strtolower(str_replace(' ', '_', $sTypeLabel));
                 if (!isset($aAddress[$sTypeLabel])
-                    || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel])
                     || $aLine['class'] == 'place'
                 ) {
                     $aAddress[$sTypeLabel] = $sName;
-                    $aFallback[$sTypeLabel] = $bFallback;
                 }
             }
         }

--- a/lib/AddressDetails.php
+++ b/lib/AddressDetails.php
@@ -61,7 +61,7 @@ class AddressDetails
         return join(', ', $aParts);
     }
 
-    public function getAddressNames()
+    public function getAddressNames($sCountry = null)
     {
         $aAddress = array();
         $aFallback = array();
@@ -72,10 +72,11 @@ class AddressDetails
             }
 
             $bFallback = false;
-            $aTypeLabel = ClassTypes\getInfo($aLine);
+            $sTypeLabel = ClassTypes\getSimpleLabel($aLine);
 
-            if ($aTypeLabel === false) {
-                $aTypeLabel = ClassTypes\getFallbackInfo($aLine);
+            if ($sTypeLabel === false) {
+                $aTypeLabel = ClassTypes\getFallbackLabel($aLine['rank_address'],
+                                                          $sCountry);
                 $bFallback = true;
             }
 
@@ -87,16 +88,13 @@ class AddressDetails
             }
 
             if (isset($sName)) {
-                $sTypeLabel = strtolower(isset($aTypeLabel['simplelabel']) ? $aTypeLabel['simplelabel'] : $aTypeLabel['label']);
-                $sTypeLabel = str_replace(' ', '_', $sTypeLabel);
+                $sTypeLabel = strtolower(str_replace(' ', '_', $sTypeLabel));
                 if (!isset($aAddress[$sTypeLabel])
-                    || isset($aFallback[$sTypeLabel])
+                    || (isset($aFallback[$sTypeLabel]) && $aFallback[$sTypeLabel])
                     || $aLine['class'] == 'place'
                 ) {
                     $aAddress[$sTypeLabel] = $sName;
-                    if ($bFallback) {
-                        $aFallback[$sTypeLabel] = $bFallback;
-                    }
+                    $aFallback[$sTypeLabel] = $bFallback;
                 }
             }
         }

--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -237,6 +237,20 @@ function getIcon($aPlace)
 }
 
 /**
+ * Get an icon for the given object with its full URL.
+ */
+function getIconFile($aPlace)
+{
+    $sIcon = getIcon($aPlace);
+
+    if (!isset($sIcon)) {
+        return null;
+    }
+
+    return CONST_Website_BaseURL.'images/mapicons/'.$sIcon.'.p.20.png';
+}
+
+/**
  * Return a class importance value for the given place.
  *
  * @param array[] $aPlace  Information about the place.

--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -17,7 +17,7 @@ function getLabelTag($aPlace, $sCountry = null)
     if (isset($aPlace['place_type'])) {
         $sLabel = $aPlace['place_type'];
     } elseif ($aPlace['class'] == 'boundary' && $aPlace['type'] == 'administrative') {
-        $sLabel = getBoundaryLabel($iRank, $sCountry);
+        $sLabel = getBoundaryLabel($iRank/2, $sCountry);
     } elseif ($iRank < 26) {
         $sLabel = $aPlace['type'];
     } elseif ($iRank < 28) {
@@ -32,7 +32,7 @@ function getLabelTag($aPlace, $sCountry = null)
         $sLabel = $aPlace['class'];
     }
 
-    return strtolower(str_replace('_', ' ', $sLabel));
+    return strtolower(str_replace(' ', '_', $sLabel));
 }
 
 /**
@@ -47,11 +47,11 @@ function getLabel($aPlace, $sCountry = null)
     }
 
     if ($aPlace['class'] == 'boundary' && $aPlace['type'] == 'administrative') {
-        return getBoundaryLabel((int)($aPlace['admin_level'] ?? 15, $sCountry ?? null);
+        return getBoundaryLabel(($aPlace['rank_address'] ?? 30)/2, $sCountry ?? null);
     }
 
     // Return a label only for 'important' class/type combinations
-    if (isset(getImportance($aPlace)) {
+    if (getImportance($aPlace) !== null) {
         return ucwords(str_replace('_', ' ', $aPlace['type']));
     }
 
@@ -82,7 +82,7 @@ function getBoundaryLabel($iAdminLevel, $sCountry, $sFallback = 'Administrative'
                                            6 => 'County',
                                            7 => 'Municipality',
                                            8 => 'City',
-                                           9 => 'City District'
+                                           9 => 'City District',
                                            10 => 'Suburb',
                                            11 => 'Neighbourhood'
                                            )
@@ -108,7 +108,7 @@ function getBoundaryLabel($iAdminLevel, $sCountry, $sFallback = 'Administrative'
 function getDefRadius($aPlace)
 {
     $aSpecialRadius = array(
-                       'place:continent' => 25
+                       'place:continent' => 25,
                        'place:country' => 7,
                        'place:state' => 2.6,
                        'place:province' => 2.6,
@@ -246,7 +246,10 @@ function getIcon($aPlace)
  */
 function getImportance($aPlace)
 {
-    static $aWithImportance = array_flip(array(
+    static $aWithImportance = null;
+
+    if ($aWithImportance === null) {
+        $aWithImportance = array_flip(array(
                                            'place:country',
                                            'place:state',
                                            'place:province',
@@ -526,7 +529,8 @@ function getImportance($aPlace)
                                            'railway:disused_station',
                                            'railway:abandoned',
                                            'railway:disused'
-                );
+                ));
+    }
 
     $sClassPlace = $aPlace['class'].':'.$aPlace['type'];
 

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -903,9 +903,9 @@ class Geocode
             }
 
             // Is there an icon set for this type of result?
-            $sIcon = ClassTypes\getIcon($aResult);
+            $sIcon = ClassTypes\getIconFile($aResult);
             if (isset($sIcon)) {
-                $aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$sIcon.'.p.20.png';
+                $aResult['icon'] = $sIcon;
             }
 
             $sLabel = ClassTypes\getLabel($aResult);

--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -897,7 +897,7 @@ class Geocode
         foreach ($aSearchResults as $iIdx => $aResult) {
             $fRadius = ClassTypes\getDefRadius($aResult);
 
-            $aOutlineResult = $this->oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fDiameter);
+            $aOutlineResult = $this->oPlaceLookup->getOutlines($aResult['place_id'], $aResult['lon'], $aResult['lat'], $fRadius);
             if ($aOutlineResult) {
                 $aResult = array_merge($aResult, $aOutlineResult);
             }
@@ -905,7 +905,7 @@ class Geocode
             // Is there an icon set for this type of result?
             $sIcon = ClassTypes\getIcon($aResult);
             if (isset($sIcon)) {
-                $aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aIcon.'.p.20.png';
+                $aResult['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$sIcon.'.p.20.png';
             }
 
             $sLabel = ClassTypes\getLabel($aResult);
@@ -941,7 +941,7 @@ class Geocode
                 // - number of exact matches from the query
                 $aResult['foundorder'] -= $aResults[$aResult['place_id']]->iExactMatches;
                 // - importance of the class/type
-                $iClassImportance = ClassTypes/getImportance($aResult);
+                $iClassImportance = ClassTypes\getImportance($aResult);
                 if (isset($iClassImportance)) {
                     $aResult['foundorder'] += 0.0001 * $iClassImportance;
                 } else {

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -448,10 +448,9 @@ class PlaceLookup
                 }
             }
 
-            $aPlace['addresstype'] = ClassTypes\getProperty(
-                $aPlace,
-                'simplelabel',
-                $aPlace['class']
+            $aPlace['addresstype'] = ClassTypes\getLabelTag(
+                    $aPlace,
+                    $aPlace['country_code']
             );
         }
 

--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -449,8 +449,8 @@ class PlaceLookup
             }
 
             $aPlace['addresstype'] = ClassTypes\getLabelTag(
-                    $aPlace,
-                    $aPlace['country_code']
+                $aPlace,
+                $aPlace['country_code']
             );
         }
 

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -57,10 +57,12 @@
         return $sHTML;
     }
 
-    function map_icon($sIcon)
+    function map_icon($aPlace)
     {
+        $sIcon = Nominatim\ClassTypes\getIconFile($aPlace);
         if (isset($sIcon)) {
-            echo '<img id="mapicon" src="'.CONST_Website_BaseURL.'images/mapicons/'.$sIcon.'.n.32.png'.'" alt="'.$sIcon.'" />';
+            $sLabel = Nominatim\ClassTypes\getIcon($aPlace);
+            echo '<img id="mapicon" src="'.$sIcon.'" alt="'.$sLabel.'" />';
         }
     }
 
@@ -112,7 +114,7 @@
                 </h1>
             </div>
             <div class="col-sm-2 text-right">
-                <?php map_icon($aPointDetails['icon']) ?>
+                <?php map_icon($aPointDetails) ?>
             </div>
         </div>
         <div class="row">

--- a/lib/template/details-html.php
+++ b/lib/template/details-html.php
@@ -59,7 +59,7 @@
 
     function map_icon($sIcon)
     {
-        if ($sIcon){
+        if (isset($sIcon)) {
             echo '<img id="mapicon" src="'.CONST_Website_BaseURL.'images/mapicons/'.$sIcon.'.n.32.png'.'" alt="'.$sIcon.'" />';
         }
     }

--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -26,8 +26,9 @@ $aPlaceDetails['calculated_importance'] = (float) $aPointDetails['calculated_imp
 
 $aPlaceDetails['extratags'] = $aPointDetails['aExtraTags'];
 $aPlaceDetails['calculated_wikipedia'] = $aPointDetails['wikipedia'];
-if (isset($aPointDetails['icon'])) {
-    $aPlaceDetails['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aPointDetails['icon'].'.n.32.png';
+$sIcon = Nominatim\ClassTypes\getIconFile($aPointDetails);
+if (isset($sIcon)) {
+    $aPlaceDetails['icon'] = $sIcon;
 }
 
 $aPlaceDetails['rank_address'] = (int) $aPointDetails['rank_address'];

--- a/lib/template/details-json.php
+++ b/lib/template/details-json.php
@@ -26,7 +26,7 @@ $aPlaceDetails['calculated_importance'] = (float) $aPointDetails['calculated_imp
 
 $aPlaceDetails['extratags'] = $aPointDetails['aExtraTags'];
 $aPlaceDetails['calculated_wikipedia'] = $aPointDetails['wikipedia'];
-if ($aPointDetails['icon']) {
+if (isset($aPointDetails['icon'])) {
     $aPlaceDetails['icon'] = CONST_Website_BaseURL.'images/mapicons/'.$aPointDetails['icon'].'.n.32.png';
 }
 

--- a/test/bdd/api/search/params.feature
+++ b/test/bdd/api/search/params.feature
@@ -59,9 +59,8 @@ Feature: Search queries
           | ID | class   | type |
           | 0  | leisure | dog_park |
         And result addresses contain
-          | ID | address29 |
+          | ID | leisure |
           | 0  | Hundeauslauf |
-        And address of result 0 has no types leisure,dog_park
 
     Scenario: Disabling deduplication
         When sending json search query "Sievekingsallee, Hamburg"

--- a/test/php/Nominatim/AddressDetailsTest.php
+++ b/test/php/Nominatim/AddressDetailsTest.php
@@ -70,7 +70,7 @@ class AddressDetailsTest extends \PHPUnit\Framework\TestCase
     {
         $oAD = new AddressDetails($this->oDbStub, 194663412, 10, 'en');
         $expected = array(
-                     'attraction' => '10 Downing Street',
+                     'tourism' => '10 Downing Street',
                      'house_number' => '10',
                      'road' => 'Downing Street',
                      'neighbourhood' => 'St. James\'s',

--- a/test/php/Nominatim/ClassTypesTest.php
+++ b/test/php/Nominatim/ClassTypesTest.php
@@ -9,41 +9,40 @@ class ClassTypesTest extends \PHPUnit\Framework\TestCase
     public function testGetLabelTag()
     {
         $aPlace = array('class' => 'boundary', 'type' => 'administrative',
-                        'rank_address' => '4', 'place_type' => 'city');
+                   'rank_address' => '4', 'place_type' => 'city');
         $this->assertEquals('city', ClassTypes\getLabelTag($aPlace));
 
         $aPlace = array('class' => 'boundary', 'type' => 'administrative',
-                        'rank_address' => '10');
+                   'rank_address' => '10');
         $this->assertEquals('state_district', ClassTypes\getLabelTag($aPlace));
 
         $aPlace = array('class' => 'boundary', 'type' => 'administrative');
         $this->assertEquals('administrative', ClassTypes\getLabelTag($aPlace));
 
-        $aPlace = array('class' => 'place', 'type' => 'hamlet',
-                        'rank_address' => '20');
+        $aPlace = array('class' => 'place', 'type' => 'hamlet', 'rank_address' => '20');
         $this->assertEquals('hamlet', ClassTypes\getLabelTag($aPlace));
 
         $aPlace = array('class' => 'highway', 'type' => 'residential',
-                        'rank_address' => '26');
+                   'rank_address' => '26');
         $this->assertEquals('road', ClassTypes\getLabelTag($aPlace));
 
         $aPlace = array('class' => 'place', 'type' => 'house_number',
-                        'rank_address' => '30');
+                   'rank_address' => '30');
         $this->assertEquals('house_number', ClassTypes\getLabelTag($aPlace));
 
         $aPlace = array('class' => 'amenity', 'type' => 'prison',
-                        'rank_address' => '30');
+                   'rank_address' => '30');
         $this->assertEquals('amenity', ClassTypes\getLabelTag($aPlace));
     }
 
     public function testGetLabel()
     {
         $aPlace = array('class' => 'boundary', 'type' => 'administrative',
-                        'rank_address' => '4', 'place_type' => 'city');
+                   'rank_address' => '4', 'place_type' => 'city');
         $this->assertEquals('City', ClassTypes\getLabel($aPlace));
 
         $aPlace = array('class' => 'boundary', 'type' => 'administrative',
-                        'rank_address' => '10');
+                   'rank_address' => '10');
         $this->assertEquals('State District', ClassTypes\getLabel($aPlace));
 
         $aPlace = array('class' => 'boundary', 'type' => 'administrative');

--- a/test/php/Nominatim/ClassTypesTest.php
+++ b/test/php/Nominatim/ClassTypesTest.php
@@ -6,89 +6,88 @@ require_once(CONST_BasePath.'/lib/ClassTypes.php');
 
 class ClassTypesTest extends \PHPUnit\Framework\TestCase
 {
-    public function testGetInfo()
+    public function testGetLabelTag()
     {
-        // 1) Admin level set
-        // city Dublin
-        // https://nominatim.openstreetmap.org/details.php?osmtype=R&osmid=1109531
-        $aPlace = array(
-                   'admin_level' => 7,
-                   'class' => 'boundary',
-                   'type' => 'administrative',
-                   'rank_address' => 14
-        );
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative',
+                        'rank_address' => '4', 'place_type' => 'city');
+        $this->assertEquals('city', ClassTypes\getLabelTag($aPlace));
 
-        $this->assertEquals('Municipality', ClassTypes\getInfo($aPlace)['label']);
-        $this->assertEquals('Municipality', ClassTypes\getFallbackInfo($aPlace)['label']);
-        $this->assertEquals('Municipality', ClassTypes\getProperty($aPlace, 'label'));
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative',
+                        'rank_address' => '10');
+        $this->assertEquals('state_district', ClassTypes\getLabelTag($aPlace));
 
-        // 2) No admin level
-        // Eiffel Tower
-        // https://nominatim.openstreetmap.org/details.php?osmtype=W&osmid=5013364
-        $aPlace = array(
-                   'class' => 'tourism',
-                   'type' => 'attraction',
-                   'rank_address' => 29
-        );
-        $this->assertEquals('Attraction', ClassTypes\getInfo($aPlace)['label']);
-        $this->assertEquals(array('simplelabel' => 'address29'), ClassTypes\getFallbackInfo($aPlace));
-        $this->assertEquals('Attraction', ClassTypes\getProperty($aPlace, 'label'));
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative');
+        $this->assertEquals('administrative', ClassTypes\getLabelTag($aPlace));
 
-        // 3) Unknown type
-        // La Maison du Toutou, Paris
-        // https://nominatim.openstreetmap.org/details.php?osmtype=W&osmid=164011651
-        $aPlace = array(
-                   'class' => 'shop',
-                   'type' => 'pet_grooming',
-                   'rank_address' => 29
-        );
-        $this->assertEquals(false, ClassTypes\getInfo($aPlace));
-        $this->assertEquals(array('simplelabel' => 'address29'), ClassTypes\getFallbackInfo($aPlace));
-        $this->assertEquals(false, ClassTypes\getProperty($aPlace, 'label'));
-        $this->assertEquals('mydefault', ClassTypes\getProperty($aPlace, 'label', 'mydefault'));
+        $aPlace = array('class' => 'place', 'type' => 'hamlet',
+                        'rank_address' => '20');
+        $this->assertEquals('hamlet', ClassTypes\getLabelTag($aPlace));
+
+        $aPlace = array('class' => 'highway', 'type' => 'residential',
+                        'rank_address' => '26');
+        $this->assertEquals('road', ClassTypes\getLabelTag($aPlace));
+
+        $aPlace = array('class' => 'place', 'type' => 'house_number',
+                        'rank_address' => '30');
+        $this->assertEquals('house_number', ClassTypes\getLabelTag($aPlace));
+
+        $aPlace = array('class' => 'amenity', 'type' => 'prison',
+                        'rank_address' => '30');
+        $this->assertEquals('amenity', ClassTypes\getLabelTag($aPlace));
     }
 
-    public function testGetClassTypesWithImportance()
+    public function testGetLabel()
     {
-        $aClasses = ClassTypes\getListWithImportance();
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative',
+                        'rank_address' => '4', 'place_type' => 'city');
+        $this->assertEquals('City', ClassTypes\getLabel($aPlace));
 
-        $this->assertGreaterThan(
-            200,
-            count($aClasses)
-        );
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative',
+                        'rank_address' => '10');
+        $this->assertEquals('State District', ClassTypes\getLabel($aPlace));
 
-        $this->assertEquals(
-            array(
-             'label' => 'Country',
-             'frequency' => 0,
-             'icon' => 'poi_boundary_administrative',
-             'defzoom' => 6,
-             'defdiameter' => 15,
-             'importance' => 3
-            ),
-            $aClasses['place:country']
-        );
+        $aPlace = array('class' => 'boundary', 'type' => 'administrative');
+        $this->assertEquals('Administrative', ClassTypes\getLabel($aPlace));
+
+        $aPlace = array('class' => 'amenity', 'type' => 'prison');
+        $this->assertEquals('Prison', ClassTypes\getLabel($aPlace));
+
+        $aPlace = array('class' => 'amenity', 'type' => 'foobar');
+        $this->assertNull(ClassTypes\getLabel($aPlace));
     }
 
+    public function testGetBoundaryLabel()
+    {
+        $this->assertEquals('City', ClassTypes\getBoundaryLabel(8, null));
+        $this->assertEquals('Administrative', ClassTypes\getBoundaryLabel(18, null));
+        $this->assertEquals('None', ClassTypes\getBoundaryLabel(18, null, 'None'));
+        $this->assertEquals('State', ClassTypes\getBoundaryLabel(4, 'de', 'None'));
+    }
 
-    public function testGetResultDiameter()
+    public function testGetDefRadius()
     {
         $aResult = array('class' => '', 'type' => '');
-        $this->assertEquals(
-            0.0001,
-            ClassTypes\getProperty($aResult, 'defdiameter', 0.0001)
-        );
+        $this->assertEquals(0.00005, ClassTypes\getDefRadius($aResult));
 
         $aResult = array('class' => 'place', 'type' => 'country');
-        $this->assertEquals(
-            15,
-            ClassTypes\getProperty($aResult, 'defdiameter', 0.0001)
-        );
+        $this->assertEquals(7, ClassTypes\getDefRadius($aResult));
+    }
 
-        $aResult = array('class' => 'boundary', 'type' => 'administrative', 'admin_level' => 6);
-        $this->assertEquals(
-            0.32,
-            ClassTypes\getProperty($aResult, 'defdiameter', 0.0001)
-        );
+    public function testGetIcon()
+    {
+        $aResult = array('class' => '', 'type' => '');
+        $this->assertNull(ClassTypes\getIcon($aResult));
+
+        $aResult = array('class' => 'place', 'type' => 'airport');
+        $this->assertEquals('transport_airport2', ClassTypes\getIcon($aResult));
+    }
+
+    public function testGetImportance()
+    {
+        $aResult = array('class' => '', 'type' => '');
+        $this->assertNull(ClassTypes\getImportance($aResult));
+
+        $aResult = array('class' => 'place', 'type' => 'airport');
+        $this->assertGreaterThan(0, ClassTypes\getImportance($aResult));
     }
 }

--- a/website/details.php
+++ b/website/details.php
@@ -149,7 +149,6 @@ if (!$aPointDetails) {
 }
 
 $aPointDetails['localname'] = $aPointDetails['localname']?$aPointDetails['localname']:$aPointDetails['housenumber'];
-$aPointDetails['icon'] = Nominatim\ClassTypes\getIcon($aPointDetails);
 $aPointDetails['rank_search_label'] = getSearchRankLabel($aPointDetails['rank_search']); // only used in HTML format
 
 // Get all alternative names (languages, etc)

--- a/website/details.php
+++ b/website/details.php
@@ -149,7 +149,7 @@ if (!$aPointDetails) {
 }
 
 $aPointDetails['localname'] = $aPointDetails['localname']?$aPointDetails['localname']:$aPointDetails['housenumber'];
-$aPointDetails['icon'] = Nominatim\ClassTypes\getProperty($aPointDetails, 'icon', false);
+$aPointDetails['icon'] = Nominatim\ClassTypes\getIcon($aPointDetails);
 $aPointDetails['rank_search_label'] = getSearchRankLabel($aPointDetails['rank_search']); // only used in HTML format
 
 // Get all alternative names (languages, etc)

--- a/website/hierarchy.php
+++ b/website/hierarchy.php
@@ -103,10 +103,8 @@ if (!empty($aParentOfLines)) {
     echo '<h2>Parent Of:</h2>';
     $aGroupedAddressLines = array();
     foreach ($aParentOfLines as $aAddressLine) {
-        $aAddressLine['label'] = Nominatim\ClassTypes\getProperty($aAddressLine, 'label');
-        if (!$aAddressLine['label']) {
-            $aAddressLine['label'] = ucwords($aAddressLine['type']);
-        }
+        $aAddressLine['label'] = Nominatim\ClassTypes\getLabel($aAddressLine)
+                                 ?? ucwords($aAddressLine['type']);
 
         if (!isset($aGroupedAddressLines[$aAddressLine['label']])) $aGroupedAddressLines[$aAddressLine['label']] = array();
             $aGroupedAddressLines[$aAddressLine['label']][] = $aAddressLine;

--- a/website/lookup.php
+++ b/website/lookup.php
@@ -58,7 +58,7 @@ foreach ($aOsmIds as $sItem) {
                 $oPlace['place_id'],
                 $oPlace['lon'],
                 $oPlace['lat'],
-                Nominatim\ClassTypes\getProperty($oPlace, 'defdiameter', 0.0001)
+                Nominatim\ClassTypes\getDefRadius($oPlace)
             );
 
             if ($aOutlineResult) {

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -55,7 +55,7 @@ if (isset($aPlace)) {
         $aPlace['place_id'],
         $aPlace['lon'],
         $aPlace['lat'],
-        Nominatim\ClassTypes\getProperty($aPlace, 'defdiameter', 0.0001),
+        Nominatim\ClassTypes\getDefRadius($aPlace),
         $fLat,
         $fLon
     );


### PR DESCRIPTION
Instead of having one huge array with selected information about each class/type combination, have a   dedicated function for each property. Simple label (now called label tag) and label can be deduced from the class/type names. For other properties, we only remember the exceptions to the rules. That reduces the amount of information that needs to be saved (and loaded on each run).

Label tags are even more simplified than before and for rank 30 now generally use the class. This means that there are less possible values for the address parts, which has always been a source of complaints.

This PR prepares a) for the possibility to have country-specific admin boundary types, and b) to get rid of most of the information in ClassTypes. Icons and labels should go into nominiatim-ui, class importance should go into the indexing step in SQL, leaving us essentially with the radius and the label tag.