### PR TITLE
ignore postcodes with colons

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -643,7 +643,7 @@ BEGIN
       addr_street := NEW.address->'street';
       addr_place := NEW.address->'place';
 
-      IF NEW.address ? 'postcode' and NEW.address->'postcode' not similar to '%(,|;)%' THEN
+      IF NEW.address ? 'postcode' and NEW.address->'postcode' not similar to '%(:|,|;)%' THEN
         i := getorcreate_postcode_id(NEW.address->'postcode');
       END IF;
   END IF;


### PR DESCRIPTION
Colons are used as a delimiter in tiger:left and tiger:right tags
when multiple postcodes are given. Ignore those. This was already
done in the postcode update script. This changes just makes the
two places consistent where postcodes are added.