### PR TITLE
Reranking of results must be stable

### DIFF
--- a/lib/PlaceLookup.php
+++ b/lib/PlaceLookup.php
@@ -452,11 +452,13 @@ class PlaceLookup
                 $aPlace,
                 $aPlace['country_code']
             );
+
+            $aResults[$aPlace['place_id']] = $aPlace;
         }
 
-        Debug::printVar('Places', $aPlaces);
+        Debug::printVar('Places', $aResults);
 
-        return $aPlaces;
+        return $aResults;
     }
 
     /* returns an array which will contain the keys

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -55,7 +55,7 @@ function byImportance($a, $b)
     if ($a['importance'] != $b['importance'])
         return ($a['importance'] > $b['importance']?-1:1);
 
-    return ($a['foundorder'] < $b['foundorder']?-1:1);
+    return $a['foundorder'] <=> $b['foundorder'];
 }
 
 


### PR DESCRIPTION
The initial result candidates that are retrieved from the database are already preordered, either by importance or by distance. When reranking the results we must keep this order when all other things are equal.

This PR ensures that PlaceLookup()->lookup() returns the place information in the same order as it was requested and that ordering by importance is stable.

Fixes #1436.