### PR TITLE
viewbox arguments are no longer accepter "in any order"

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -116,7 +116,7 @@ Limit the number of returned results. (Default: 10, Maximum: 50)
 * `viewbox=<x1>,<y1>,<x2>,<y2>`
 
 The preferred area to find search results. Any two corner points of the box
-are accepted in any order as long as they span a real box. `x` is longitude,
+are accepted as long as they span a real box. `x` is longitude,
 `y` is latitude.
 
 


### PR DESCRIPTION
Order should be longitude, then latitude