### PR TITLE
Reenable debug parameter

### DIFF
--- a/cmake/website.tmpl
+++ b/cmake/website.tmpl
@@ -1,3 +1,5 @@
 <?php
+@define('CONST_Debug', (isset($_GET['debug']) && $_GET['debug']));
 require_once(dirname(dirname(__FILE__)).'/website/settings-frontend.php');
+
 require_once(CONST_BasePath.'/@script_source@');

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -708,7 +708,7 @@ class SetupFunctions
 if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
 
 @define('CONST_Database_DSN', '".CONST_Database_DSN."'); // or add ;host=...;port=...;user=...;password=...
-@define('CONST_Default_Language', ".(CONST_Default_Language ? 'true' : 'false').");
+@define('CONST_Default_Language', ".(CONST_Default_Language ? ("'".CONST_Default_Language."'") : 'false').");
 @define('CONST_Default_Lat', ".CONST_Default_Lat.");
 @define('CONST_Default_Lon', ".CONST_Default_Lon.");
 @define('CONST_Default_Zoom', ".CONST_Default_Zoom.");

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -707,7 +707,6 @@ class SetupFunctions
 @define('CONST_BasePath', '".CONST_BasePath."');
 if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
 
-@define('CONST_Debug', ". (CONST_Debug? 'true' : 'false').");
 @define('CONST_Database_DSN', '".CONST_Database_DSN."'); // or add ;host=...;port=...;user=...;password=...
 @define('CONST_Default_Language', ".(CONST_Default_Language ? 'true' : 'false').");
 @define('CONST_Default_Lat', ".CONST_Default_Lat.");

--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -3,10 +3,8 @@
 @define('CONST_InstallPath', '@CMAKE_BINARY_DIR@');
 if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));
 if (file_exists(CONST_InstallPath.'/settings/local.php')) require_once(CONST_InstallPath.'/settings/local.php');
-if (isset($_GET['debug']) && $_GET['debug']) @define('CONST_Debug', true);
 
 // General settings
-@define('CONST_Debug', false);
 @define('CONST_Database_DSN', 'pgsql:dbname=nominatim'); // or add ;host=...;port=...;user=...;password=...
 @define('CONST_Database_Web_User', 'www-data');
 @define('CONST_Database_Module_Path', CONST_InstallPath.'/module');


### PR DESCRIPTION
The parameter got lost when switching to website settings.
Given that the use of a fixed parameter is limited,
debugging output can now only be set via the URL parameter.

Also changes generation of `CONST_DefaultLanguage` which is a string when not set to false