### PR TITLE
Remove postcodes from search index

### DIFF
--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -18,6 +18,8 @@ function getLabelTag($aPlace, $sCountry = null)
         $sLabel = $aPlace['place_type'];
     } elseif ($aPlace['class'] == 'boundary' && $aPlace['type'] == 'administrative') {
         $sLabel = getBoundaryLabel($iRank/2, $sCountry);
+    } elseif ($aPlace['type'] == 'postal_code') {
+        $sLabel = 'postcode';
     } elseif ($iRank < 26) {
         $sLabel = $aPlace['type'];
     } elseif ($iRank < 28) {

--- a/settings/import-address.style
+++ b/settings/import-address.style
@@ -44,7 +44,8 @@
 {
     "keys" : ["boundary"],
     "values" : {
-        "administrative" : "main"
+        "administrative" : "main",
+        "postal_code" : "main"
     }
 },
 {

--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -125,6 +125,7 @@
     "keys" : ["boundary"],
     "values" : {
         "place" : "skip",
+        "postal_code" : "main",
         "" : "main,with_name"
     }
 },

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -125,6 +125,7 @@
     "keys" : ["boundary"],
     "values" : {
         "place" : "skip",
+        "postal_code" : "main",
         "" : "main,with_name"
     }
 },

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -581,6 +581,15 @@ BEGIN
     RETURN NEW;
   END IF;
 
+  -- Postcodes are just here to compute the centroids. They are not searchable
+  -- unless they are a boundary=postal_code.
+  -- There was an error in the style so that boundary=postal_code used to be
+  -- imported as place=postcode. That's why relations are allowed to pass here.
+  -- This can go away in a couple of versions.
+  IF NEW.class = 'place'  and NEW.type = 'postcode' and NEW.osm_type != 'R' THEN
+    RETURN NEW;
+  END IF;
+
   -- Speed up searches - just use the centroid of the feature
   -- cheaper but less acurate
   NEW.centroid := ST_PointOnSurface(NEW.geometry);

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -703,7 +703,7 @@ BEGIN
 
   -- ---------------------------------------------------------------------------
   -- For low level elements we inherit from our parent road
-  IF (NEW.rank_search > 27 OR (NEW.type = 'postcode' AND NEW.rank_search = 25)) THEN
+  IF NEW.rank_search > 27 THEN
 
     --DEBUG: RAISE WARNING 'finding street for % %', NEW.osm_type, NEW.osm_id;
     NEW.parent_place_id := null;
@@ -766,11 +766,6 @@ BEGIN
       -- Performance, it would be more acurate to do all the rest of the import
       -- process but it takes too long
       -- Just be happy with inheriting from parent road only
-      IF NEW.rank_search <= 25 and NEW.rank_address > 0 THEN
-        result := add_location(NEW.place_id, NEW.country_code, NEW.partition, name_vector, NEW.rank_search, NEW.rank_address, upper(trim(NEW.address->'postcode')), NEW.geometry);
-        --DEBUG: RAISE WARNING 'Place added to location table';
-      END IF;
-
       result := insertSearchName(NEW.partition, NEW.place_id, name_vector,
                                  NEW.rank_search, NEW.rank_address, NEW.geometry);
 

--- a/sql/functions/ranking.sql
+++ b/sql/functions/ranking.sql
@@ -145,10 +145,6 @@ BEGIN
   THEN
     SELECT * INTO search_rank, address_rank
       FROM get_postcode_rank(country, postcode);
-
-    IF NOT extended_type = 'A' THEN
-      address_rank := 0;
-    END IF;
   ELSEIF extended_type = 'N' AND place_class = 'highway' THEN
     search_rank = 30;
     address_rank = 0;

--- a/test/bdd/api/search/structured.feature
+++ b/test/bdd/api/search/structured.feature
@@ -18,7 +18,7 @@ Feature: Structured search queries
           | 22547 |
         Then results contain
           | type |
