### PR TITLE
Rework collection of address parts

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -895,8 +895,9 @@ BEGIN
   END IF;
 
   SELECT * FROM insert_addresslines(NEW.place_id, NEW.partition,
-                                    CASE WHEN NEW.rank_address = 0
-                                      THEN NEW.rank_search ELSE NEW.rank_address END,
+                                    CASE WHEN NEW.rank_address = 0 THEN NEW.rank_search
+                                         WHEN NEW.rank_address > 25 THEN 25::smallint
+                                         ELSE NEW.rank_address END,
                                     NEW.address,
                                     CASE WHEN NEW.rank_search >= 26
                                              AND NEW.rank_search < 30

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -624,7 +624,7 @@ BEGIN
       SELECT rank_address FROM placex
       WHERE class = 'place' and rank_address < 24
             and rank_address > NEW.rank_address
-            and geometry ~ NEW.geometry
+            and geometry && NEW.geometry
             and ST_Relate(geometry, NEW.geometry, 'T*T***FF*') -- contains but not equal
       ORDER BY rank_address desc LIMIT 1
     LOOP
@@ -640,7 +640,7 @@ BEGIN
         SELECT rank_address FROM placex
         WHERE osm_type = 'R' and class = 'boundary' and type = 'administrative'
               and rank_address = NEW.rank_address
-              and geometry ~ NEW.centroid and _ST_Covers(geometry, NEW.centroid)
+              and geometry && NEW.centroid and _ST_Covers(geometry, NEW.centroid)
         LIMIT 1
     LOOP
       NEW.rank_address = NEW.rank_address + 2;
@@ -743,10 +743,10 @@ BEGIN
     IF NEW.osm_type = 'N' AND addr_street IS NULL AND addr_place IS NULL
        AND NEW.housenumber IS NULL THEN
       FOR location IN
-        -- The additional ~ condition works around the misguided query
+        -- The additional && condition works around the misguided query
         -- planner of postgis 3.0.
         SELECT address from placex where ST_Covers(geometry, NEW.centroid)
-            and geometry ~ NEW.centroid
+            and geometry && NEW.centroid
             and (address ? 'housenumber' or address ? 'street' or address ? 'place')
             and rank_search > 28 AND ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon')
             limit 1

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -507,7 +507,7 @@ BEGIN
       FROM placex
       WHERE osm_type = 'R' and class = 'boundary' and type = 'administrative'
             and admin_level < in_level
-            and geometry && geom and ST_Covers(geometry, geom)
+            and geometry ~ geom and _ST_Covers(geometry, geom)
       ORDER BY admin_level desc LIMIT 1;
   END IF;
 
@@ -624,7 +624,7 @@ BEGIN
       SELECT rank_address FROM placex
       WHERE class = 'place' and rank_address < 24
             and rank_address > NEW.rank_address
-            and geometry && NEW.geometry
+            and geometry ~ NEW.geometry
             and ST_Relate(geometry, NEW.geometry, 'T*T***FF*') -- contains but not equal
       ORDER BY rank_address desc LIMIT 1
     LOOP
@@ -640,7 +640,7 @@ BEGIN
         SELECT rank_address FROM placex
         WHERE osm_type = 'R' and class = 'boundary' and type = 'administrative'
               and rank_address = NEW.rank_address
-              and geometry && NEW.centroid and _ST_Covers(geometry, NEW.centroid)
+              and geometry ~ NEW.centroid and _ST_Covers(geometry, NEW.centroid)
         LIMIT 1
     LOOP
       NEW.rank_address = NEW.rank_address + 2;
@@ -743,10 +743,10 @@ BEGIN
     IF NEW.osm_type = 'N' AND addr_street IS NULL AND addr_place IS NULL
        AND NEW.housenumber IS NULL THEN
       FOR location IN
-        -- The additional && condition works around the misguided query
+        -- The additional ~ condition works around the misguided query
         -- planner of postgis 3.0.
         SELECT address from placex where ST_Covers(geometry, NEW.centroid)
-            and geometry && NEW.centroid
+            and geometry ~ NEW.centroid
             and (address ? 'housenumber' or address ? 'street' or address ? 'place')
             and rank_search > 28 AND ST_GeometryType(geometry) in ('ST_Polygon','ST_MultiPolygon')
             limit 1

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -801,7 +801,8 @@ BEGIN
           IF NEW.rank_search <= 25 and NEW.rank_address > 0 THEN
             result := add_location(NEW.place_id, NEW.country_code, NEW.partition,
                                    name_vector, NEW.rank_search, NEW.rank_address,
-                                   upper(trim(NEW.address->'postcode')), NEW.geometry);
+                                   upper(trim(NEW.address->'postcode')), NEW.geometry,
+                                   NEW.centroid);
             --DEBUG: RAISE WARNING 'Place added to location table';
           END IF;
 
@@ -932,7 +933,7 @@ BEGIN
   IF NEW.name IS NOT NULL THEN
 
     IF NEW.rank_search <= 25 and NEW.rank_address > 0 THEN
-      result := add_location(NEW.place_id, NEW.country_code, NEW.partition, name_vector, NEW.rank_search, NEW.rank_address, upper(trim(NEW.address->'postcode')), NEW.geometry);
+      result := add_location(NEW.place_id, NEW.country_code, NEW.partition, name_vector, NEW.rank_search, NEW.rank_address, upper(trim(NEW.address->'postcode')), NEW.geometry, NEW.centroid);
       --DEBUG: RAISE WARNING 'added to location (full)';
     END IF;
 

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -307,7 +307,13 @@ BEGIN
   END LOOP;
 
   FOR location IN
