### PR TITLE
Exclude unnamed highway areas

### DIFF
--- a/settings/import-address.style
+++ b/settings/import-address.style
@@ -5,7 +5,7 @@
         "no" : "skip"
     }
 },
-{   "keys" : ["wikipedia", "wikipedia:*", "wikidata"],
+{   "keys" : ["wikipedia", "wikipedia:*", "wikidata", "area"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -237,7 +237,8 @@
               "population", "description", "image", "attribution", "fax",
               "email", "url", "website", "phone", "real_ale", "smoking",
               "food", "camera", "brewery", "locality", "wikipedia",
-              "wikipedia:*", "access:*", "contact:*", "drink:*", "toll:*"],
+              "wikipedia:*", "access:*", "contact:*", "drink:*", "toll:*",
+              "area"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-street.style
+++ b/settings/import-street.style
@@ -1,5 +1,5 @@
 [
-{   "keys" : ["wikipedia", "wikipedia:*", "wikidata"],
+{   "keys" : ["wikipedia", "wikipedia:*", "wikidata", "area"],
     "values" : {
         "" : "extra"
     }

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -417,7 +417,12 @@ BEGIN
 
       NEW.name := hstore('ref', NEW.address->'postcode');
 
-    ELSEIF NEW.class = 'boundary' AND NOT is_area THEN
+    ELSEIF NEW.class = 'highway' AND is_area AND NEW.name is null
+           AND NEW.extratags ? 'area' AND NEW.extratags->'area' = 'yes'
+    THEN
+        RETURN NULL;
+    ELSEIF NEW.class = 'boundary' AND NOT is_area
+    THEN
         RETURN NULL;
     ELSEIF NEW.class = 'boundary' AND NEW.type = 'administrative'
            AND NEW.admin_level <= 4 AND NEW.osm_type = 'W'


### PR DESCRIPTION
These are used to mark large paved areas in OSM. Sometimes they exists together with named regular streets. In such cases the unnamed area may overshadow the actual street when computing the address parent. As unnamed highways are not very useful anyway, simply remove them from the database.