### PR TITLE
POIs with unknown addr:place must add parent name to address

### DIFF
--- a/sql/functions/normalization.sql
+++ b/sql/functions/normalization.sql
@@ -518,16 +518,14 @@ BEGIN
     addr_place_ids := addr_ids_from_name(address->'place');
     IF not addr_place_ids <@ parent_name_vector THEN
       -- addr:place tag exists without a corresponding place. Mix in addr:place
-      -- in the address and drop the name from the parent. This would only be
-      -- the street name of the nearest street.
-      nameaddress_vector := array_merge(nameaddress_vector, addr_place_ids);
+      -- in the address.
       name_vector := ARRAY[getorcreate_name_id(housenumber)];
+      nameaddress_vector := array_merge(nameaddress_vector, addr_place_ids);
     END IF;
-  ELSE
-    nameaddress_vector := array_merge(nameaddress_vector, parent_name_vector);
   END IF;
 
-  -- The address vector always gets merged in.
+  -- Merge the parent name and address.
+  nameaddress_vector := array_merge(nameaddress_vector, parent_name_vector);
   nameaddress_vector := array_merge(nameaddress_vector, parent_address_vector);
 
 END;

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -56,7 +56,7 @@ Feature: Creation of search terms
         When importing
         Then search_name has no entry for N1
 
-    Scenario: Unnamed POIs doesn't inherit parent name when unknown addr:place is present
+    Scenario: Unnamed POIs inherit parent name when unknown addr:place is present
         Given the scene roads-with-pois
         And the places
          | osm | class   | type        | housenr | addr+place | geometry |
@@ -66,15 +66,18 @@ Feature: Creation of search terms
          | W1  | highway | residential | Rose Street  | :w-north |
          | N2  | place   | city        | Strange Town | :p-N1 |
         When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | N2              |
         Then search_name contains
          | object | name_vector | nameaddress_vector |
-         | N1     | #23         | Walltown |
+         | N1     | #23         | Walltown, Strange, Town |
         When searching for "23 Rose Street"
         Then exactly 1 results are returned
         And results contain
          | osm_type | osm_id | name |
          | W        | 1      | Rose Street, Strange Town |
-        When searching for "23 Walltown"
+        When searching for "23 Walltown, Strange Town"
         Then results contain
          | osm_type | osm_id | name |
          | N        | 1      | 23, Walltown, Strange Town |


### PR DESCRIPTION
The previous behaviour was a left-over from a former version where such POIs parented to the street. Now that they parent to places, it should be included.