### PR TITLE
Add wiki tags to all styles

### DIFF
--- a/settings/import-address.style
+++ b/settings/import-address.style
@@ -5,6 +5,11 @@
         "no" : "skip"
     }
 },
+{   "keys" : ["wikipedia", "wikipedia:*", "wikidata"],
+    "values" : {
+        "" : "extra"
+    }
+},
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
               "name:botanical", "*wikidata"],

--- a/settings/import-admin.style
+++ b/settings/import-admin.style
@@ -1,4 +1,9 @@
 [
+{   "keys" : ["wikipedia", "wikipedia:*", "wikidata"],
+    "values" : {
+        "" : "extra"
+    }
+},
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
               "name:botanical", "*wikidata"],

--- a/settings/import-street.style
+++ b/settings/import-street.style
@@ -1,4 +1,9 @@
 [
+{   "keys" : ["wikipedia", "wikipedia:*", "wikidata"],
+    "values" : {
+        "" : "extra"
+    }
+},
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
               "name:botanical", "*wikidata"],


### PR DESCRIPTION
wikipedia and wikidata tags are needed to compute the importance
so we need to put them into extra tags for all styles.

Fixes #1885.