### PR TITLE
Remove unused idx_placex_geometry_reverse_lookupPoint

### DIFF
--- a/sql/indices.src.sql
+++ b/sql/indices.src.sql
@@ -10,11 +10,6 @@ CREATE INDEX idx_placex_rank_search ON placex USING BTREE (rank_search) {ts:sear
 CREATE INDEX idx_placex_rank_address ON placex USING BTREE (rank_address) {ts:search-index};
 CREATE INDEX idx_placex_parent_place_id ON placex USING BTREE (parent_place_id) {ts:search-index} where parent_place_id IS NOT NULL;
 
-CREATE INDEX idx_placex_geometry_reverse_lookupPoint
-  ON placex USING gist (geometry) {ts:search-index}
-  WHERE (name is not null or housenumber is not null or rank_address between 26 and 27)
-    AND class not in ('railway','tunnel','bridge','man_made')
-    AND rank_address >= 26 AND indexed_status = 0 AND linked_place_id is null;
 CREATE INDEX idx_placex_geometry_reverse_lookupPolygon
   ON placex USING gist (geometry) {ts:search-index}
   WHERE St_GeometryType(geometry) in ('ST_Polygon', 'ST_MultiPolygon')

--- a/utils/check_import_finished.php
+++ b/utils/check_import_finished.php
@@ -106,7 +106,6 @@ $aExpectedIndices = array(
     'idx_placex_rank_address',
     'idx_placex_pendingsector',
     'idx_placex_parent_place_id',
-    'idx_placex_geometry_reverse_lookuppoint',
     'idx_placex_geometry_reverse_lookuppolygon',
     'idx_placex_geometry_reverse_placenode',
     'idx_location_area_country_place_id',


### PR DESCRIPTION
The index has been unused ever since the query using it was changed two years ago. Given that it has not been missed much, drop it completely here.

If you have a Nominatim 3.5.x installation, you can safely drop the index as well. Saves about 12GB.