### PR TITLE
Merge places into address lists referred to by addr:* tags but not computed by Nominatim

### DIFF
--- a/sql/functions/normalization.sql
+++ b/sql/functions/normalization.sql
@@ -446,7 +446,7 @@ BEGIN
     FROM (SELECT skeys(address) as k, svals(address) as v) a
    WHERE not addr_ids_from_name(v) && parent_address_vector
          AND k not in ('country', 'street', 'place', 'postcode',
-                       'housenumber', 'streetnumber', 'consriptionnumber');
+                       'housenumber', 'streetnumber', 'conscriptionnumber');
 
   -- Compute all search terms from the addr: tags.
   IF filtered_address IS NOT NULL THEN

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -813,13 +813,17 @@ BEGIN
 
       END IF;
 
-      IF NOT %REVERSE-ONLY% THEN
+      IF array_length(name_vector, 1) is not NULL
+         OR inherited_address is not NULL OR NEW.address is not NULL
+      THEN
         SELECT * INTO name_vector, nameaddress_vector
-          FROM create_poi_search_terms(NEW.parent_place_id,
+          FROM create_poi_search_terms(NEW.place_id,
+                                       NEW.partition, NEW.parent_place_id,
                                        inherited_address || NEW.address,
-                                       NEW.housenumber, name_vector);
+                                       NEW.country_code, NEW.housenumber,
+                                       name_vector, NEW.centroid);
 
-        IF array_length(name_vector, 1) is not NULL THEN
+        IF not %REVERSE-ONLY% AND array_length(name_vector, 1) is not NULL THEN
           INSERT INTO search_name (place_id, search_rank, address_rank,
                                    importance, country_code, name_vector,
                                    nameaddress_vector, centroid)

--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -254,6 +254,7 @@ CREATE OR REPLACE FUNCTION insert_addresslines(obj_place_id BIGINT,
                                                maxrank SMALLINT,
                                                address HSTORE,
                                                geometry GEOMETRY,
+                                               country TEXT,
                                                OUT parent_place_id BIGINT,
                                                OUT postcode TEXT,
                                                OUT nameaddress_vector INT[])
@@ -265,45 +266,49 @@ DECLARE
   current_boundary GEOMETRY := NULL;
   current_node_area GEOMETRY := NULL;
 
-  location RECORD;
-  addr_item RECORD;
+  parent_place_rank INT := 0;
+  addr_place_ids BIGINT[];
 
-  isin_tokens INT[];
+  location RECORD;
 BEGIN
   parent_place_id := 0;
   nameaddress_vector := '{}'::int[];
-  isin_tokens := '{}'::int[];
 
-  ---- convert address store to array of tokenids
-  IF address IS NOT NULL THEN
-    FOR addr_item IN SELECT * FROM each(address)
-    LOOP
-      IF addr_item.key IN ('city', 'tiger:county', 'state', 'suburb', 'province',
-                           'district', 'region', 'county', 'municipality',
-                           'hamlet', 'village', 'subdistrict', 'town',
-                           'neighbourhood', 'quarter', 'parish')
-      THEN
-        isin_tokens := array_merge(isin_tokens,
-                                   word_ids_from_name(addr_item.value));
-        IF NOT %REVERSE-ONLY% THEN
-          nameaddress_vector := array_merge(nameaddress_vector,
-                                            addr_ids_from_name(addr_item.value));
+  address_havelevel := array_fill(false, ARRAY[maxrank]);
+
+  FOR location IN
+    SELECT * FROM get_places_for_addr_tags(partition, geometry,
+                                                   address, country)
+    ORDER BY rank_address, distance, isguess desc
+  LOOP
+    IF NOT %REVERSE-ONLY% THEN
+      nameaddress_vector := array_merge(nameaddress_vector,
+                                        location.keywords::int[]);
+    END IF;
+
+    IF location.place_id is not null THEN
+      location_isaddress := not address_havelevel[location.rank_address];
+      IF not address_havelevel[location.rank_address] THEN
+        address_havelevel[location.rank_address] := true;
+        IF parent_place_rank < location.rank_address THEN
+          parent_place_id := location.place_id;
+          parent_place_rank := location.rank_address;
         END IF;
       END IF;
