### PR TITLE
Use place type of for result object in address parts

### DIFF
--- a/sql/functions/address_lookup.sql
+++ b/sql/functions/address_lookup.sql
@@ -180,6 +180,7 @@ BEGIN
   -- Return the record for the base entry.
   FOR location IN
     SELECT placex.place_id, osm_type, osm_id, name,
+           coalesce(extratags->'linked_place', extratags->'place') as place_type,
            class, type, admin_level,
            type not in ('postcode', 'postal_code') as isaddress,
            CASE WHEN rank_address = 0 THEN 100
@@ -198,7 +199,8 @@ BEGIN
       searchcountrycode := NULL;
     END IF;
     countrylocation := ROW(location.place_id, location.osm_type, location.osm_id,
-                           location.name, location.class, location.type, NULL,
+                           location.name, location.class, location.type,
+                           location.place_type,
                            location.admin_level, true, location.isaddress,
                            location.rank_address, location.distance)::addressline;
     RETURN NEXT countrylocation;

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -182,3 +182,11 @@ Feature: Search queries
         Then results contain
           | class   | type |
           | highway | residential |
+
+
+    # github #1949
+    Scenario: Addressdetails always return the place type
+       When sending json search query "Rotherbaum" with address
+       Then result addresses contain
+         | ID | suburb |
+         | 0  | Rotherbaum |


### PR DESCRIPTION
Boundaries shound derive the address part type from the
linked place if possible. This was already implemented
for the address objects but not for the address information
from the address itself.

Fixes #1949.