### PR TITLE
Rework indexing order of places

### DIFF
--- a/docs/admin/Migration.md
+++ b/docs/admin/Migration.md
@@ -8,6 +8,23 @@ SQL statements should be executed from the PostgreSQL commandline. Execute
 
 ## 3.5.0 -> master
 
+### Change order during indexing
+
+When reindexing places during updates, there is now a different order used
+which needs a different database index. Create it with the following SQL command:
+
+```sql
+CREATE INDEX idx_placex_pendingsector_rank_address
+  ON placex USING BTREE (rank_address, geometry_sector) where indexed_status > 0;
+```
+
+You can then drop the old index with:
+
+```sql
+DROP INDEX idx_placex_pendingsector
+```
+
+
 ### Switching to dotenv
 
 As part of the work changing the configuration format, the configuration for

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -566,12 +566,19 @@ class SetupFunctions
         info('Index ranks 0 - 4');
         $oCmd = (clone $oBaseCmd)->addParams('--maxrank', 4);
         echo $oCmd->escapedCmd();
-        
+
         $iStatus = $oCmd->run();
         if ($iStatus != 0) {
             fail('error status ' . $iStatus . ' running nominatim!');
         }
         if (!$bIndexNoanalyse) $this->pgsqlRunScript('ANALYSE');
+
+        info('Index administrative boundaries');
+        $oCmd = (clone $oBaseCmd)->addParams('-b');
+        $iStatus = $oCmd->run();
+        if ($iStatus != 0) {
+            fail('error status ' . $iStatus . ' running nominatim!');
+        }
 
         info('Index ranks 5 - 25');
         $oCmd = (clone $oBaseCmd)->addParams('--minrank', 5, '--maxrank', 25);
@@ -579,6 +586,7 @@ class SetupFunctions
         if ($iStatus != 0) {
             fail('error status ' . $iStatus . ' running nominatim!');
         }
+
         if (!$bIndexNoanalyse) $this->pgsqlRunScript('ANALYSE');
 
         info('Index ranks 26 - 30');

--- a/nominatim/indexer/db.py
+++ b/nominatim/indexer/db.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This file is part of Nominatim.
+# Copyright (C) 2020 Sarah Hoffmann
+
+import logging
+import psycopg2
+from psycopg2.extras import wait_select
+
+log = logging.getLogger()
+
+def make_connection(options, asynchronous=False):
+    params = {'dbname' : options.dbname,
+              'user' : options.user,
+              'password' : options.password,
+              'host' : options.host,
+              'port' : options.port,
+              'async' : asynchronous}
+
+    return psycopg2.connect(**params)
+
+class DBConnection(object):
+    """ A single non-blocking database connection.
+    """
+
+    def __init__(self, options):
+        self.current_query = None
+        self.current_params = None
+        self.options = options
+
+        self.conn = None
+        self.connect()
+
+    def connect(self):
+        """ (Re)connect to the database. Creates an asynchronous connection
+            with JIT and parallel processing disabled. If a connection was
+            already open, it is closed and a new connection established.
+            The caller must ensure that no query is pending before reconnecting.
+        """
+        if self.conn is not None:
+            self.cursor.close()
+            self.conn.close()
+
+        self.conn = make_connection(self.options, asynchronous=True)
+        self.wait()
+
+        self.cursor = self.conn.cursor()
+        # Disable JIT and parallel workers as they are known to cause problems.
+        # Update pg_settings instead of using SET because it does not yield
+        # errors on older versions of Postgres where the settings are not
+        # implemented.
+        self.perform(
+            """ UPDATE pg_settings SET setting = -1 WHERE name = 'jit_above_cost';
+                UPDATE pg_settings SET setting = 0 
+                   WHERE name = 'max_parallel_workers_per_gather';""")
+        self.wait()
+
+    def wait(self):
+        """ Block until any pending operation is done.
+        """
+        while True:
+            try:
+                wait_select(self.conn)
+                self.current_query = None
+                return
+            except psycopg2.extensions.TransactionRollbackError as e:
+                if e.pgcode == '40P01':
+                    log.info("Deadlock detected (params = {}), retry."
+                              .format(self.current_params))
+                    self.cursor.execute(self.current_query, self.current_params)
+                else:
+                    raise
+            except psycopg2.errors.DeadlockDetected:
+                self.cursor.execute(self.current_query, self.current_params)
+
+    def perform(self, sql, args=None):
+        """ Send SQL query to the server. Returns immediately without
+            blocking.
+        """
+        self.current_query = sql
+        self.current_params = args
+        self.cursor.execute(sql, args)
+
+    def fileno(self):
+        """ File descriptor to wait for. (Makes this class select()able.)
+        """
+        return self.conn.fileno()
+
+    def is_done(self):
+        """ Check if the connection is available for a new query.
+
+            Also checks if the previous query has run into a deadlock.
+            If so, then the previous query is repeated.
+        """
+        if self.current_query is None:
+            return True
+
+        try:
+            if self.conn.poll() == psycopg2.extensions.POLL_OK:
+                self.current_query = None
+                return True
+        except psycopg2.extensions.TransactionRollbackError as e:
+            if e.pgcode == '40P01':
+                log.info("Deadlock detected (params = {}), retry.".format(self.current_params))
+                self.cursor.execute(self.current_query, self.current_params)
+            else:
+                raise
+        except psycopg2.errors.DeadlockDetected:
+            self.cursor.execute(self.current_query, self.current_params)
+
+        return False
+