-    END LOOP;
-  END IF;
-  IF NOT %REVERSE-ONLY% THEN
-    nameaddress_vector := array_merge(nameaddress_vector, isin_tokens);
-  END IF;
 
-  ---- now compute the address terms
-  FOR i IN 1..maxrank LOOP
-    address_havelevel[i] := false;
+      INSERT INTO place_addressline (place_id, address_place_id, fromarea,
+                                     isaddress, distance, cached_rank_address)
+        VALUES (obj_place_id, location.place_id, not location.isguess,
+                true, location.distance, location.rank_address);
+
+      addr_place_ids := array_append(addr_place_ids, location.place_id);
+    END IF;
   END LOOP;
 
   FOR location IN
     SELECT * FROM getNearFeatures(partition, geometry, maxrank)
-    ORDER BY rank_address, isin_tokens && keywords desc, isguess asc,
+    WHERE addr_place_ids is null or not addr_place_ids @> ARRAY[place_id]
+    ORDER BY rank_address, isguess asc,
              distance *
                CASE WHEN rank_address = 16 AND rank_search = 15 THEN 0.2
                     WHEN rank_address = 16 AND rank_search = 16 THEN 0.25
@@ -920,7 +925,8 @@ BEGIN
                                     NEW.address,
                                     CASE WHEN (NEW.rank_address = 0 or
                                                NEW.rank_search between 26 and 29)
-                                         THEN NEW.geometry ELSE NEW.centroid END)
+                                         THEN NEW.geometry ELSE NEW.centroid END,
+                                    NEW.country_code)
     INTO NEW.parent_place_id, NEW.postcode, nameaddress_vector;
 
   --DEBUG: RAISE WARNING 'RETURN insert_addresslines: %, %, %', NEW.parent_place_id, NEW.postcode, nameaddress_vector;

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -176,7 +176,7 @@ BEGIN
       INTO parent
       WHERE name_vector && isin_token
             AND centroid && ST_Expand(point, 0.015)
-            AND search_rank between 26 and 27
+            AND address_rank between 26 and 27
       ORDER BY ST_Distance(centroid, point) ASC limit 1;
     RETURN parent;
   END IF;
@@ -224,8 +224,8 @@ BEGIN
   IF in_partition = -partition- THEN
     DELETE FROM search_name_-partition- values WHERE place_id = in_place_id;
     IF in_rank_address > 0 THEN
-      INSERT INTO search_name_-partition- (place_id, search_rank, address_rank, name_vector, centroid)
-        values (in_place_id, in_rank_search, in_rank_address, in_name_vector, in_geometry);
+      INSERT INTO search_name_-partition- (place_id, address_rank, name_vector, centroid)
+        values (in_place_id, in_rank_address, in_name_vector, in_geometry);
     END IF;
     RETURN TRUE;
   END IF;

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -72,8 +72,6 @@ BEGIN
   FOR item IN
     SELECT (get_addr_tag_rank(key, country)).*, key, name FROM
       (SELECT skeys(address) as key, svals(address) as name) x
-        WHERE key not in ('country', 'postcode', 'housenumber',
-                          'conscriptionnumber', 'streetnumber')
   LOOP
    IF item.from_rank is null THEN
      CONTINUE;

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -87,7 +87,7 @@ BEGIN
           AND rank_address between item.from_rank and item.to_rank
           AND word_ids_from_name(item.name) && keywords
         GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
-        ORDER BY ST_Intersects(ST_Collect(geometry), feature), distance LIMIT 1;
+        ORDER BY bool_or(ST_Intersects(geometry, feature)), distance LIMIT 1;
       IF r.place_id is null THEN
         -- If we cannot find a place for the term, just return the
         -- search term for the given name. That ensures that the address

