### PR TITLE
Added setup website option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+CONST_BasePath=@CMAKE_SOURCE_DIR@
+#CONST_InstallPath=@CMAKE_BINARY_DIR@
+#CONST_Phrase_Config='${CONST_BasePath}/settings/phrase_settings.php'
+
+CONST_Debug=false
+CONST_Database_DSN=pgsql:dbname=nominatim
+CONST_Default_Language=false
+CONST_Default_Lat=20.0
+CONST_Default_Lon=0.0
+CONST_Default_Zoom=2
+
+CONST_Log_DB=false
+CONST_Log_File=false
+CONST_Map_Tile_Attribution=''
+CONST_Map_Tile_URL='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+CONST_Max_Word_Frequency=50000
+CONST_NoAccessControl=true
+CONST_Places_Max_ID_count=50
+CONST_PolygonOutput_MaximumTypes=1
+CONST_Search_AreaPolygons=true
+CONST_Search_BatchMode=false
+CONST_Search_NameOnlySearchFrequencyThreshold=500
+CONST_Search_ReversePlanForAll=true
+CONST_Term_Normalization_Rules=":: NFD (); [[:Nonspacing Mark:] [:Cf:]] >;  :: lower (); [[:Punctuation:][:Space:]]+ > ' '; :: NFC ();"
+CONST_Use_Aux_Location_data=false
+CONST_Use_US_Tiger_Data=false
+CONST_Website_BaseURL='http://'.php_uname('n').'/'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data/wiki_specialphrases.sql
 data/osmosischange.osc
 
 .vagrant
+.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,9 @@ endif()
 configure_file(${PROJECT_SOURCE_DIR}/settings/defaults.php
                ${PROJECT_BINARY_DIR}/settings/settings.php)
 
+configure_file(${PROJECT_SOURCE_DIR}/.env
+               ${PROJECT_BINARY_DIR}/.env @ONLY)
+               
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------

