### PR TITLE
Added setup-website option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ script:
   - if [[ $TEST_SUITE == "tests" ]]; then phpcs --report-width=120 . ; fi
   - cd $TRAVIS_BUILD_DIR/test/php
   - if [[ $TEST_SUITE == "tests" ]]; then /usr/bin/phpunit ./ ; fi
+  - cd $TRAVIS_BUILD_DIR/build
+  - /usr/bin/env php ./utils/setup.php --setup-website
   - cd $TRAVIS_BUILD_DIR/test/bdd
   - # behave --format=progress3 api
   - if [[ $TEST_SUITE == "tests" ]]; then behave -DREMOVE_TEMPLATE=1 --format=progress3 db ; fi

--- a/cmake/website.tmpl
+++ b/cmake/website.tmpl
@@ -1,3 +1,3 @@
 <?php
-require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
+require_once(dirname(dirname(__FILE__)).'/settings/settings-frontend.php');
 require_once(CONST_BasePath.'/@script_source@');

--- a/cmake/website.tmpl
+++ b/cmake/website.tmpl
@@ -1,3 +1,3 @@
 <?php
-require_once(dirname(dirname(__FILE__)).'/settings/settings-frontend.php');
+require_once(dirname(dirname(__FILE__)).'/website/settings-frontend.php');
 require_once(CONST_BasePath.'/@script_source@');

