### PR TITLE
Add support for finding pg_config in Postgresql repos

### DIFF
--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,5 +1,14 @@
 # just use the pgxs makefile
-find_program(PG_CONFIG pg_config)
+
+foreach(suffix ${PostgreSQL_ADDITIONAL_VERSIONS} "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3")
+    list(APPEND PG_CONFIG_HINTS
+         "/usr/pgsql-${suffix}/bin")
+endforeach()
+
+find_program(PG_CONFIG pg_config HINTS ${PG_CONFIG_HINTS})
+
+
+
 execute_process(COMMAND ${PG_CONFIG} --pgxs
             OUTPUT_VARIABLE PGXS
             OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/vagrant/Install-on-Centos-7.sh
+++ b/vagrant/Install-on-Centos-7.sh
@@ -42,11 +42,7 @@
                         python3-pip python3-setuptools python3-devel \
                         expat-devel zlib-devel
 
-    # make sure pg_config gets found
-    echo 'PATH=/usr/pgsql-11/bin/:$PATH' >> ~/.bash_profile
-    source ~/.bash_profile
-
-    pip3 install --user psycopg2 pytidylib
+    pip3 install --user psycopg2
 
 
 #

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -35,11 +35,7 @@
                         python3-pip python3-setuptools python3-devel \
                         expat-devel zlib-devel
 
-    # make sure pg_config gets found
-    echo 'PATH=/usr/pgsql-12/bin:$PATH' >> ~/.bash_profile
-    source ~/.bash_profile
-
-    pip3 install --user psycopg2 pytidylib
+    pip3 install --user psycopg2
 
 
 #


### PR DESCRIPTION
It uses the same PostgreSQL_ADDITIONAL_VERSIONS variable as
osm2pgsql so that setting that should be sufficient to make
it work.