--- a/cmake/website.tmpl
+++ b/cmake/website.tmpl
@@ -1,3 +1,3 @@
 <?php
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(dirname(dirname(__FILE__)).'/settings/settings_test.php');
 require_once(CONST_BasePath.'/@script_source@');

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nominatim;
+
+use Dotenv\Dotenv;
+
+/**
+ * Uses Dotenv to acess environment values
+ */
+class Config
+{
+    static $dotenv;
+    
+    public static function setupEnv($dir = __DIR__, $path = '../.env')
+    {
+        define('DIR_VENDOR', dirname(__DIR__).'/vendor/');
+        echo 'Trying to connect from the directory: '.$dir."\n";
+        if (file_exists(DIR_VENDOR . 'autoload.php')) {
+            require_once(DIR_VENDOR . 'autoload.php');
+            $dotenv = Dotenv::createImmutable($dir, $path);
+            $dotenv->load();
+        } else {
+            echo 'Failed to load autoload.php from '.DIR_VENDOR;
+        }
+    }
+}

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -9,7 +9,7 @@ use Dotenv\Dotenv;
  */
 class Config
 {
-    static $dotenv;
+    public static $dotenv;
     
     public static function setupEnv($dir = __DIR__, $path = '../.env')
     {

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -697,10 +697,10 @@ class SetupFunctions
     }
 
     /**
-     * Setup settings_test.php in the build/settings directory from build/.env file 
+     * Setup settings_test.php in the build/settings directory from build/.env file
      *
      * @return null
-     */    
+     */
     public function setupWebsite()
     {
         info('Setting up website\n');
@@ -711,7 +711,7 @@ class SetupFunctions
         $contents = file_get_contents($fileName);
         $contents = explode("\n", $contents);
 
-        $op = fopen(CONST_InstallPath.'/settings/settings_test.php', "w");
+        $op = fopen(CONST_InstallPath.'/settings/settings_test.php', 'w');
 
         // Currently using CONST_BasePath and CONST_InstallPath.
         // Once dotenv is setup, getenv() can be used, or another
@@ -725,26 +725,22 @@ if (isset(\$_GET['debug']) && \$_GET['debug']) @define('CONST_Debug', true);");
         
 
         // Array used to store all the env variables in key-value format.
-        $envVariables = [];
+        $envVariables = array();
 
-        foreach ($contents as $data)
-        {
+        foreach ($contents as $data) {
             $arr = explode('=', $data, 2);
             // Avoid empty lines, CONST_BasePath, CONST_InstallPath and comments in .env
-            if ($arr[0] !== '' and $arr[0] !== 'CONST_BasePath' and $arr[0] !== 'CONST_InstallPath' and $data[0] != '#')
-            {
+            if ($arr[0] !== '' and $arr[0] !== 'CONST_BasePath' and $arr[0] !== 'CONST_InstallPath' and $data[0] != '#') {
                 // To handle `${}` type of values in .env
                 // This is not required for current set of env variables, but could be used if required.
                 // NOTE: This works only if the `${}` is in the beginning.
-                if (preg_match("{[$]\{.*\}}", $arr[1], $aMatch))
-                {
-                    $arr[1] = preg_replace("{[$]\{.*\}}", $envVariables[substr($aMatch[0], 2, strlen($aMatch[0]) - 3)], $arr[1]);
+                if (preg_match('{[$]\{.*\}}', $arr[1], $aMatch)) {
+                    $arr[1] = preg_replace('{[$]\{.*\}}', $envVariables[substr($aMatch[0], 2, strlen($aMatch[0]) - 3)], $arr[1]);
                 }
                 $envVariables[$arr[0]] = $arr[1];
 
                 // Add single quotes to strings which require them.
-                if ($arr[1][0] !== "\"" and $arr[1][0] !== "'" and $arr[1] !== 'true' and $arr[1] !== 'false')
-                {
+                if ($arr[1][0] !== '"' and $arr[1][0] !== "'" and $arr[1] !== 'true' and $arr[1] !== 'false') {
                     $arr[1] = "'$arr[1]'";
                 }
                 fwrite($op, "@define('$arr[0]', $arr[1]);\n");

--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -85,7 +85,7 @@ if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 @define('CONST_Replication_Recheck_Interval', '60');
 
 // Website settings
-@define('CONST_NoAccessControl', true);
+// @define('CONST_NoAccessControl', true);
 
 @define('CONST_Website_BaseURL', 'http://'.php_uname('n').'/');
 // Language to assume when none is supplied with the query.
@@ -93,24 +93,24 @@ if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 // will be used.
 @define('CONST_Default_Language', false);
 // Appearance of the map in the debug interface.
-@define('CONST_Default_Lat', 20.0);
-@define('CONST_Default_Lon', 0.0);
-@define('CONST_Default_Zoom', 2);
-@define('CONST_Map_Tile_URL', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
-@define('CONST_Map_Tile_Attribution', ''); // Set if tile source isn't osm.org
+// @define('CONST_Default_Lat', 20.0);
+// @define('CONST_Default_Lon', 0.0);
+// @define('CONST_Default_Zoom', 2);
+// @define('CONST_Map_Tile_URL', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+// @define('CONST_Map_Tile_Attribution', ''); // Set if tile source isn't osm.org
 
 @define('CONST_Search_AreaPolygons', true);
 
-@define('CONST_Search_BatchMode', false);
+// @define('CONST_Search_BatchMode', false);
 
 @define('CONST_Search_NameOnlySearchFrequencyThreshold', 500);
 // If set to true, then reverse order of queries will be tried by default.
 // When set to false only selected languages alloow reverse search.
-@define('CONST_Search_ReversePlanForAll', true);
+// @define('CONST_Search_ReversePlanForAll', true);
 
 // Maximum number of OSM ids that may be queried at once
 // for the places endpoint.
-@define('CONST_Places_Max_ID_count', 50);
+// @define('CONST_Places_Max_ID_count', 50);
 
 // Number of different geometry formats that may be queried in parallel.
 // Set to zero to disable polygon output.

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -44,6 +44,7 @@ $aCMDOptions
    array('create-search-indices', '', 0, 1, 0, 0, 'bool', 'Create additional indices required for search and update'),
    array('create-country-names', '', 0, 1, 0, 0, 'bool', 'Create default list of searchable country names'),
    array('drop', '', 0, 1, 0, 0, 'bool', 'Drop tables needed for updates, making the database readonly (EXPERIMENTAL)'),
+   array('setup-website', '', 0, 1, 0, 0, 'bool', 'Used to compile environment variables for the website (EXPERIMENTAL)'),
   );
 
 // $aCMDOptions passed to getCmdOpt by reference
@@ -151,6 +152,11 @@ if ($aCMDResult['create-search-indices'] || $aCMDResult['all']) {
 if ($aCMDResult['create-country-names'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->createCountryNames($aCMDResult);
+}
+
+if ($aCMDResult['setup-website']) {
+    $bDidSomething = true;
+    $oSetup->setupWebsite();
 }
 
 // ******************************************************


### PR DESCRIPTION
For issue #946:

**Following changes are implemented in this PR:**

- [x] Created `.env.example` with all variables exclusively used by `/website` module.
- [x] CMake builds `.env` to the build folder.
- [x] Add --setup-website option in `setup.php` to build `settings_test.php` from the `.env` file. The function setupWebsite() in `SetupClass.php` covers all the cases I came across but is still not perfect.
- [x] Updated `website.tmpl` to use `settings/settings_test.php` instead of `settings/settings.php`.
- [x] Commented out these website-only variables from `defaults.php`. Once the Further steps are implemented, we can safely dispose of `defaults.php`.
- [x] Added `lib/Config.php` class to use dotenv(). This will be used to get env variables for scripts.


**Setup instructions:**

1. Copy `.env.example` to `.env`. Make any required env changes.
2. Build nominatim.
3. Run `./utils/setup.php --setup-website` to set up `settings_test.php`.
4. Run tests if necessary.

**Further steps:**

- [ ] Replace CONST_* variables in scripts with getenv() function.
- [ ] Using overlapping(used by both scripts and website) variables.
- [ ] Renaming variables according to [this comment](https://github.com/osm-search/Nominatim/issues/946#issuecomment-476330531)
- [ ] Adapt tests according to these changes.
- [ ] Add setup instructions.