### PR TITLE
More fine tuning of default rank assignments

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -29,7 +29,9 @@
           "square" : 25,
           "houses" : [28, 0],
           "farm" : [20, 0],
-          "locality" : [20, 0]
+          "locality" : [20, 0],
+          "house" : 30,
+          "" : [22, 0]
       },
       "boundary" : {
           "administrative2" : 4,
@@ -42,7 +44,8 @@
           "administrative9" : 18,
           "administrative10" : 20,
           "administrative11" : 22,
-          "administrative12" : 24
+          "administrative12" : 24,
+          "" : [25, 0]
       },
       "landuse" : {
           "residential" : 22,
@@ -88,7 +91,7 @@
           "" : [20, 0]
       },
       "historic" : {
-          "neighbourhood" : [30, 0]
+          "neighbourhood" : [22, 0]
       }
   }
 },

--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -124,6 +124,7 @@
 {
     "keys" : ["boundary"],
     "values" : {
+        "place" : "skip",
         "" : "main,with_name"
     }
 },

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -124,6 +124,7 @@
 {
     "keys" : ["boundary"],
     "values" : {
+        "place" : "skip",
         "" : "main,with_name"
     }
 },

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -92,7 +92,7 @@ BEGIN
     END IF;
 
     IF fallback THEN
-      IF ST_Area(bbox) < 0.01 THEN
+      IF ST_Area(bbox) < 0.005 THEN
         -- for smaller features get the nearest road
         SELECT getNearestRoadPlaceId(poi_partition, bbox) INTO parent_place_id;
         --DEBUG: RAISE WARNING 'Checked for nearest way (%)', parent_place_id;

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -596,7 +596,9 @@ BEGIN
                             (NEW.extratags->'capital') = 'yes',
                             NEW.address->'postcode');
   -- We must always increase the address level relative to the admin boundary.
-  IF NEW.class = 'boundary' and NEW.type = 'administrative' and NEW.osm_type = 'R' THEN
+  IF NEW.class = 'boundary' and NEW.type = 'administrative'
+     and NEW.osm_type = 'R' and NEW.rank_address > 0
+  THEN
     parent_address_level := get_parent_address_level(NEW.centroid, NEW.admin_level);
     IF parent_address_level >= NEW.rank_address THEN
       IF parent_address_level >= 24 THEN

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -148,9 +148,9 @@ Feature: Import into placex
         And placex contains
           | object | rank_search | rank_address |
           | R20    | 4           | 4 |
-          | R21    | 30          | 30 |
-          | R22    | 30          | 30 |
-          | R23    | 30          | 30 |
+          | R21    | 25          | 0 |
+          | R22    | 25          | 0 |
+          | R23    | 25          | 0 |
           | R40    | 4           | 0 |
           | R41    | 8           | 0 |
 

--- a/test/bdd/db/import/rank_computation.feature
+++ b/test/bdd/db/import/rank_computation.feature
@@ -24,7 +24,7 @@ Feature: Rank assignment
         Then placex contains
           | object | rank_search | rank_address |
           | N1     | 30          | 30 |
-          | N11    | 30          | 30 |
+          | N11    | 22          | 0 |
           | N12    | 2           | 0 |
           | N13    | 2           | 0 |
           | N14    | 4           | 0 |
@@ -48,11 +48,11 @@ Feature: Rank assignment
         Then placex contains
           | object | rank_search | rank_address |
           | R20    | 4           | 4 |
-          | R21    | 30          | 30 |
+          | R21    | 25          | 0 |
           | R22    | 12          | 12 |
           | R23    | 20          | 20 |
 
-    Scenario: Ranks for boundaries with place assignment go with place address ranks if available
+    Scenario: Ranks for addressable boundaries with place assignment go with place address ranks if available
         Given the named places
           | osm | class    | type           | admin | extra+place | geometry |
           | R20 | boundary | administrative | 3     | state       | (1 1, 2 2, 1 2, 1 1) |
@@ -63,7 +63,7 @@ Feature: Rank assignment
         Then placex contains
           | object | rank_search | rank_address |
           | R20    | 6           | 6  |
-          | R21    | 30          | 20 |
+          | R21    | 25          | 0  |
           | R22    | 12          | 16 |
           | R23    | 20          | 16 |
 

--- a/test/bdd/db/update/simple.feature
+++ b/test/bdd/db/update/simple.feature
@@ -28,10 +28,10 @@ Feature: Update of simple objects
 
     Scenario: Do delete large features of low rank
         Given the named places
-          | osm | class    | type          | geometry |
-          | W1  | place    | house         | poly-area:5.0 |
-          | R1  | boundary | national_park | poly-area:5.0 |
-          | R2  | highway  | residential   | poly-area:5.0 |
+          | osm | class    | type        | geometry |
+          | W1  | place    | house       | poly-area:5.0 |
+          | R1  | natural  | wood        | poly-area:5.0 |
+          | R2  | highway  | residential | poly-area:5.0 |
         When importing
         Then placex contains
           | object | rank_address |
@@ -106,4 +106,4 @@ Feature: Update of simple objects
           | W1  | boundary | historic       | Haha | 5     | (1, 2, 4, 3, 1) |
         Then placex contains
           | object | rank_address |
-          | W1     | 30            |
+          | W1     | 0            |

--- a/test/bdd/steps/db_ops.py
+++ b/test/bdd/steps/db_ops.py
@@ -110,6 +110,9 @@ class PlaceObjName(object):
         if self.pid is None:
             return "<null>"
 
+        if self.pid == 0:
+            return "place ID 0"
+
         cur = self.conn.cursor()
         cur.execute("""SELECT osm_type, osm_id, class
                        FROM placex WHERE place_id = %s""",


### PR DESCRIPTION
Boundaries and places are now never assigned to POI level anymore and thus never won't have a street in their address. Also fiddle a bit with the definition of a large-area POI (also not bound to a street because of its size).