### PR TITLE
Disable JIT and parallel workers when indexing 

### DIFF
--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -36,18 +36,14 @@ For compiling:
 
 For running Nominatim:
 
-  * [PostgreSQL](https://www.postgresql.org) (9.3 - 11)
-  * [PostGIS](https://postgis.org) (2.2 - 2.5)
+  * [PostgreSQL](https://www.postgresql.org) (9.3+)
+  * [PostGIS](https://postgis.org) (2.2+)
   * [Python 3](https://www.python.org/)
   * [Psycopg2](https://initd.org/psycopg)
   * [PHP](https://php.net) (7.0 or later)
   * PHP-pgsql
   * PHP-intl (bundled with PHP)
   * a webserver (apache or nginx are recommended)
-
-!!! danger "Important"
-    Postgresql 12+ and Postgis 3.0+ are known to cause performance issues. They are
-    not recommended for a production installation at the moment.
 
 For running continuous updates:
 

--- a/nominatim/nominatim.py
+++ b/nominatim/nominatim.py
@@ -124,6 +124,15 @@ class DBConnection(object):
         self.wait()
 
         self.cursor = self.conn.cursor()
+        # Disable JIT and parallel workers as they are known to cause problems.
+        # Update pg_settings instead of using SET because it does not yield
+        # errors on older versions of Postgres where the settings are not
+        # implemented.
+        self.perform(
+            """ UPDATE pg_settings SET setting = -1 WHERE name = 'jit_above_cost';
+                UPDATE pg_settings SET setting = 0 
+                   WHERE name = 'max_parallel_workers_per_gather';""")
+        self.wait()
 
     def wait(self):
         """ Block until any pending operation is done.


### PR DESCRIPTION
Locally disable jit and parallel workers in the connection that
do indexing. The query planner tends to be overenthusiastic about
using JIT. But with the rather less complex queries we have, the
overhead tends to be larger than the performance gain.

Fixes #1677.