### PR TITLE
Remove linked_place from extratags when updating

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -574,6 +574,8 @@ BEGIN
          where linked_place_id = NEW.place_id;
   -- update not necessary for osmline, cause linked_place_id does not exist
 
+  NEW.extratags := NEW.extratags - 'linked_place'::TEXT;
+
   IF NEW.linked_place_id is not null THEN
     --DEBUG: RAISE WARNING 'place already linked to %', NEW.linked_place_id;
     RETURN NEW;
@@ -925,10 +927,14 @@ DECLARE
 BEGIN
   -- RAISE WARNING 'placex_delete % %',OLD.osm_type,OLD.osm_id;
 
-  update placex set linked_place_id = null, indexed_status = 2 where linked_place_id = OLD.place_id and indexed_status = 0;
-  --DEBUG: RAISE WARNING 'placex_delete:01 % %',OLD.osm_type,OLD.osm_id;
-  update placex set linked_place_id = null where linked_place_id = OLD.place_id;
-  --DEBUG: RAISE WARNING 'placex_delete:02 % %',OLD.osm_type,OLD.osm_id;
+  IF OLD.linked_place_id is null THEN
+    update placex set linked_place_id = null, indexed_status = 2 where linked_place_id = OLD.place_id and indexed_status = 0;
+    --DEBUG: RAISE WARNING 'placex_delete:01 % %',OLD.osm_type,OLD.osm_id;
+    update placex set linked_place_id = null where linked_place_id = OLD.place_id;
+    --DEBUG: RAISE WARNING 'placex_delete:02 % %',OLD.osm_type,OLD.osm_id;
+  ELSE
+    update placex set indexed_status = 2 where place_id = OLD.linked_place_id and indexed_status = 0;
+  END IF;
 
   IF OLD.rank_address < 30 THEN
 

--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -133,3 +133,36 @@ Feature: Updates of linked places
          | object | extratags |
          | R1     | 'wikidata' : '34', 'oneway' : 'yes', 'linked_place' : 'city' |
 
+    Scenario: Remove linked_place info when linkee is removed
+        Given the places
+            | osm | class | type | name | geometry |
+            | N1  | place | city | foo  | 0 0 |
+        And the places
+            | osm | class    | type           | name | admin | geometry |
+            | R1  | boundary | administrative | foo  | 8     | poly-area:0.1 |
+        When importing
+        Then placex contains
+            | object | extratags |
+            | R1     | 'linked_place' : 'city' |
+        When marking for delete N1
+        Then placex contains
+            | object | extratags |
+            | R1     |  |
+
+    Scenario: Update linked_place info when linkee type changes
+        Given the places
+            | osm | class | type | name | geometry |
+            | N1  | place | city | foo  | 0 0 |
+        And the places
+            | osm | class    | type           | name | admin | geometry |
+            | R1  | boundary | administrative | foo  | 8     | poly-area:0.1 |
+        When importing
+        Then placex contains
+            | object | extratags |
+            | R1     | 'linked_place' : 'city' |
+        When updating places
+            | osm | class | type | name | geometry |
+            | N1  | place | town | foo  | 0 0 |
+        Then placex contains
+            | object | extratags |
+            | R1     | 'linked_place' : 'town' |


### PR DESCRIPTION
Before updating an admin boundary we need to make sure that any artificially generated 'linked_place' entry is removed from the extratags column. This ensures that the place designation does not linger when a linked place disappears and that it is updated when the linking changes.