### PR TITLE
Add support for place=square

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -26,6 +26,7 @@
           "isolated_dwelling" : [22, 20],
           "city_block" : 22,
           "mountain_pass" : [20, 0],
+          "square" : 25,
           "houses" : [28, 0],
           "farm" : [20, 0],
           "locality" : [20, 0]

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -160,7 +160,7 @@ BEGIN
       FROM search_name_-partition-
       WHERE name_vector && isin_token
             AND centroid && ST_Expand(point, 0.04)
-            AND search_rank between 16 and 22
+            AND search_rank between 16 and 25
       ORDER BY ST_Distance(centroid, point) ASC limit 1;
     RETURN parent;
   END IF;

--- a/test/bdd/db/import/parenting.feature
+++ b/test/bdd/db/import/parenting.feature
@@ -460,3 +460,23 @@ Feature: Parenting of objects
         Then placex contains
           | object | parent_place_id |
           | N10    | W1 |
+
+     Scenario: place=square may be parented via addr:place
+        Given the grid
+            |   |   | 9 |   |   |
+            |   | 5 |   | 6 |   |
+            |   | 8 |   | 7 |   |
+        And the places
+            | osm | class    | type    | name+name | geometry        |
+            | W2  | place    | square  | Foo pl    | (5, 6, 7, 8, 5) |
+        And the places
+            | osm | class    | type    | name+name | housenr | addr_place | geometry |
+            | N10 | shop     | grocery | le shop   | 5       | Foo pl     | 9        |
+        When importing
+        Then placex contains
+            | object | rank_address |
+            | W2     | 25           |
+        Then placex contains
+            | object | parent_place_id |
+            | N10    | W2              |
+


### PR DESCRIPTION
Squares are now addressable (on address level 25) and thus can be attached to a house number via addr:place. Needed to increase the rank range for matching up addr:place to 25.

Fixes #1517.