### PR TITLE
Switch recursive updates to using rank_search

### DIFF
--- a/sql/functions/place_triggers.sql
+++ b/sql/functions/place_triggers.sql
@@ -162,14 +162,14 @@ BEGIN
       IF st_area(NEW.geometry) < 0.000000001 AND st_area(existinggeometry) < 1 THEN
 
         -- re-index points that have moved in / out of the polygon, could be done as a single query but postgres gets the index usage wrong
-        update placex set indexed_status = 2 where indexed_status = 0 and 
-            (st_covers(NEW.geometry, placex.geometry) OR ST_Intersects(NEW.geometry, placex.geometry))
-            AND NOT (st_covers(existinggeometry, placex.geometry) OR ST_Intersects(existinggeometry, placex.geometry))
+        update placex set indexed_status = 2 where indexed_status = 0
+            AND ST_Intersects(NEW.geometry, placex.geometry)
+            AND NOT ST_Intersects(existinggeometry, placex.geometry)
             AND rank_search > existingplacex.rank_search AND (rank_search < 28 or name is not null);
 
-        update placex set indexed_status = 2 where indexed_status = 0 and 
-            (st_covers(existinggeometry, placex.geometry) OR ST_Intersects(existinggeometry, placex.geometry))
-            AND NOT (st_covers(NEW.geometry, placex.geometry) OR ST_Intersects(NEW.geometry, placex.geometry))
+        update placex set indexed_status = 2 where indexed_status = 0
+            AND ST_Intersects(existinggeometry, placex.geometry)
+            AND NOT ST_Intersects(NEW.geometry, placex.geometry)
             AND rank_search > existingplacex.rank_search AND (rank_search < 28 or name is not null);
 
       END IF;

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -451,9 +451,9 @@ BEGIN
   --    RAISE WARNING 'placex poly insert: % % % %',NEW.osm_type,NEW.osm_id,NEW.class,NEW.type;
 
         -- work around bug in postgis, this may have been fixed in 2.0.0 (see http://trac.osgeo.org/postgis/ticket/547)
-        update placex set indexed_status = 2 where (st_covers(NEW.geometry, placex.geometry) OR ST_Intersects(NEW.geometry, placex.geometry)) 
+        update placex set indexed_status = 2 where ST_Intersects(NEW.geometry, placex.geometry)
          AND rank_search > NEW.rank_search and indexed_status = 0 and ST_geometrytype(placex.geometry) = 'ST_Point' and (rank_search < 28 or name is not null or (NEW.rank_search >= 16 and address ? 'place'));
-        update placex set indexed_status = 2 where (st_covers(NEW.geometry, placex.geometry) OR ST_Intersects(NEW.geometry, placex.geometry)) 
+        update placex set indexed_status = 2 where ST_Intersects(NEW.geometry, placex.geometry)
          AND rank_search > NEW.rank_search and indexed_status = 0 and ST_geometrytype(placex.geometry) != 'ST_Point' and (rank_search < 28 or name is not null or (NEW.rank_search >= 16 and address ? 'place'));
       END IF;
     ELSE

--- a/sql/functions/utils.sql
+++ b/sql/functions/utils.sql
@@ -474,9 +474,9 @@ BEGIN
   IF placegeom IS NOT NULL AND ST_IsValid(placegeom) THEN
     IF ST_GeometryType(placegeom) in ('ST_Polygon','ST_MultiPolygon') THEN
       FOR geom IN select split_geometry(placegeom) FROM placex WHERE place_id = placeid LOOP
-        update placex set indexed_status = 2 where (st_covers(geom, placex.geometry) OR ST_Intersects(geom, placex.geometry)) 
+        update placex set indexed_status = 2 where ST_Intersects(geom, placex.geometry)
         AND rank_search > rank and indexed_status = 0 and ST_geometrytype(placex.geometry) = 'ST_Point' and (rank_search < 28 or name is not null or (rank >= 16 and address ? 'place'));
-        update placex set indexed_status = 2 where (st_covers(geom, placex.geometry) OR ST_Intersects(geom, placex.geometry)) 
+        update placex set indexed_status = 2 where ST_Intersects(geom, placex.geometry)
         AND rank_search > rank and indexed_status = 0 and ST_geometrytype(placex.geometry) != 'ST_Point' and (rank_search < 28 or name is not null or (rank >= 16 and address ? 'place'));
       END LOOP;
     ELSE


### PR DESCRIPTION
I forgot to update the invalidation functions when switching address computation to using rank_address instead of rank_search.

This also removes the duplicate checks with ST_Covers and ST_Intersects. They are unnecessary and severely confuse the query planner in newer versions of Postgis. It should fix https://github.com/openstreetmap/osm2pgsql/issues/1273.