--- a/nominatim/nominatim.py
+++ b/nominatim/nominatim.py
@@ -28,24 +28,12 @@ import sys
 import re
 import getpass
 from datetime import datetime
-import psycopg2
-from psycopg2.extras import wait_select
 import select
 
 from indexer.progress import ProgressLogger
+from indexer.db import DBConnection, make_connection
 
 log = logging.getLogger()
-
-def make_connection(options, asynchronous=False):
-    params = {'dbname' : options.dbname,
-              'user' : options.user,
-              'password' : options.password,
-              'host' : options.host,
-              'port' : options.port,
-              'async' : asynchronous}
-
-    return psycopg2.connect(**params)
-
 
 class RankRunner(object):
     """ Returns SQL commands for indexing one rank within the placex table.
@@ -93,92 +81,6 @@ class InterpolationRunner(object):
         return """UPDATE location_property_osmline
                   SET indexed_status = 0 WHERE place_id IN ({})"""\
                .format(','.join((str(i) for i in ids)))
-
-
-class DBConnection(object):
-    """ A single non-blocking database connection.
-    """
-
-    def __init__(self, options):
-        self.current_query = None
-        self.current_params = None
-
-        self.conn = None
-        self.connect()
-
-    def connect(self):
-        if self.conn is not None:
-            self.cursor.close()
-            self.conn.close()
-
-        self.conn = make_connection(options, asynchronous=True)
-        self.wait()
-
-        self.cursor = self.conn.cursor()
-        # Disable JIT and parallel workers as they are known to cause problems.
-        # Update pg_settings instead of using SET because it does not yield
-        # errors on older versions of Postgres where the settings are not
-        # implemented.
-        self.perform(
-            """ UPDATE pg_settings SET setting = -1 WHERE name = 'jit_above_cost';
-                UPDATE pg_settings SET setting = 0 
-                   WHERE name = 'max_parallel_workers_per_gather';""")
-        self.wait()
-
-    def wait(self):
-        """ Block until any pending operation is done.
-        """
-        while True:
-            try:
-                wait_select(self.conn)
-                self.current_query = None
-                return
-            except psycopg2.extensions.TransactionRollbackError as e:
-                if e.pgcode == '40P01':
-                    log.info("Deadlock detected (params = {}), retry."
-                              .format(self.current_params))
-                    self.cursor.execute(self.current_query, self.current_params)
-                else:
-                    raise
-            except psycopg2.errors.DeadlockDetected:
-                self.cursor.execute(self.current_query, self.current_params)
-
-    def perform(self, sql, args=None):
-        """ Send SQL query to the server. Returns immediately without
-            blocking.
-        """
-        self.current_query = sql
-        self.current_params = args
-        self.cursor.execute(sql, args)
-
-    def fileno(self):
-        """ File descriptor to wait for. (Makes this class select()able.)
-        """
-        return self.conn.fileno()
-
-    def is_done(self):
-        """ Check if the connection is available for a new query.
-
-            Also checks if the previous query has run into a deadlock.
-            If so, then the previous query is repeated.
-        """
-        if self.current_query is None:
-            return True
-
-        try:
-            if self.conn.poll() == psycopg2.extensions.POLL_OK:
-                self.current_query = None
-                return True
-        except psycopg2.extensions.TransactionRollbackError as e:
-            if e.pgcode == '40P01':
-                log.info("Deadlock detected (params = {}), retry.".format(self.current_params))
-                self.cursor.execute(self.current_query, self.current_params)
-            else:
-                raise
-        except psycopg2.errors.DeadlockDetected:
-            self.cursor.execute(self.current_query, self.current_params)
-
-        return False
 
 
 class Indexer(object):

--- a/sql/functions/normalization.sql
+++ b/sql/functions/normalization.sql
@@ -207,16 +207,22 @@ CREATE OR REPLACE FUNCTION addr_ids_from_name(lookup_word TEXT)
   AS $$
 DECLARE
   lookup_token TEXT;
+  id INTEGER;
   return_word_id INTEGER[];
 BEGIN
   lookup_token := make_standard_name(lookup_word);
   SELECT array_agg(word_id) FROM word
     WHERE word_token = lookup_token and class is null and type is null
     INTO return_word_id;
+  IF return_word_id IS NULL THEN
+    id := nextval('seq_word');
+    INSERT INTO word VALUES (id, lookup_token, null, null, null, null, 0);
+    return_word_id = ARRAY[id];
+  END IF;
   RETURN return_word_id;
 END;
 $$
-LANGUAGE plpgsql STABLE;
+LANGUAGE plpgsql;
 
 
 -- Normalize a string and look up its name ids (full words).

--- a/sql/indices_updates.src.sql
+++ b/sql/indices_updates.src.sql
@@ -1,7 +1,7 @@
 -- Indices used only during search and update.
 -- These indices are created only after the indexing process is done.
 
-CREATE INDEX CONCURRENTLY idx_placex_pendingsector ON placex USING BTREE (rank_search,geometry_sector) {ts:address-index} where indexed_status > 0;
+CREATE INDEX CONCURRENTLY idx_placex_pendingsector ON placex USING BTREE (rank_address,geometry_sector) {ts:address-index} where indexed_status > 0;
 
 CREATE INDEX CONCURRENTLY idx_location_area_country_place_id ON location_area_country USING BTREE (place_id) {ts:address-index};
 

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -39,13 +39,13 @@ Feature: Creation of search terms
          | object | nameaddress_vector |
          | W1     | bonn, new york, smalltown |
 
-    Scenario: A known addr:* tag is not added if the name is unknown
+    Scenario: A known addr:* tag is added even if the name is unknown
         Given the scene roads-with-pois
         And the places
          | osm | class   | type        | name | addr+city | geometry |
          | W1  | highway | residential | Road | Nandu     | :w-north |
         When importing
-        Then search_name contains not
+        Then search_name contains
          | object | nameaddress_vector |
          | W1     | nandu |
 

--- a/utils/update.php
+++ b/utils/update.php
@@ -278,9 +278,11 @@ if ($aResult['recompute-word-counts']) {
 
 if ($aResult['index']) {
     $oCmd = (clone $oIndexCmd)
-            ->addParams('--minrank', $aResult['index-rank']);
+            ->addParams('--minrank', $aResult['index-rank'], '-b');
+    $oCmd->run();
 
-    // echo $oCmd->escapedCmd()."\n";
+    $oCmd = (clone $oIndexCmd)
+            ->addParams('--minrank', $aResult['index-rank']);
     $oCmd->run();
 
     $oDB->exec('update import_status set indexed = true');
@@ -421,9 +423,18 @@ if ($aResult['import-osmosis'] || $aResult['import-osmosis-all']) {
 
         // Index file
         if (!$aResult['no-index']) {
-            $oThisIndexCmd = clone($oIndexCmd);
             $fCMDStartTime = time();
 
+            $oThisIndexCmd = clone($oIndexCmd);
+            $oThisIndexCmd->addParams('-b');
+            echo $oThisIndexCmd->escapedCmd()."\n";
+            $iErrorLevel = $oThisIndexCmd->run();
+            if ($iErrorLevel) {
+                echo "Error: $iErrorLevel\n";
+                exit($iErrorLevel);
+            }
+
+            $oThisIndexCmd = clone($oIndexCmd);
             echo $oThisIndexCmd->escapedCmd()."\n";
             $iErrorLevel = $oThisIndexCmd->run();
             if ($iErrorLevel) {


### PR DESCRIPTION
With the new system of dynamically assigned address rank, the simple indexing order by search rank is not workable anymore because it leads to anomalies when assigning address objects. This PR changes the order to the following:

1. countries and super-national structures
2. admin boundaries according to search rank
3. places that can be an address item according to address rank
4. streets
5. places that cannot be an address item
6. address interpolations
7. POIs and house numbers

The order ensures that all places needed for the address formation are indexed in the correct order.