### PR TITLE
add country-specific address ranks for Russia

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -137,6 +137,17 @@
           "administrative10" : 24
       }
   }
+},
+{ "countries" : ["ru"],
+  "tags" : {
+      "place" : {
+          "municipality" : 18
+      },
+      "boundary" : {
+          "administrative7" : [13, 0],
+          "administrative8" : 14
+      }
+  }
 }
 ]
 


### PR DESCRIPTION
Removes admin level 7, which should not exist and promotes admin level 8 to municipality level.

place=municipality is only used for boroughs of St. Petersburg, so demote to level 18.

Fixes #926.