--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -195,6 +195,17 @@ Run this script to verify all required tables and indices got created successful
 ./utils/check_import_finished.php
 ```
 
+### Setting up the website
+
+Run the following command to set up the `settings/settings-frontend.php`.
+These settings are used in website/*.php files. You can use the website only after this 
+step is completed.
+
+```sh
+./utils/setup.php --setup-website
+```
+!!! Note
+    This step is not necessary if you use `--all` option while setting up the DB.
 
 ## Tuning the database
 

--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -197,7 +197,7 @@ Run this script to verify all required tables and indices got created successful
 
 ### Setting up the website
 
-Run the following command to set up the `settings/settings-frontend.php`.
+Run the following command to set up the `website/settings-frontend.php`.
 These settings are used in website/*.php files. You can use the website only after this 
 step is completed.
 

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -695,17 +695,13 @@ class SetupFunctions
     }
 
     /**
-     * Setup settings_test.php in the build/settings directory from build/.env file
+     * Setup settings-frontend.php in the build/website directory
      *
      * @return null
      */
     public function setupWebsite()
     {
-        $rOutputFile = fopen(CONST_InstallPath.'/settings/settings-frontend.php', 'w');
-
-        // Currently using CONST_BasePath and CONST_InstallPath.
-        // Once dotenv is setup, getenv() can be used, or another
-        // alternate option is to build settings_test.php using cmake.
+        $rOutputFile = fopen(CONST_InstallPath.'/website/settings-frontend.php', 'w');
 
         fwrite($rOutputFile, "<?php
 @define('CONST_BasePath', '".CONST_BasePath."');
@@ -734,7 +730,7 @@ if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SE
 @define('CONST_Use_US_Tiger_Data', ".(CONST_Use_US_Tiger_Data ? 'true' : 'false').");
 @define('CONST_Website_BaseURL', '".CONST_Website_BaseURL."');
 ");
-        info(CONST_InstallPath.'/settings/settings-frontend.php has been set up successfully');
+        info(CONST_InstallPath.'/website/settings-frontend.php has been set up successfully');
     }
 
     private function removeFlatnodeFile()

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -694,6 +694,49 @@ class SetupFunctions
         $this->removeFlatnodeFile();
     }
 
+    /**
+     * Setup settings_test.php in the build/settings directory from build/.env file
+     *
+     * @return null
+     */
+    public function setupWebsite()
+    {
+        $rOutputFile = fopen(CONST_InstallPath.'/settings/settings-frontend.php', 'w');
+
+        // Currently using CONST_BasePath and CONST_InstallPath.
+        // Once dotenv is setup, getenv() can be used, or another
+        // alternate option is to build settings_test.php using cmake.
+
+        fwrite($rOutputFile, "<?php
+@define('CONST_BasePath', '".CONST_BasePath."');
+if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
+
+@define('CONST_Debug', ". (CONST_Debug? 'true' : 'false').");
+@define('CONST_Database_DSN', '".CONST_Database_DSN."'); // or add ;host=...;port=...;user=...;password=...
+@define('CONST_Default_Language', ".(CONST_Default_Language ? 'true' : 'false').");
+@define('CONST_Default_Lat', ".CONST_Default_Lat.");
+@define('CONST_Default_Lon', ".CONST_Default_Lon.");
+@define('CONST_Default_Zoom', ".CONST_Default_Zoom.");
+@define('CONST_Map_Tile_URL', '".CONST_Map_Tile_URL."');
+@define('CONST_Map_Tile_Attribution', '".CONST_Map_Tile_Attribution."'); // Set if tile source isn't osm.org
+@define('CONST_Log_DB', ".(CONST_Log_DB ? 'true' : 'false').");
+@define('CONST_Log_File', ".(CONST_Log_File ? 'true' : 'false').");
+@define('CONST_Max_Word_Frequency', '".CONST_Max_Word_Frequency."');
+@define('CONST_NoAccessControl', ".CONST_NoAccessControl.");
+@define('CONST_Places_Max_ID_count', ".CONST_Places_Max_ID_count.");
+@define('CONST_PolygonOutput_MaximumTypes', ".CONST_PolygonOutput_MaximumTypes.");
+@define('CONST_Search_AreaPolygons', ".CONST_Search_AreaPolygons.");
+@define('CONST_Search_BatchMode', ".(CONST_Search_BatchMode ? 'true' : 'false').");
+@define('CONST_Search_NameOnlySearchFrequencyThreshold', ".CONST_Search_NameOnlySearchFrequencyThreshold.");
+@define('CONST_Search_ReversePlanForAll', ".CONST_Search_ReversePlanForAll.");
+@define('CONST_Term_Normalization_Rules', \"".CONST_Term_Normalization_Rules."\");
+@define('CONST_Use_Aux_Location_data', ".(CONST_Use_Aux_Location_data ? 'true' : 'false').");
+@define('CONST_Use_US_Tiger_Data', ".(CONST_Use_US_Tiger_Data ? 'true' : 'false').");
+@define('CONST_Website_BaseURL', '".CONST_Website_BaseURL."');
+");
+        info(CONST_InstallPath.'/settings/settings-frontend.php has been set up successfully');
+    }
+
     private function removeFlatnodeFile()
     {
         if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -77,15 +77,17 @@ if ($aCMDResult['create-db'] || $aCMDResult['all']) {
     $oSetup->createDB();
 }
 
-$oSetup->connect();
+if (!$aCMDResult['setup-website']) {
+    $oSetup->connect();
+    // Try accessing the C module, so we know early if something is wrong
+    checkModulePresence(); // raises exception on failure
+}
 
 if ($aCMDResult['setup-db'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->setupDB();
 }
 
-// Try accessing the C module, so we know early if something is wrong
-checkModulePresence(); // raises exception on failure
 
 if ($aCMDResult['import-data'] || $aCMDResult['all']) {
     $bDidSomething = true;

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -44,6 +44,7 @@ $aCMDOptions
    array('create-search-indices', '', 0, 1, 0, 0, 'bool', 'Create additional indices required for search and update'),
    array('create-country-names', '', 0, 1, 0, 0, 'bool', 'Create default list of searchable country names'),
    array('drop', '', 0, 1, 0, 0, 'bool', 'Drop tables needed for updates, making the database readonly (EXPERIMENTAL)'),
+   array('setup-website', '', 0, 1, 0, 0, 'bool', 'Used to compile environment variables for the website (EXPERIMENTAL)'),
   );
 
 // $aCMDOptions passed to getCmdOpt by reference
@@ -151,6 +152,11 @@ if ($aCMDResult['create-search-indices'] || $aCMDResult['all']) {
 if ($aCMDResult['create-country-names'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->createCountryNames($aCMDResult);
+}
+
+if ($aCMDResult['setup-website'] || $aCMDResult['all']) {
+    $bDidSomething = true;
+    $oSetup->setupWebsite();
 }
 
 // ******************************************************


### PR DESCRIPTION
For issue #946:

This is a replacement for PR [1802](https://github.com/osm-search/Nominatim/pull/1802) and acts as the first step in moving to dotenv files.

**Changes implemented:**
* `utils/setup.php --setup-website` now sets up build/settings/settings-frontend.php.
* settings-frontend.php is used by website/*.php files. The website will be usable only after executing the above step.

PS: `rOutputFile` is a resource type variable. Hence, the prefix. 

