### PR TITLE
Restrict postcode searches to postcode in first token 

### DIFF
--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -199,15 +199,10 @@ class SearchDescription
         } elseif (($sPhraseType == '' || $sPhraseType == 'postalcode')
                   && is_a($oSearchTerm, '\Nominatim\Token\Postcode')
         ) {
-            // We need to try the case where the postal code is the primary element
-            // (i.e. no way to tell if it is (postalcode, city) OR (city, postalcode)
-            // so try both.
             if (!$this->sPostcode) {
                 // If we have structured search or this is the first term,
                 // make the postcode the primary search element.
-                if ($this->iOperator == Operator::NONE
-                    && ($sPhraseType == 'postalcode' || $bFirstToken)
-                ) {
+                if ($this->iOperator == Operator::NONE && $bFirstToken) {
                     $oSearch = clone $this;
                     $oSearch->iSearchRank++;
                     $oSearch->iOperator = Operator::POSTCODE;

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -24,7 +24,6 @@ Feature: Search queries
           | house_number  | 86 |
           | road          | Schellingstraße |
           | suburb        | Eilbek |
-          | neighbourhood | Auenviertel |
           | postcode      | 22089 |
           | city          | Hamburg |
           | country       | Deutschland |
@@ -38,7 +37,6 @@ Feature: Search queries
           | type          | value |
           | house_number  | 73 |
           | road          | Schellingstraße |
-          | neighbourhood | Auenviertel |
           | suburb        | Eilbek |
           | postcode      | 22089 |
           | city          | Hamburg |


### PR DESCRIPTION
In structured queries we should only assume that it is a postcode search when only the postcode and optionally the country is given. If any other term is present, it is better to avoid the search for postcode as it yields too many bad searches. Given that the terms in a structured query are ordered, this means that the postcode must be the first token just like in the unstructured query.

Also reverts a bad fix of the API tests.

Fixes #1988.
