### PR TITLE
exclude language-specific name:prefix and name:suffix

### DIFF
--- a/settings/import-address.style
+++ b/settings/import-address.style
@@ -6,7 +6,8 @@
     }
 },
 {
-    "keys" : ["name:prefix", "name:suffix", "name:botanical", "*wikidata"],
+    "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
+              "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }

--- a/settings/import-admin.style
+++ b/settings/import-admin.style
@@ -1,6 +1,7 @@
 [
 {
-    "keys" : ["name:prefix", "name:suffix", "name:botanical", "*wikidata"],
+    "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
+              "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }

--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -6,8 +6,8 @@
     }
 },
 {
-    "keys" : ["name:prefix", "name:suffix", "name:botanical", "wikidata",
-              "*:wikidata"],
+    "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
+              "name:botanical", "wikidata", "*:wikidata"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -6,8 +6,8 @@
     }
 },
 {
-    "keys" : ["name:prefix", "name:suffix", "name:botanical", "wikidata",
-              "*:wikidata"],
+    "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
+              "name:botanical", "wikidata", "*:wikidata"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-street.style
+++ b/settings/import-street.style
@@ -1,6 +1,7 @@
 [
 {
-    "keys" : ["name:prefix", "name:suffix", "name:botanical", "*wikidata"],
+    "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
+              "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }


### PR DESCRIPTION
There are about 1k suffixes and 20k prefixes with a
language-speicfic variant in use. These should not
show up as names.