### PR TITLE
Drop support for is_in tag

### DIFF
--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -211,7 +211,7 @@
     }
 },
 {
-    "keys" : ["addr:*", "is_in:*", "tiger:county", "is_in"],
+    "keys" : ["addr:*", "is_in:*", "tiger:county"],
     "values" : {
         "" : "address"
     }

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -211,7 +211,7 @@
     }
 },
 {
-    "keys" : ["addr:*", "is_in:*", "tiger:county", "is_in"],
+    "keys" : ["addr:*", "is_in:*", "tiger:county"],
     "values" : {
         "" : "address"
     }

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -290,23 +290,6 @@ BEGIN
         END IF;
       END IF;
     END LOOP;
-
-    IF address ? 'is_in' THEN
-      -- is_in items need splitting
-      isin := regexp_split_to_array(address->'is_in', E'[;,]');
-      IF array_upper(isin, 1) IS NOT NULL THEN
-        FOR i IN 1..array_upper(isin, 1) LOOP
-          isin_tokens := array_merge(isin_tokens,
-                                     word_ids_from_name(isin[i]));
-
-          -- merge word into address vector
-          IF NOT %REVERSE-ONLY% THEN
-            nameaddress_vector := array_merge(nameaddress_vector,
-                                              addr_ids_from_name(isin[i]));
-          END IF;
-        END LOOP;
-      END IF;
-    END IF;
   END IF;
   IF NOT %REVERSE-ONLY% THEN
     nameaddress_vector := array_merge(nameaddress_vector, isin_tokens);

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -223,21 +223,6 @@ Feature: Creation of search terms
          | object | nameaddress_vector |
          | W1     | 12345 |
 
-    Scenario: is_in is split and added to the address search terms
-        Given the scene roads-with-pois
-        And the places
-         | osm | class   | type        | name     | geometry |
-         | N1  | place   | state       | new york | 80 80 |
-         | N2  | place   | city        | bonn     | 81 81 |
-         | N3  | place   | suburb      | smalltown| 80 81 |
-        And the named places
-         | osm | class   | type    | addr+is_in                | geometry |
-         | W1  | highway | service | bonn, New York, Smalltown | :w-north |
-        When importing
-        Then search_name contains
-         | object | nameaddress_vector |
-         | W1     | bonn, new york, smalltown |
-
     Scenario: a linked place does not show up in search name
         Given the named places
          | osm  | class    | type           | admin | geometry |


### PR DESCRIPTION
The `is_in` tag had its use in OSM in times before we had administrative boundaries and the more specific `addr:*` and `is_in:*` tags. Nowadays it does more good than harm to process it. So it is time to drop support for it.