### PR TITLE
Make SQL debug statements execute again

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -31,7 +31,6 @@ BEGIN
     LOOP
       FOR i IN 1..array_upper(location.members, 1) BY 2 LOOP
         IF location.members[i+1] = 'street' THEN
-          --DEBUG: RAISE WARNING 'node in relation %',relation;
           FOR parent IN
             SELECT place_id from placex
              WHERE osm_type = 'W' and osm_id = substring(location.members[i],2)::bigint
@@ -707,7 +706,6 @@ BEGIN
         NEW.housenumber := location.address->'housenumber';
         addr_street := location.address->'street';
         addr_place := location.address->'place';
-        --DEBUG: RAISE WARNING 'Found surrounding building % %', location.osm_type, location.osm_id;
       END LOOP;
     END IF;
 

--- a/sql/functions/utils.sql
+++ b/sql/functions/utils.sql
@@ -237,7 +237,7 @@ BEGIN
     IF word_ids is not null THEN
       parent_place_id := getNearestNamedRoadPlaceId(partition, centroid, word_ids);
       IF parent_place_id is not null THEN
-        --DEBUG: RAISE WARNING 'Get parent form addr:street: %', parent.place_id;
+        --DEBUG: RAISE WARNING 'Get parent form addr:street: %', parent_place_id;
         RETURN parent_place_id;
       END IF;
     END IF;
@@ -249,7 +249,7 @@ BEGIN
     IF word_ids is not null THEN
       parent_place_id := getNearestNamedPlacePlaceId(partition, centroid, word_ids);
       IF parent_place_id is not null THEN
-        --DEBUG: RAISE WARNING 'Get parent form addr:place: %', parent.place_id;
+        --DEBUG: RAISE WARNING 'Get parent form addr:place: %', parent_place_id;
         RETURN parent_place_id;
       END IF;
     END IF;
@@ -322,7 +322,7 @@ BEGIN
 
   ELSEIF ST_GeometryType(geometry) = 'ST_Point' THEN
     radius := near_feature_rank_distance(rank_search);
-    --DEBUG: RAISE WARNING 'adding % diameter %', place_id, diameter;
+    --DEBUG: RAISE WARNING 'adding % radius %', place_id, radius;
 
     -- Create a bounding box with an extent computed from the radius (in meters).
     secgeo := ST_Envelope(ST_Collect(


### PR DESCRIPTION
There were some old variable names used that are no longer valid. Either fix them or remove the statement completely.

Fixes #1907.