### PR TITLE
When result without housenumber is found, continue search first in same street, and then any street around to find an address with housenumber

### DIFF
--- a/docs/api/Reverse.md
+++ b/docs/api/Reverse.md
@@ -101,6 +101,24 @@ Simplify the output geometry before returning. The parameter is the
 tolerance in degrees with which the geometry may differ from the original
 geometry. Topology is preserved in the result. (Default: 0.0)
 
+### Extended search for housenumber
+
+* `housenumbersamestreetsearchdistance=<value>`
+
+When an address without housenumber is found initially, continue search in the same
+street with a maximum distance of <value> meter to find an address with housenumber.
+This search is only done when initial search returns a street.
+
+* `housenumbersearchdistance=<value>`
+
+When an address without housenumber is found initially, continue search with a
+maximum distance of <value> meter to find an address with housenumber (may be in
+another street).
+
+Above options can be combined, in that case first a search is done in the same street,
+if that does not result in a result with housenumber, search is done also in other
+streets.
+
 ### Other
 
 * `email=<valid email address>`

--- a/lib/DB.php
+++ b/lib/DB.php
@@ -77,6 +77,7 @@ class DB
             $stmt = $this->getQueryStatement($sSQL, $aInputVars, $sErrMessage);
             $row = $stmt->fetch();
         } catch (\PDOException $e) {
+            file_put_contents(CONST_Log_File, $e . ": " . $sSQL . "\n", FILE_APPEND | LOCK_EX);
             throw new \Nominatim\DatabaseError($sErrMessage, 500, null, $e, $sSQL);
         }
         return $row;
@@ -184,6 +185,7 @@ class DB
                 $stmt = $this->connection->query($sSQL);
             }
         } catch (\PDOException $e) {
+            file_put_contents(CONST_Log_File, $e . ": " . $sSQL . "\n", FILE_APPEND | LOCK_EX);
             throw new \Nominatim\DatabaseError($sErrMessage, 500, null, $e, $sSQL);
         }
         return $stmt;

--- a/website/reverse.php
+++ b/website/reverse.php
@@ -44,6 +44,30 @@ if ($sOsmType && $iOsmId > 0) {
         $aPlaces = $oPlaceLookup->lookup(array($oLookup->iId => $oLookup));
         if (!empty($aPlaces)) {
             $aPlace = reset($aPlaces);
+            $maxHousenumberSameStreetDistance = $oParams->getInt('housenumbersamestreetsearchdistance', 0);
+            $maxHousenumberDistance = $oParams->getInt('housenumbersearchdistance', 0);
+            if( ($maxHousenumberSameStreetDistance > 0 || $maxHousenumberDistance > 0) && !isset($aPlace['address']->getAddressNames()['house_number']) ) {
+                if( isset($aPlace['address']->getAddressNames()['road']) ) {
+                    $street = $aPlace['address']->getAddressNames()['road'];
+                }else if( isset($aPlace['address']->getAddressNames()['cycleway']) ) {
+                    $street = $aPlace['address']->getAddressNames()['cycleway'];
+                }else if( isset($aPlace['address']->getAddressNames()['pedestrian']) ) {
+                    $street = $aPlace['address']->getAddressNames()['pedestrian'];
+                }else if( isset($aPlace['address']->getAddressNames()['footway']) ) {
+                    $street = $aPlace['address']->getAddressNames()['footway'];
+                }else if( isset($aPlace['address']->getAddressNames()['construction']) ) {
+                    $street = $aPlace['address']->getAddressNames()['construction'];
+                }
+                $oLookup = $oReverseGeocode->lookupWithHousenumber($fLat, $fLon, $street, $maxHousenumberSameStreetDistance, $maxHousenumberDistance);
+                if (CONST_Debug) var_dump($oLookup);
+
+                if ($oLookup) {
+                    $aPlaces = $oPlaceLookup->lookup(array($oLookup->iId => $oLookup));
+                    if (!empty($aPlaces)) {
+                        $aPlace = reset($aPlaces);
+                    }
+                }
+            }
         }
     }
 } elseif ($sOutputFormat != 'html') {


### PR DESCRIPTION
Make additional searches in wider area in case a result is found without a housenumber. Can be both limited to same street or any street around.

Fixes ##1469