### PR TITLE
Improve secondary result ordering for administrative boundaries

### DIFF
--- a/lib/ClassTypes.php
+++ b/lib/ClassTypes.php
@@ -275,6 +275,7 @@ function getImportance($aPlace)
 
     if ($aWithImportance === null) {
         $aWithImportance = array_flip(array(
+                                           'boundary:administrative',
                                            'place:country',
                                            'place:state',
                                            'place:province',


### PR DESCRIPTION
This improves two things with regard to result ordering:

* Make sure that `boundary=administrative` comes before anything else when all other things are equal.
* For places that don't  have a secondary importance from their address terms (like countries, which don't have an address), use their importance for secondary result ordering as well. So far they got a hardcoded score that was very bad.

Fixes #2023.