### PR TITLE
Make addresses searchable by their addr: tags

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -224,7 +224,7 @@ LANGUAGE plpgsql STABLE;
 -- \param maxrank       Rank of the place. All address features must have
 --                      a search rank lower than the given rank.
 -- \param address       Address terms for the place.
--- \param geoemtry      Geometry to which the address objects should be close.
+-- \param geometry      Geometry to which the address objects should be close.
 --
 -- \retval parent_place_id  Place_id of the address object that is the direct
 --                          ancestor.
@@ -541,6 +541,9 @@ DECLARE
 
   name_vector INTEGER[];
   nameaddress_vector INTEGER[];
+  addr_nameaddress_vector INTEGER[];
+
+  inherited_address HSTORE;
 
   linked_node_id BIGINT;
   linked_importance FLOAT;
@@ -710,6 +713,7 @@ BEGIN
 
     -- if we have a POI and there is no address information,
     -- see if we can get it from a surrounding building
+    inherited_address := ''::HSTORE;
     IF NEW.osm_type = 'N' AND addr_street IS NULL AND addr_place IS NULL
        AND NEW.housenumber IS NULL THEN
       FOR location IN
@@ -724,6 +728,7 @@ BEGIN
         NEW.housenumber := location.address->'housenumber';
         addr_street := location.address->'street';
         addr_place := location.address->'place';
+        inherited_address := location.address;
       END LOOP;
     END IF;
 
@@ -754,28 +759,26 @@ BEGIN
         NEW.postcode := get_nearest_postcode(NEW.country_code, NEW.geometry);
       END IF;
 
-      -- If there is no name it isn't searchable, don't bother to create a search record
-      IF NEW.name is NULL THEN
-        --DEBUG: RAISE WARNING 'Not a searchable place % %', NEW.osm_type, NEW.osm_id;
-        return NEW;
+      IF NEW.name is not NULL THEN
+          NEW.name := add_default_place_name(NEW.country_code, NEW.name);
+          name_vector := make_keywords(NEW.name);
+
+          IF NEW.rank_search <= 25 and NEW.rank_address > 0 THEN
+            result := add_location(NEW.place_id, NEW.country_code, NEW.partition,
+                                   name_vector, NEW.rank_search, NEW.rank_address,
+                                   upper(trim(NEW.address->'postcode')), NEW.geometry);
+            --DEBUG: RAISE WARNING 'Place added to location table';
+          END IF;
+
       END IF;
 
-      NEW.name := add_default_place_name(NEW.country_code, NEW.name);
-      name_vector := make_keywords(NEW.name);
-
-      -- Performance, it would be more acurate to do all the rest of the import
-      -- process but it takes too long
-      -- Just be happy with inheriting from parent road only
-      result := insertSearchName(NEW.partition, NEW.place_id, name_vector,
-                                 NEW.rank_search, NEW.rank_address, NEW.geometry);
-
       IF NOT %REVERSE-ONLY% THEN
-          -- Merge address from parent
-          SELECT array_merge(s.name_vector, s.nameaddress_vector)
-            INTO nameaddress_vector
-            FROM search_name s
-            WHERE s.place_id = NEW.parent_place_id;
+        SELECT * INTO name_vector, nameaddress_vector
+          FROM create_poi_search_terms(NEW.parent_place_id,
+                                       inherited_address || NEW.address,
+                                       NEW.housenumber, name_vector);
 
+        IF array_length(name_vector, 1) is not NULL THEN
           INSERT INTO search_name (place_id, search_rank, address_rank,
                                    importance, country_code, name_vector,
                                    nameaddress_vector, centroid)
@@ -784,8 +787,9 @@ BEGIN
                          nameaddress_vector, NEW.centroid);
           --DEBUG: RAISE WARNING 'Place added to search table';
         END IF;
+      END IF;
 
-      return NEW;
+      RETURN NEW;
     END IF;
 
   END IF;

--- a/test/bdd/db/import/parenting.feature
+++ b/test/bdd/db/import/parenting.feature
@@ -374,7 +374,7 @@ Feature: Parenting of objects
          | W1     | N4              | 3 |
          | N1     | W2              | None |
          | N2     | W3              | 4 |
-         | N3     | W2              | None |
+         | N3     | N4              | None |
 
     Scenario: POIs parent a road if they are attached to it
         Given the scene points-on-roads

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -62,24 +62,32 @@ Feature: Creation of search terms
          | osm | class   | type        | housenr | addr+place | geometry |
          | N1  | place   | house       | 23      | Walltown   | :p-N1 |
         And the places
