### PR TITLE
starting PHP 5.4 get_magic_quotes_gpc() returns false, no need to check

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -2,8 +2,3 @@
 
 require_once(CONST_BasePath.'/lib/lib.php');
 require_once(CONST_BasePath.'/lib/DB.php');
-
-if (get_magic_quotes_gpc()) {
-    echo "Please disable magic quotes in your php.ini configuration\n";
-    exit;
-}


### PR DESCRIPTION
PHP 7.4 starts printing deprecation warnings.

https://www.php.net/manual/en/function.get-magic-quotes-gpc.php says starting PHP 5.4 it always returned `false` anyway.