### PR TITLE
fix Install-on-Centos-8.sh

### DIFF
--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -39,7 +39,7 @@
     echo 'PATH=/usr/pgsql-12/bin:$PATH' >> ~/.bash_profile
     source ~/.bash_profile
 
-    pip3 install --user psycopg2 pytidylib
+    pip3 install --user psycopg2 pytidylib osmium
 
 
 #

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -165,6 +165,7 @@ fi                                 #DOCS:
     cd $USERHOME
     mkdir build
     cd build
+    export PostgreSQL_ROOT=/usr/pgsql-12/
     cmake $USERHOME/Nominatim
     make
 


### PR DESCRIPTION
* Installs `osmium` for `pyosmium-get-changes`
* Sets `PostgreSQL_ROOT` for `FindPostgreSQL.cmake` to find `PostgreSQL_INCLUDE_DIR`.