### PR TITLE
Ubuntu 20: use postgresql-contrib-12 so no version higher gets installed

### DIFF
--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -31,7 +31,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
                         libbz2-dev libpq-dev libproj-dev \
                         postgresql-server-dev-12 postgresql-12-postgis-3 \
-                        postgresql-contrib postgresql-12-postgis-3-scripts \
+                        postgresql-contrib-12 postgresql-12-postgis-3-scripts \
                         php php-pgsql php-intl \
                         python3-psycopg2 git
 


### PR DESCRIPTION
Postgresql 13 became the new default version on Ubuntu 20 two weeks ago. https://www.postgresql.org/support/versioning/ (section 'Releases')

When fetching packages from http://apt.postgresql.org/pub/repos/apt/ and then running `apt-get upgrade` the `postgresql-contrib` now points to Postgresql 13 and installs `postgresql-13` while keeping the already existing `postgresql-12`. That adds confusion and it's an `apt remove` doesn't clear all the file it creates, e.g. data and /etc/ directories. I expect the same trouble to occur with Ubuntu's default package repos soon, too.
