### PR TITLE
Implicitly connect to database during setup

### DIFF
--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -6,7 +6,7 @@ Feature: Address computation
     Scenario: Roads crossing boundaries should contain both states
         Given the grid
             | 1 |   |   | 2 |   | 3 |
-            |   | 7 |   | 8 |   |   |
+            |   | 7 |   |   | 8 |   |
             | 4 |   |   | 5 |   | 6 |
         And the named places
             | osm | class   | type | geometry |

--- a/utils/setup.php
+++ b/utils/setup.php
@@ -77,17 +77,10 @@ if ($aCMDResult['create-db'] || $aCMDResult['all']) {
     $oSetup->createDB();
 }
 
-if (!$aCMDResult['setup-website']) {
-    $oSetup->connect();
-    // Try accessing the C module, so we know early if something is wrong
-    checkModulePresence(); // raises exception on failure
-}
-
 if ($aCMDResult['setup-db'] || $aCMDResult['all']) {
     $bDidSomething = true;
     $oSetup->setupDB();
 }
-
 
 if ($aCMDResult['import-data'] || $aCMDResult['all']) {
     $bDidSomething = true;

--- a/utils/update.php
+++ b/utils/update.php
@@ -151,7 +151,6 @@ if ($aResult['init-updates']) {
                                       'enable-diff-updates' => true,
                                       'verbose' => $aResult['verbose']
                                      ));
-        $cSetup->connect();
         $cSetup->createFunctions();
     }
 


### PR DESCRIPTION
Make access to the DB object a function, so that the connection
can be opened implicitly when the object is accessed for the first
time. This way we no longer need to check beforehand if a specific
function of the setup needs DB access or not.

Also move the check for the module to the relevant sub step.