### PR TITLE
update to latest osm2pgsql version

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -260,3 +260,6 @@ CREATE TABLE wikipedia_redirect (
 );
 ALTER TABLE ONLY wikipedia_redirect ADD CONSTRAINT wikipedia_redirect_pkey PRIMARY KEY (language, from_title);
 
+-- osm2pgsql does not create indexes on the middle tables for Nominatim
+-- Add one for lookup of associated street relations.
+CREATE INDEX planet_osm_rels_parts_associated_idx ON planet_osm_rels USING gin(parts) WHERE tags @> ARRAY['associatedStreet'];


### PR DESCRIPTION
The latest version of osm2pgsql no longer creates indexes on the members of planet_osm_rels. So we do that ourselves. Given that we only need to access associated street relations, the index can become quite a bit smaller.

Fixes #1978.