### PR TITLE
make house number reappear in display name on named POIs

### DIFF
--- a/sql/functions/address_lookup.sql
+++ b/sql/functions/address_lookup.sql
@@ -272,7 +272,7 @@ BEGIN
   END IF;
 
   IF searchhousenumber IS NOT NULL THEN
-    location := ROW(in_place_id, null, null, hstore('ref', searchhousenumber),
+    location := ROW(null, null, null, hstore('ref', searchhousenumber),
                     'place', 'house_number', null, null, true, true, 28, 0)::addressline;
     RETURN NEXT location;
   END IF;


### PR DESCRIPTION
After 6cc6cf950c3c08103e6159a079c85b5a4f1c09fa names and house numbers of POIS got mingled into a single item when creating the display name. Add the house number as extra information without place_id to avoid later mangling.