--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -10,8 +10,8 @@ CREATE TYPE nearfeaturecentr AS (
   centroid GEOMETRY
 );
 
-        -- feature intersects geoemtry
-        -- for areas and linestrings they must touch at least along a line
+-- feature intersects geoemtry
+-- for areas and linestrings they must touch at least along a line
 CREATE OR REPLACE FUNCTION is_relevant_geometry(de9im TEXT, geom_type TEXT)
 RETURNS BOOLEAN
 AS $$
@@ -39,8 +39,10 @@ BEGIN
 
 -- start
   IF in_partition = -partition- THEN
-    FOR r IN 
-      SELECT place_id, keywords, rank_address, rank_search, min(ST_Distance(feature, centroid)) as distance, isguess, postcode, centroid
+    FOR r IN
+      SELECT place_id, keywords, rank_address, rank_search,
+             min(ST_Distance(feature, centroid)) as distance,
+             isguess, postcode, centroid
       FROM location_area_large_-partition-
       WHERE geometry && feature
         AND is_relevant_geometry(ST_Relate(geometry, feature), ST_GeometryType(feature))
@@ -55,6 +57,56 @@ BEGIN
 
   RAISE EXCEPTION 'Unknown partition %', in_partition;
 END
+$$
+LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE FUNCTION get_places_for_addr_tags(in_partition SMALLINT,
+                                                    feature GEOMETRY,
+                                                    address HSTORE, country TEXT)
+  RETURNS SETOF nearfeaturecentr
+  AS $$
+DECLARE
+  r nearfeaturecentr%rowtype;
+  item RECORD;
+BEGIN
+  FOR item IN
+    SELECT (get_addr_tag_rank(key, country)).*, key, name FROM
+      (SELECT skeys(address) as key, svals(address) as name) x
+        WHERE key not in ('country', 'postcode', 'housenumber',
+                          'conscriptionnumber', 'streetnumber')
+  LOOP
+   IF item.from_rank is null THEN
+     CONTINUE;
+   END IF;
+
+-- start
+    IF in_partition = -partition- THEN
+        SELECT place_id, keywords, rank_address, rank_search,
+               min(ST_Distance(feature, centroid)) as distance,
+               isguess, postcode, centroid INTO r
+        FROM location_area_large_-partition-
+        WHERE geometry && ST_Expand(feature, item.extent)
+          AND rank_address between item.from_rank and item.to_rank
+          AND word_ids_from_name(item.name) && keywords
+        GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
+        ORDER BY ST_Intersects(ST_Collect(geometry), feature), distance LIMIT 1;
+      IF r.place_id is null THEN
+        -- If we cannot find a place for the term, just return the
+        -- search term for the given name. That ensures that the address
+        -- element can still be searched for, even though it will not be
+        -- displayed.
+        RETURN NEXT ROW(null, addr_ids_from_name(item.name), null, null,
+                        null, null, null, null)::nearfeaturecentr;
+      ELSE
+        RETURN NEXT r;
+      END IF;
+      CONTINUE;
+    END IF;
+-- end
+
+    RAISE EXCEPTION 'Unknown partition %', in_partition;
+  END LOOP;
+END;
 $$
 LANGUAGE plpgsql STABLE;
 
@@ -153,7 +205,7 @@ BEGIN
       FROM search_name_-partition-
       WHERE name_vector && isin_token
             AND centroid && ST_Expand(point, 0.04)
-            AND search_rank between 16 and 25
+            AND address_rank between 16 and 25
       ORDER BY ST_Distance(centroid, point) ASC limit 1;
     RETURN parent;
   END IF;
@@ -163,7 +215,6 @@ BEGIN
 END
 $$
 LANGUAGE plpgsql STABLE;
