### PR TITLE
demote place nodes in admin areas

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -624,6 +624,21 @@ BEGIN
         NEW.rank_address := parent_address_level + 2;
       END IF;
     END IF;
+  -- If a place node is contained in a admin boundary with the same address level
+  -- and has not been linked, then make the node a subpart by increasing the
+  -- address rank (city level and above).
+  ELSEIF NEW.class = 'place' and NEW.osm_type = 'N'
+     and NEW.rank_address between 16 and 23
+  THEN
+    FOR location IN
+        SELECT rank_address FROM placex
+        WHERE osm_type = 'R' and class = 'boundary' and type = 'administrative'
+              and rank_address = NEW.rank_address
+              and geometry && NEW.centroid and _ST_Covers(geometry, NEW.centroid)
+        LIMIT 1
+    LOOP
+      NEW.rank_address = NEW.rank_address + 2;
+    END LOOP;
   ELSE
     parent_address_level := 3;
   END IF;

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -211,7 +211,11 @@ BEGIN
     FOR linked_placex IN
       SELECT placex.* from placex
       WHERE make_standard_name(name->'name') = bnd_name
-        AND ((bnd.rank_address > 0 and placex.rank_address = bnd.rank_address)
+        AND ((bnd.rank_address > 0
+              and bnd.rank_address = (compute_place_rank(placex.country_code,
+                                                         'N', placex.class,
+                                                         placex.type, 15::SMALLINT,
+                                                         false, placex.postcode)).address_rank)
              OR (bnd.rank_address = 0 and placex.rank_search = bnd.rank_search))
         AND placex.osm_type = 'N'
         AND placex.rank_search < 26 -- needed to select the right index

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -19,11 +19,10 @@ Feature: Search queries
         When sending json search query "Schellingstr 86, Hamburg" with address
           | accept-language |
           | de |
-        Then address of result 0 is
+        Then address of result 0 contains
           | type          | value |
           | house_number  | 86 |
           | road          | Schellingstraße |
-          | suburb        | Eilbek |
           | postcode      | 22089 |
           | city          | Hamburg |
           | country       | Deutschland |
@@ -33,11 +32,10 @@ Feature: Search queries
         When sending json search query "Schellingstr 73, Hamburg" with address
           | accept-language |
           | de |
-        Then address of result 0 is
+        Then address of result 0 contains
           | type          | value |
           | house_number  | 73 |
           | road          | Schellingstraße |
-          | suburb        | Eilbek |
           | postcode      | 22089 |
           | city          | Hamburg |
           | country       | Deutschland |

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -583,8 +583,8 @@ def check_address(context, lid, neg, attrs):
         else:
             assert_in(attr, addr_parts)
 
-@then(u'address of result (?P<lid>\d+) is')
-def check_address(context, lid):
+@then(u'address of result (?P<lid>\d+) (?P<complete>is|contains)')
+def check_address(context, lid, complete):
     context.execute_steps("then more than %s results are returned" % lid)
 
     addr_parts = dict(context.response.result[int(lid)]['address'])
@@ -595,7 +595,8 @@ def check_address(context, lid):
                      "Bad address value for %s" % line['type'])
         del addr_parts[line['type']]
 
-    eq_(0, len(addr_parts), "Additional address parts found: %s" % str(addr_parts))
+    if complete == 'is':
+        eq_(0, len(addr_parts), "Additional address parts found: %s" % str(addr_parts))
 
 @then(u'result (?P<lid>\d+ )?has bounding box in (?P<coords>[\d,.-]+)')
 def step_impl(context, lid, coords):


### PR DESCRIPTION
If a place node of city rank and above finds itself in an administrative boundary of the same address rank, then increase the address rank by 2. This catches the rather frequent case where city suburbs are tagged for historical reasons as towns or villages. It also improves the address output for municipalities that consist of multiple formerly independent villages where often the municipality is tagged with place=village as well.