-          | postcode |
+          | ^post(al_)?code |
         And result addresses contain
           | postcode |
           | 22547 |

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -139,8 +139,8 @@ Feature: Address computation
             | R1  | boundary | administrative | 6     | 112           | :b0      |
             | R34 | boundary | administrative | 8     | 112 DE        | :b1:E    |
         And the places
-            | osm | class    | type      | addr+postcode | geometry |
-            | R4  | place    | postcode  | 112 DE 34     | :b2:N    |
+            | osm | class    | type        | addr+postcode | geometry |
+            | R4  | boundary | postal_code | 112 DE 34     | :b2:N    |
         And the named places
             | osm | class    | type           | geometry |
             | W93 | highway  | residential    | :w2N     |

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -69,10 +69,10 @@ Feature: Import into placex
          | N3   | place | postcode | Y45      | country:gb |
         When importing
         Then placex contains
-         | object | postcode | country_code | rank_search | rank_address |
-         | N1     | E45 2CD  | gb           | 25          | 0 |
-         | N2     | E45 2    | gb           | 23          | 0 |
-         | N3     | Y45      | gb           | 21          | 0 |
+         | object | addr+postcode | country_code | rank_search | rank_address |
+         | N1     | E45 2CD       | gb           | 25          | 5 |
+         | N2     | E45 2         | gb           | 23          | 5 |
+         | N3     | Y45           | gb           | 21          | 5 |
 
     Scenario: wrongly formatted GB postcodes are down-ranked
         Given the places
@@ -82,8 +82,8 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | gb           | 30          | 0 |
-         | N2     | gb           | 30          | 0 |
+         | N1     | gb           | 30          | 30 |
+         | N2     | gb           | 30          | 30 |
 
     Scenario: search and address rank for DE postcodes correctly assigned
         Given the places
@@ -95,10 +95,10 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | de           | 21          | 0 |
-         | N2     | de           | 30          | 0 |
-         | N3     | de           | 30          | 0 |
-         | N4     | de           | 30          | 0 |
+         | N1     | de           | 21          | 11 |
+         | N2     | de           | 30          | 30 |
+         | N3     | de           | 30          | 30 |
+         | N4     | de           | 30          | 30 |
 
     Scenario: search and address rank for other postcodes are correctly assigned
         Given the places
@@ -115,15 +115,15 @@ Feature: Import into placex
         When importing
         Then placex contains
          | object | country_code | rank_search | rank_address |
-         | N1     | ca           | 21          | 0 |
-         | N2     | ca           | 21          | 0 |
-         | N3     | ca           | 21          | 0 |
-         | N4     | ca           | 21          | 0 |
-         | N5     | ca           | 21          | 0 |
-         | N6     | ca           | 21          | 0 |
-         | N7     | ca           | 25          | 0 |
-         | N8     | ca           | 25          | 0 |
-         | N9     | ca           | 25          | 0 |
+         | N1     | ca           | 21          | 11 |
+         | N2     | ca           | 21          | 11 |
+         | N3     | ca           | 21          | 11 |
+         | N4     | ca           | 21          | 11 |
+         | N5     | ca           | 21          | 11 |
+         | N6     | ca           | 21          | 11 |
+         | N7     | ca           | 25          | 11 |
+         | N8     | ca           | 25          | 11 |
+         | N9     | ca           | 25          | 11 |
 
     Scenario: search and address ranks for boundaries are correctly assigned
         Given the named places


### PR DESCRIPTION
All places of type `place=postcode` just exist in placex so we can compute the content of the `location_postcode` table. They should be neither searchable nor appear in the address tables. That means we might as well ignore them completely during indexing.

Minor problem with that is that `boundary=postal_code` accidentally got indexed as `place=postcode` as well. Those we want to have in the search table and address because they represent authoritative postcode boundaries. With this change the boundaries now get the correct label. To be backward compatible with existing installations, continue indexing `place=postcode` that are relations for now.