### PR TITLE
Do not block deletion of large highway areas

### DIFF
--- a/sql/functions/place_triggers.sql
+++ b/sql/functions/place_triggers.sql
@@ -262,7 +262,7 @@ BEGIN
 
   -- deleting large polygons can have a massive effect on the system - require manual intervention to let them through
   IF st_area(OLD.geometry) > 2 and st_isvalid(OLD.geometry) THEN
-    SELECT bool_or(not (rank_address = 0 or rank_address > 26)) as ranked FROM placex WHERE osm_type = OLD.osm_type and osm_id = OLD.osm_id and class = OLD.class and type = OLD.type INTO has_rank;
+    SELECT bool_or(not (rank_address = 0 or rank_address > 25)) as ranked FROM placex WHERE osm_type = OLD.osm_type and osm_id = OLD.osm_id and class = OLD.class and type = OLD.type INTO has_rank;
     IF has_rank THEN
       insert into import_polygon_delete (osm_type, osm_id, class, type) values (OLD.osm_type,OLD.osm_id,OLD.class,OLD.type);
       RETURN NULL;

--- a/test/bdd/db/update/simple.feature
+++ b/test/bdd/db/update/simple.feature
@@ -31,14 +31,17 @@ Feature: Update of simple objects
           | osm | class    | type          | geometry |
           | W1  | place    | house         | poly-area:5.0 |
           | R1  | boundary | national_park | poly-area:5.0 |
+          | R2  | highway  | residential   | poly-area:5.0 |
         When importing
         Then placex contains
           | object | rank_address |
           | R1     | 30 |
+          | R2     | 26 |
           | W1     | 30 |
-        When marking for delete R1,W1
+        When marking for delete R1,R2,W1
         Then placex has no entry for W1
         Then placex has no entry for R1
+        Then placex has no entry for R2
 
     Scenario: type mutation
         Given the places


### PR DESCRIPTION
Deletion of areas should only e blocked for addressable features. Streets and POIs do not have a large impact on updates.

This fixes an issue where recently `highway` tags have been added to a number of large administrative boundaries. The issues were fixed quickly in OSM but the offending feature was not deleted in the Nominatim database. If you find such a large feature, note the place ID in your database and then delete it via the SQL command `SELECT place_force_delete(<place id>)`.