### PR TITLE
reverse: ignore place nodes without an address rank

### DIFF
--- a/lib/ReverseGeocode.php
+++ b/lib/ReverseGeocode.php
@@ -193,6 +193,7 @@ class ReverseGeocode
                 // for place nodes at rank_address 16
                 $sSQL .= ' AND rank_search > '.$iRankSearch;
                 $sSQL .= ' AND rank_search <= '.$iMaxRank;
+                $sSQL .= ' AND rank_address > 0';
                 $sSQL .= ' AND class = \'place\'';
                 $sSQL .= ' AND type != \'postcode\'';
                 $sSQL .= ' AND name IS NOT NULL ';


### PR DESCRIPTION
We already exclude all polygon places without an address
rank. place nodes should also be ignored. This removes
places like locality from the reverse results.

Fixes #1839.