-         | osm | class   | type        | name+name   | geometry |
-         | W1  | highway | residential | Rose Street | :w-north |
+         | osm | class   | type        | name+name    | geometry |
+         | W1  | highway | residential | Rose Street  | :w-north |
+         | N2  | place   | city        | Strange Town | :p-N1 |
         When importing
         Then search_name contains
          | object | name_vector | nameaddress_vector |
          | N1     | #23         | Walltown |
-        When searching for "23 Rose Street, Walltown"
-        Then exactly 0 results are returned
+        When searching for "23 Rose Street"
+        Then exactly 1 results are returned
+        And results contain
+         | osm_type | osm_id |
+         | W        | 1 |
+        When searching for "23 Walltown"
+        Then results contain
+         | osm_type | osm_id |
+         | N        | 1 |
 
-    # XXX Need to change parenting of POis without addr:street and with addr:place
     Scenario: Unnamed POIs doesn't inherit parent name when addr:place is present only in parent address
         Given the scene roads-with-pois
         And the places
          | osm | class   | type        | housenr | addr+place | geometry |
          | N1  | place   | house       | 23      | Walltown   | :p-N1 |
         And the places
-         | osm | class   | type        | name+name   | addr+city | geometry |
-         | W1  | highway | residential | Rose Street | Walltown  | :w-north |
+         | osm | class   | type        | name+name    | addr+city | geometry |
+         | W1  | highway | residential | Rose Street  | Walltown  | :w-north |
+         | N2  | place   | suburb      | Strange Town | Walltown  | :p-N1 |
         When importing
         Then search_name contains
          | object | name_vector | nameaddress_vector |
@@ -89,6 +97,11 @@ Feature: Creation of search terms
         And results contain
          | osm_type | osm_id |
          | W        | 1 |
+        When searching for "23  Walltown"
+        Then exactly 1 result is returned
+        And results contain
+         | osm_type | osm_id |
+         | N        | 1 |
 
     Scenario: Unnamed POIs does inherit parent name when unknown addr:place and addr:street is present
         Given the scene roads-with-pois
@@ -147,17 +160,19 @@ Feature: Creation of search terms
          | osm | class   | type        | name+name  | addr+place | geometry |
          | N1  | place   | house       | Green Moss | Walltown  | :p-N1 |
         And the places
-         | osm | class   | type        | name+name   | geometry |
-         | W1  | highway | residential | Rose Street | :w-north |
+         | osm | class   | type        | name+name    | geometry |
+         | W1  | highway | residential | Rose Street  | :w-north |
+         | N2  | place   | suburb      | Strange Town | :p-N1 |
         When importing
         Then search_name contains
          | object | name_vector | nameaddress_vector |
          | N1     | #Green Moss | Walltown |
         When searching for "Green Moss, Rose Street, Walltown"
-        Then exactly 1 result is returned
-        And results contain
+        Then exactly 0 result is returned
+        When searching for "Green Moss, Walltown"
+        Then results contain
          | osm_type | osm_id |
-         | W        | 1 |
+         | N        | 1 |
 
     Scenario: Named POIs inherit address from parent
         Given the scene roads-with-pois

--- a/test/bdd/db/update/parenting.feature
+++ b/test/bdd/db/update/parenting.feature
@@ -9,8 +9,8 @@ Scenario: POI inside building inherits addr:street change
          | N2  | shop    | bakery     | :n-edge-NS |
          | N3  | shop    | supermarket| :n-edge-WE |
         And the places
-         | osm | class    | type | addr_place | housenr | geometry |
-         | W1  | building | yes  | nowhere    | 3       | :w-building |
+         | osm | class    | type | street  | housenr | geometry |
+         | W1  | building | yes  | nowhere | 3       | :w-building |
         And the places
          | osm | class    | type        | name | geometry |
          | W2  | highway  | primary     | bar  | :w-WE |
@@ -34,5 +34,3 @@ Scenario: POI inside building inherits addr:street change
          | N1     | W3              | 3 |
          | N2     | W3              | 3 |
          | N3     | W3              | 3 |
-
-


### PR DESCRIPTION
With this PR we add rank 30 objects to the search_name table when they have addr: tags that are not covered by the search names of the parent street/place. If the object is unnamed, then the house number takes the place of the name.

Parenting behaviour is changed slightly as well. While addr:street tags still require a street with the same name for parenting, addr:place tags do no longer need to have a place object with the same name. If an object of the given name is not found, we
parent with a the nearest place instead, assuming that the addr:place intentionally points to something 'virtual'. 

Resolves half of #148. This PR only makes these addresses searchable by their addr: tags. It does not change the final display name. We still show the location description computed using the parent street/place. We can't unconditionally replace items in the address with the content of addr: because we would loose translations. This can be really problematic in some cases, especially when different scripts are involved. For example, if we unconditionally replaced all addr:city tags, English speakers would suddenly see 'Москва' instead of  'Moscow' for addresses in the Russian capital.