-    SELECT * FROM getNearFeatures(partition, geometry, maxrank, isin_tokens)
+    SELECT * FROM getNearFeatures(partition, geometry, maxrank)
+    ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
+             distance *
+               CASE WHEN rank_address = 16 AND rank_search = 15 THEN 0.2
+                    WHEN rank_address = 16 AND rank_search = 16 THEN 0.25
+                    WHEN rank_address = 16 AND rank_search = 18 THEN 0.5
+                    ELSE 1 END ASC
   LOOP
     IF location.rank_address != current_rank_address THEN
       current_rank_address := location.rank_address;

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -360,7 +360,7 @@ BEGIN
 
     INSERT INTO place_addressline (place_id, address_place_id, fromarea,
                                      isaddress, distance, cached_rank_address)
-        VALUES (obj_place_id, location.place_id, true,
+        VALUES (obj_place_id, location.place_id, not location.isguess,
                 location_isaddress, location.distance, location.rank_address);
   END LOOP;
 END;

--- a/sql/functions/postcode_triggers.sql
+++ b/sql/functions/postcode_triggers.sql
@@ -27,8 +27,8 @@ BEGIN
     NEW.parent_place_id = 0;
     FOR location IN
       SELECT place_id
-        FROM getNearFeatures(partition, NEW.geometry, NEW.rank_search, '{}'::int[])
-        WHERE NOT isguess ORDER BY rank_address DESC LIMIT 1
+        FROM getNearFeatures(partition, NEW.geometry, NEW.rank_search)
+        WHERE NOT isguess ORDER BY rank_address DESC, distance asc LIMIT 1
     LOOP
         NEW.parent_place_id = location.place_id;
     END LOOP;

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -32,7 +32,7 @@ BEGIN
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-create or replace function getNearFeatures(in_partition INTEGER, feature GEOMETRY, maxrank INTEGER, isin_tokens INT[]) RETURNS setof nearfeaturecentr AS $$
+create or replace function getNearFeatures(in_partition INTEGER, feature GEOMETRY, maxrank INTEGER) RETURNS setof nearfeaturecentr AS $$
 DECLARE
   r nearfeaturecentr%rowtype;
 BEGIN
@@ -46,13 +46,6 @@ BEGIN
         AND is_relevant_geometry(ST_Relate(geometry, feature), ST_GeometryType(feature))
         AND rank_address < maxrank
       GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
-      ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
-        ST_Distance(feature, centroid) *
-          CASE 
-               WHEN rank_address = 16 AND rank_search = 15 THEN 0.2 -- capital city
-               WHEN rank_address = 16 AND rank_search = 16 THEN 0.25 -- city
-               WHEN rank_address = 16 AND rank_search = 17 THEN 0.5 -- town
-               ELSE 1 END ASC -- everything else
     LOOP
       RETURN NEXT r;
     END LOOP;

--- a/test/bdd/db/import/rank_computation.feature
+++ b/test/bdd/db/import/rank_computation.feature
@@ -2,7 +2,7 @@
 Feature: Rank assignment
     Tests for assignment of search and address ranks.
 
-    Scenario: Ranks for place nodes are assinged according to thier type
+    Scenario: Ranks for place nodes are assigned according to their type
         Given the named places
           | osm  | class     | type      |
           | N1   | foo       | bar       |
@@ -113,3 +113,36 @@ Feature: Rank assignment
           | R20    | 12          | 22 |
           | R21    | 14          | 24 |
           | R22    | 16          | 25 |
+
+    Scenario: admin levels contained in a place area must not overtake address ranks
+        Given the named places
+            | osm | class    | type           | admin | geometry |
+            | R10 | place    | city           | 15    | (0 0, 0 2, 2 0, 0 0) |
+            | R20 | boundary | administrative | 6     | (0 0, 0 1, 1 0, 0 0) |
+        When importing
+        Then placex contains
+            | object | rank_search | rank_address |
+            | R10    | 16          | 16           |
+            | R20    | 12          | 18           |
+
+    Scenario: admin levels overlapping a place area are not demoted
+        Given the named places
+            | osm | class    | type           | admin | geometry |
+            | R10 | place    | city           | 15    | (0 0, 0 2, 2 0, 0 0) |
+            | R20 | boundary | administrative | 6     | (-1 0, 0 1, 1 0, -1 0) |
+        When importing
+        Then placex contains
+            | object | rank_search | rank_address |
+            | R10    | 16          | 16           |
+            | R20    | 12          | 12           |
+
+    Scenario: admin levels with equal area as a place area are not demoted
+        Given the named places
+            | osm | class    | type           | admin | geometry |
+            | R10 | place    | city           | 15    | (0 0, 0 2, 2 0, 0 0) |
+            | R20 | boundary | administrative | 6     | (0 0, 0 2, 2 0, 0 0) |
+        When importing
+        Then placex contains
+            | object | rank_search | rank_address |
+            | R10    | 16          | 16           |
+            | R20    | 12          | 12           |


### PR DESCRIPTION
This improves the address collection in  couple of ways

* simplified algorithm to determine the visible address parts, it now mainly relies on spatial containment
* ensure that the chosen addresses are consistent with respect to containing each other (fixes #1400)
* put place areas into the address hierarchy according to how areas contain each other (fixes admin level/place area mixture in Russia)
* remove address rank 25 from street level addresses (fixes an issues where squares show up in a street-level address)
* set the `fromarea` column correctly again (we will need that later for issue #328)

Also adds tests for the issues fixed. See individual commits for details.