### PR TITLE
Increase splitting for large geometries

### DIFF
--- a/sql/functions/utils.sql
+++ b/sql/functions/utils.sql
@@ -429,7 +429,7 @@ DECLARE
   geo RECORD;
 BEGIN
   -- 10000000000 is ~~ 1x1 degree
-  FOR geo IN select quad_split_geometry(geometry, 0.25, 20) as geom LOOP
+  FOR geo IN select quad_split_geometry(geometry, 0.01, 20) as geom LOOP
     RETURN NEXT geo.geom;
   END LOOP;
   RETURN;


### PR DESCRIPTION
When computing the address parts for a geometry, we need to do a ST_Relates lookup in the location_area_large_* tables. This is potentially very expensive for geometries with many vertices. There is already a function for splitting large areas to reduce the  impact. This commit reduces the minimum area of a split, effectively increasing the number of splits.

The effect on database size is minimal (around 3% increase), while the indexing speed for streets increases by a good 60%. On my machine if reduces indexing for level 26 from 20 to 12 hours.