### PR TITLE
Admin levels 8 and 10 of the Netherlands are municipal / city

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -164,6 +164,14 @@
           "administrative8" : 14
       }
   }
+},
+{ "countries" : [ "nl" ],
+  "tags" : {
+      "boundary" : {
+          "administrative8" : 14,
+          "administrative10" : 16
+      }
+  }
 }
 ]
 


### PR DESCRIPTION
Admin levels in the Netherlands are little different. See https://wiki.openstreetmap.org/wiki/Template:Admin_level_11

For example, this is a small village: https://www.openstreetmap.org/relation/334641. Definitly not a suburb/neighbourhood/hamlet. This one should be rank 16
It's part of this municipality: https://www.openstreetmap.org/relation/418760. This one should be rank 14

I tried this change for a Photon import and the result is correct.