### PR TITLE
Initialize CONST_Debug to prevent -undefined constant- warning

### DIFF
--- a/settings/defaults.php
+++ b/settings/defaults.php
@@ -120,3 +120,5 @@ if (file_exists(CONST_InstallPath.'/settings/local.php')) require_once(CONST_Ins
 @define('CONST_Log_DB', false);
 // Set to a file name to enable logging to a file.
 @define('CONST_Log_File', false);
+// Verbose debugging output, only useful when manual testing
+@define('CONST_Debug', false);


### PR DESCRIPTION
I found warnings in `PHP 7.4.3 (built May 26 2020)` when running `utils/warm.php`
```
PHP Warning:  Use of undefined constant CONST_Debug - assumed 'CONST_Debug'
(this will throw an Error in a future version of PHP)
in /srv/nominatim/Nominatim/lib/ReverseGeocode.php on line 263
```

Stripped down test script which prints such a warning
```php
cat /srv/nominatim/Nominatim/build/utils/test.php
#!/usr/bin/php -Cq
<?php
require_once(dirname(dirname(__FILE__)).'/settings/settings.php');
require_once(CONST_BasePath.'/lib/init-cmd.php');
require_once(CONST_BasePath.'/lib/ReverseGeocode.php');
$oDB = new Nominatim\DB();
$oDB->connect();
$oReverseGeocode = new Nominatim\ReverseGeocode($oDB);
$oReverseGeocode->lookup(51,7);
```

Initializing `CONST_Debug` in base settings or local.php helps.