### PR TITLE
More rank search removal

### DIFF
--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -44,7 +44,7 @@ BEGIN
       FROM location_area_large_-partition-
       WHERE geometry && feature
         AND is_relevant_geometry(ST_Relate(geometry, feature), ST_GeometryType(feature))
-        AND rank_search < maxrank AND rank_address < maxrank
+        AND rank_address < maxrank
       GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
       ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
         ST_Distance(feature, centroid) *

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -24,6 +24,7 @@ Feature: Search queries
           | house_number  | 86 |
           | road          | Schellingstraße |
           | suburb        | Eilbek |
+          | neighbourhood | Auenviertel |
           | postcode      | 22089 |
           | city          | Hamburg |
           | country       | Deutschland |
@@ -37,6 +38,7 @@ Feature: Search queries
           | type          | value |
           | house_number  | 73 |
           | road          | Schellingstraße |
+          | neighbourhood | Auenviertel |
           | suburb        | Eilbek |
           | postcode      | 22089 |
           | city          | Hamburg |


### PR DESCRIPTION
`getNearestFeature()` and `get_addressdata()` was still checking against rank_search to filter eligible address terms. This sometimes removed valid address terms in large city where rank_address gets heavily downgraded.

Fixes #1904.