-
 
 create or replace function insertSearchName(
   in_partition INTEGER, in_place_id BIGINT, in_name_vector INTEGER[],

--- a/sql/partition-tables.src.sql
+++ b/sql/partition-tables.src.sql
@@ -1,7 +1,6 @@
 drop table IF EXISTS search_name_blank CASCADE;
 CREATE TABLE search_name_blank (
   place_id BIGINT,
-  search_rank smallint,
   address_rank smallint,
   name_vector integer[],
   centroid GEOMETRY(Geometry, 4326)
@@ -15,8 +14,8 @@ CREATE INDEX idx_location_area_large_-partition-_geometry ON location_area_large
 
 CREATE TABLE search_name_-partition- () INHERITS (search_name_blank) {ts:address-data};
 CREATE INDEX idx_search_name_-partition-_place_id ON search_name_-partition- USING BTREE (place_id) {ts:address-index};
-CREATE INDEX idx_search_name_-partition-_centroid_street ON search_name_-partition- USING GIST (centroid) {ts:address-index} where search_rank between 26 and 27;
-CREATE INDEX idx_search_name_-partition-_centroid_place ON search_name_-partition- USING GIST (centroid) {ts:address-index} where search_rank between 2 and 25;
+CREATE INDEX idx_search_name_-partition-_centroid_street ON search_name_-partition- USING GIST (centroid) {ts:address-index} where address_rank between 26 and 27;
+CREATE INDEX idx_search_name_-partition-_centroid_place ON search_name_-partition- USING GIST (centroid) {ts:address-index} where address_rank between 2 and 25;
 
 DROP TABLE IF EXISTS location_road_-partition-;
 CREATE TABLE location_road_-partition- (

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -331,10 +331,10 @@ Feature: Address computation
             | osm | class    | type           | admin | name  | geometry    |
             | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
             | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
-        And the named places
-            | osm | class   | type    | addr+city | geometry |
-            | W1  | highway | primary | Right     | 8,9      |
-            | N1  | amenity | cafe    | Left      | 9        |
+        And the places
+            | osm | class   | type    | name      | addr+city | geometry |
+            | W1  | highway | primary | Wonderway | Right     | 8,9      |
+            | N1  | amenity | cafe    | Bolder    | Left      | 9        |
         When importing
         Then place_addressline contains
            | object | address | isaddress |
@@ -343,4 +343,8 @@ Feature: Address computation
         And place_addressline doesn't contain
            | object | address |
            | W1     | R1      |
+        When searching for "Bolder"
+        Then results contain
+           | osm_type | osm_id | name                    |
+           | N        | 1      | Bolder, Wonderway, Left |
 

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -298,3 +298,26 @@ Feature: Address computation
             | object | address |
             | W1     | W2      |
 
+    Scenario: addr:* tags are honored even when the place is outside
+        Given the grid
+            | 1 |   | 2 |   |   | 5 |
+            |   |   |   | 8 | 9 |   |
+            | 4 |   | 3 |   |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | addr+city | geometry |
+            | W1  | highway | primary | Left      | 8,9      |
+            | W2  | highway | primary | Right     | 8,9      |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | True      |
+           | W1     | R2      | False     |
+           | W2     | R2      | True      |
+        And place_addressline doesn't contain
+           | object | address |
+           | W2     | R1      |
+

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -298,7 +298,7 @@ Feature: Address computation
             | object | address |
             | W1     | W2      |
 
-    Scenario: addr:* tags are honored even when the place is outside
+    Scenario: addr:* tags are honored even when a street is far away from the place
         Given the grid
             | 1 |   | 2 |   |   | 5 |
             |   |   |   | 8 | 9 |   |
@@ -320,4 +320,27 @@ Feature: Address computation
         And place_addressline doesn't contain
            | object | address |
            | W2     | R1      |
+
+
+    Scenario: addr:* tags are honored even when a POI is far away from the place
+        Given the grid
+            | 1 |   | 2 |   |   | 5 |
+            |   |   |   | 8 | 9 |   |
+            | 4 |   | 3 |   |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the named places
+            | osm | class   | type    | addr+city | geometry |
+            | W1  | highway | primary | Right     | 8,9      |
+            | N1  | amenity | cafe    | Left      | 9        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R2      | True      |
+           | N1     | R1      | True      |
+        And place_addressline doesn't contain
+           | object | address |
+           | W1     | R1      |
 

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -348,3 +348,52 @@ Feature: Address computation
            | osm_type | osm_id | name                    |
            | N        | 1      | Bolder, Wonderway, Left |
 
+    Scenario: addr:* tags do not produce addresslines when the parent has the address part
+        Given the grid
+            | 1 |   |   | 5 |
+            |   | 8 | 9 |   |
+            | 4 |   |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Outer | (1,5,6,4,1) |
+        And the places
+            | osm | class   | type    | name      | addr+city | geometry |
+            | W1  | highway | primary | Wonderway | Outer     | 8,9      |
+            | N1  | amenity | cafe    | Bolder    | Outer     | 9        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | True      |
+        And place_addressline doesn't contain
+           | object | address |
+           | N1     | R1      |
+        When searching for "Bolder"
+        Then results contain
+           | osm_type | osm_id | name                     |
+           | N        | 1      | Bolder, Wonderway, Outer |
+
+    Scenario: addr:* tags on outside do not produce addresslines when the parent has the address part
+        Given the grid
+            | 1 |   | 2 |   |   | 5 |
+            |   |   |   | 8 | 9 |   |
+            | 4 |   | 3 |   |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | name      | addr+city | geometry |
+            | W1  | highway | primary | Wonderway | Left      | 8,9      |
+            | N1  | amenity | cafe    | Bolder    | Left      | 9        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | True      |
+           | W1     | R2      | False     |
+        And place_addressline doesn't contain
+           | object | address |
+           | N1     | R1      |
+        When searching for "Bolder"
+        Then results contain
+           | osm_type | osm_id | name                    |
+           | N        | 1      | Bolder, Wonderway, Left |

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -185,16 +185,15 @@ Feature: Creation of search terms
          | object | name_vector | nameaddress_vector |
          | N1     | foo         | the road |
 
-    Scenario: Some addr: tags are added to address when the name exists
+    Scenario: Some addr: tags are added to address
         Given the scene roads-with-pois
         And the places
          | osm | class   | type        | name     | geometry |
-         | N1  | place   | state       | new york | 80 80 |
          | N2  | place   | city        | bonn     | 81 81 |
          | N3  | place   | suburb      | smalltown| 80 81 |
         And the named places
-         | osm | class   | type    | addr+city | addr+state | addr+suburb | geometry |
-         | W1  | highway | service | bonn      | New York   | Smalltown   | :w-north |
+         | osm | class   | type    | addr+city | addr+municipality | addr+suburb | geometry |
+         | W1  | highway | service | bonn      | New York          | Smalltown   | :w-north |
         When importing
         Then search_name contains
          | object | nameaddress_vector |


### PR DESCRIPTION
This is the last building block towards full handling of addr:* tags.

With this PR the addr:* tags are no longer just added to the search terms but they get the full address treatment. That means that we try to look up a matching place in OSM (with a much larger search radius than the normal address building algorithm) and add the results to the place_addressline table. As a result, the addr:* terms are now displayed as part of the address. As we use the information from OSM entries, they also come with translations. The drawback is that the addr:* tags (with the expressed exception of addr:place) need to have a corresponding place in OSM.

To make the algorithm work for rank 30, POIs need to be allowed their own entries into the place_addressline table instead of only using the ones of their parents. To ensure that the table size doesn't explode, entries are only added, when the parent misses an entry for an addr:* tag. When retrieving the address, the entries for the parent and the POI are mixed and merged on the fly.

This PR also contains a cleanup of the `search_name_*` tables. The rank_search column is removed and the last uses converted to using the more correct rank_address. This change should be backward compatible with existing installations.

Fixes #148.