### PR TITLE
Remove references to public schema

### DIFF
--- a/data/country_name.sql
+++ b/data/country_name.sql
@@ -9,8 +9,6 @@ SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/data/gb_postcode_table.sql
+++ b/data/gb_postcode_table.sql
@@ -10,8 +10,6 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/data/us_postcode_table.sql
+++ b/data/us_postcode_table.sql
@@ -3,8 +3,6 @@ SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/data/words.sql
+++ b/data/words.sql
@@ -8,8 +8,6 @@ SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/sql/functions/normalization.sql
+++ b/sql/functions/normalization.sql
@@ -15,7 +15,7 @@ CREATE OR REPLACE FUNCTION make_standard_name(name TEXT) RETURNS TEXT
 DECLARE
   o TEXT;
 BEGIN
-  o := public.gettokenstring(public.transliteration(name));
+  o := gettokenstring(transliteration(name));
   RETURN trim(substr(o,1,length(o)));
 END;
 $$


### PR DESCRIPTION
Just a small PR which removes hardcoded references to the "public" schema in Postgres. The "public" schema is the default when using Postgres, so it's unnecessary to set it manually. Also, if you try to use a schema other than public the current SQLs prevent that and the import will fail.

With this PR I'd like to make the setup process more generic, so people can use a different schema.

**IMPORTANT NOTE:** `SET search_path = public, pg_catalog;` is also included in https://nominatim.org/data/country_grid.sql.gz where it should also be removed! I didn't find the source of the file in this repository, so I don't know how to do a PR for it. Should you accept this PR please also consider changing `country_grid.sql.gz` the same way as the other SQL files in this PR are changed!