### PR TITLE
Disable Postgresql jit and parallel processing for osm2pgsql updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,7 @@ script:
   - if [[ $TEST_SUITE == "monaco" ]]; then /usr/bin/env php ./utils/setup.php --osm-file ../data/monaco.osm.pbf --osm2pgsql-cache 1000 --all 2>&1 | grep -v 'ETA (seconds)'; fi
   - if [[ $TEST_SUITE == "monaco" ]]; then /usr/bin/env php ./utils/specialphrases.php --wiki-import | psql -d test_api_nominatim >/dev/null; fi
   - if [[ $TEST_SUITE == "monaco" ]]; then /usr/bin/env php ./utils/check_import_finished.php; fi
+  - if [[ $TEST_SUITE == "monaco" ]]; then /usr/bin/env php ./utils/update.php --init-updates; fi
+  - if [[ $TEST_SUITE == "monaco" ]]; then /usr/bin/env php ./utils/update.php --import-osmosis; fi
 notifications:
   email: false

--- a/utils/update.php
+++ b/utils/update.php
@@ -92,8 +92,10 @@ if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {
     $oOsm2pgsqlCmd->addParams('--flat-nodes', CONST_Osm2pgsql_Flatnode_File);
 }
 if ($fPostgresVersion >= 11.0) {
-    $oOsm2pgsqlCmd->addEnvPair('PGOPTIONS',
-                               '-c jit=off -c max_parallel_workers_per_gather=0');
+    $oOsm2pgsqlCmd->addEnvPair(
+        'PGOPTIONS',
+        '-c jit=off -c max_parallel_workers_per_gather=0'
+    );
 }
 
 

--- a/utils/update.php
+++ b/utils/update.php
@@ -55,6 +55,7 @@ date_default_timezone_set('Etc/UTC');
 
 $oDB = new Nominatim\DB();
 $oDB->connect();
+$fPostgresVersion = $oDB->getPostgresVersion();
 
 $aDSNInfo = Nominatim\DB::parseDSN(CONST_Database_DSN);
 if (!isset($aDSNInfo['port']) || !$aDSNInfo['port']) $aDSNInfo['port'] = 5432;
@@ -89,6 +90,10 @@ if (isset($aDSNInfo['password']) && $aDSNInfo['password']) {
 }
 if (!is_null(CONST_Osm2pgsql_Flatnode_File) && CONST_Osm2pgsql_Flatnode_File) {
     $oOsm2pgsqlCmd->addParams('--flat-nodes', CONST_Osm2pgsql_Flatnode_File);
+}
+if ($fPostgresVersion >= 11.0) {
+    $oOsm2pgsqlCmd->addEnvPair('PGOPTIONS',
+                               '-c jit=off -c max_parallel_workers_per_gather=0');
 }
 
 

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -20,7 +20,7 @@ sudo apt-get install -y -qq libboost-dev libboost-system-dev \
 
 sudo apt-get install -y -qq python3-dev python3-pip php-cgi
 
-pip3 install --quiet behave nose pytidylib psycopg2-binary
+pip3 install --quiet behave nose pytidylib psycopg2-binary osmium
 
 # https://github.com/squizlabs/PHP_CodeSniffer
 composer global require "squizlabs/php_codesniffer=*"

--- a/vagrant/install-on-travis-ci.sh
+++ b/vagrant/install-on-travis-ci.sh
@@ -64,5 +64,6 @@ tee settings/local.php << EOF
  @define('CONST_Website_BaseURL', '/nominatim/');
  @define('CONST_Database_DSN', 'pgsql:dbname=test_api_nominatim');
  @define('CONST_Wikipedia_Data_Path', CONST_BasePath.'/test/testdb');
+ @define('CONST_Replication_Max_Diff_size', '3');
 EOF
 


### PR DESCRIPTION
The new functions are known to cause issues with updates, see https://github.com/openstreetmap/osm2pgsql/issues/1045.

This PR also adds a simple update run to Travis, so that we have that covered as well.