### PR TITLE
Small fixes for new webserver settings file

### DIFF
--- a/cmake/website.tmpl
+++ b/cmake/website.tmpl
@@ -1,5 +1,5 @@
 <?php
 @define('CONST_Debug', (isset($_GET['debug']) && $_GET['debug']));
-require_once(dirname(dirname(__FILE__)).'/website/settings-frontend.php');
+require_once(dirname(dirname(__FILE__)).'/settings/settings-frontend.php');
 
 require_once(CONST_BasePath.'/@script_source@');

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -701,7 +701,7 @@ class SetupFunctions
      */
     public function setupWebsite()
     {
-        $rOutputFile = fopen(CONST_InstallPath.'/website/settings-frontend.php', 'w');
+        $rOutputFile = fopen(CONST_InstallPath.'/settings/settings-frontend.php', 'w');
 
         fwrite($rOutputFile, "<?php
 @define('CONST_BasePath', '".CONST_BasePath."');

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -715,7 +715,7 @@ if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SE
 @define('CONST_Map_Tile_URL', '".CONST_Map_Tile_URL."');
 @define('CONST_Map_Tile_Attribution', '".CONST_Map_Tile_Attribution."'); // Set if tile source isn't osm.org
 @define('CONST_Log_DB', ".(CONST_Log_DB ? 'true' : 'false').");
-@define('CONST_Log_File', ".(CONST_Log_File ? 'true' : 'false').");
+@define('CONST_Log_File', ".(CONST_Log_File ? ("'".CONST_Log_File."'")  : 'false').");
 @define('CONST_Max_Word_Frequency', '".CONST_Max_Word_Frequency."');
 @define('CONST_NoAccessControl', ".CONST_NoAccessControl.");
 @define('CONST_Places_Max_ID_count', ".CONST_Places_Max_ID_count.");


### PR DESCRIPTION
* CONST_Log_File is a string when it is set
* move the settings-frontend.php back to `settings/` to reduce the chance that it becomes accidentally world-readable when the webserver is badly configured