### PR TITLE
Adapt address levels for admin boundaries in Indonesia

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -122,6 +122,21 @@
           "administrative4" : 12
       }
   }
+},
+{ "countries" : ["id"],
+  "tags" : {
+      "place" : {
+          "municipality" : 18
+      },
+      "boundary" : {
+          "administrative5" : 12,
+          "administrative6" : 14,
+          "administrative7" : 16,
+          "administrative8" : 20,
+          "administrative9" : 22,
+          "administrative10" : 24
+      }
+  }
 }
 ]
 


### PR DESCRIPTION
As per description in https://wiki.openstreetmap.org/wiki/Indonesia#Tagging_conventions and https://en.wikipedia.org/wiki/Subdivisions_of_Indonesia . Indonesia uses `place=village` for rural as well as urban village. This causes problems in cities that do not have administrative boundaries. There is little we can do about it though as it is a case of missing information.