### PR TITLE
add descriptive term for address rank 24

### DIFF
--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -86,7 +86,8 @@ function getBoundaryLabel($iAdminLevel, $sCountry, $sFallback = 'Administrative'
                                            8 => 'City',
                                            9 => 'City District',
                                            10 => 'Suburb',
-                                           11 => 'Neighbourhood'
+                                           11 => 'Neighbourhood',
+                                           12 => 'City Block'
                                           ),
                              'no' => array (
                                       3 => 'State',


### PR DESCRIPTION
With that term we have terms for all ranks, so that no generic 'administrative' term will show up in the address details anymore.