### PR TITLE
Make sure that all postcodes have an entry in the word table

### DIFF
--- a/sql/functions/normalization.sql
+++ b/sql/functions/normalization.sql
@@ -81,7 +81,8 @@ BEGIN
   lookup_word := upper(trim(postcode));
   lookup_token := ' ' || make_standard_name(lookup_word);
   SELECT min(word_id) FROM word
-    WHERE word_token = lookup_token and class='place' and type='postcode'
+    WHERE word_token = lookup_token and word = lookup_word
+          and class='place' and type='postcode'
     INTO return_word_id;
   IF return_word_id IS NULL THEN
     return_word_id := nextval('seq_word');

--- a/test/bdd/db/import/postcodes.feature
+++ b/test/bdd/db/import/postcodes.feature
@@ -137,3 +137,22 @@ Feature: Import of postcodes
         And word contains
            | word  | class | type |
            | 01982 | place | postcode |
+
+    Scenario: Different postcodes with the same normalization can both be found
+        Given the places
+           | osm | class | type  | addr+postcode | addr+housenumber | geometry |
+           | N34 | place | house | EH4 7EA       | 111              | country:gb |
+           | N35 | place | house | E4 7EA        | 111              | country:gb |
+        When importing
+        Then location_postcode contains exactly
+           | country | postcode | geometry |
+           | gb      | EH4 7EA  | country:gb |
+           | gb      | E4 7EA   | country:gb |
+        When searching for "EH4 7EA"
+        Then results contain
+           | type     | placename |
+           | postcode | EH4 7EA      |
+        When searching for "E4 7EA"
+        Then results contain
+           | type     | placename |
+           | postcode | E4 7EA      |


### PR DESCRIPTION
It may happen that two different postcodes normalize to exactly
the same token. In that case we still need two different entries
in the word table. Token lookup will then make sure that the correct
one is choosen.

Fixes #1953.