### PR TITLE
Improve handling of multi-word partials in SearchDescription

### DIFF
--- a/lib/Geocode.php
+++ b/lib/Geocode.php
@@ -650,6 +650,8 @@ class Geocode
                     $this->oNormalizer
                 );
 
+                $oCtx->setFullNameWords($oValidTokens->getFullWordIDs());
+
                 // Try more interpretations for Tokens that could not be matched.
                 foreach ($aTokens as $sToken) {
                     if ($sToken[0] == ' ' && !$oValidTokens->contains($sToken)) {

--- a/lib/SearchContext.php
+++ b/lib/SearchContext.php
@@ -32,7 +32,18 @@ class SearchContext
     public $sqlCountryList = '';
     /// List of place IDs to exclude (as SQL).
     private $sqlExcludeList = '';
+    /// Subset of word ids of full words in the query.
+    private $aFullNameWords = array();
 
+    public function setFullNameWords($aWordList)
+    {
+        $this->aFullNameWords = $aWordList;
+    }
+
+    public function getFullNameTerms()
+    {
+        return $this->aFullNameWords;
+    }
 
     /**
      * Check if a reference point is defined.

--- a/lib/TokenList.php
+++ b/lib/TokenList.php
@@ -80,6 +80,21 @@ class TokenList
         return isset($this->aTokens[$sWord]) ? $this->aTokens[$sWord] : array();
     }
 
+    public function getFullWordIDs()
+    {
+        $ids = array();
+
+        foreach($this->aTokens as $aTokenList) {
+            foreach($aTokenList as $oToken) {
+                if (is_a($oToken, '\Nominatim\Token\Word') && !$oToken->bPartial) {
+                    $ids[$oToken->iId] = $oToken->iId;
+                }
+            }
+        }
+
+        return $ids;
+    }
+
     /**
      * Add token information from the word table in the database.
      *
@@ -151,7 +166,8 @@ class TokenList
                 $oToken = new Token\Word(
                     $iId,
                     $aWord['word_token'][0] != ' ',
-                    (int) $aWord['count']
+                    (int) $aWord['count'],
+                    substr_count($aWord['word_token'], ' ')
                 );
             }
 

--- a/lib/TokenList.php
+++ b/lib/TokenList.php
@@ -84,8 +84,8 @@ class TokenList
     {
         $ids = array();
 
-        foreach($this->aTokens as $aTokenList) {
-            foreach($aTokenList as $oToken) {
+        foreach ($this->aTokens as $aTokenList) {
+            foreach ($aTokenList as $oToken) {
                 if (is_a($oToken, '\Nominatim\Token\Word') && !$oToken->bPartial) {
                     $ids[$oToken->iId] = $oToken->iId;
                 }

--- a/lib/TokenWord.php
+++ b/lib/TokenWord.php
@@ -13,12 +13,15 @@ class Word
     public $bPartial;
     /// Number of appearances in the database.
     public $iSearchNameCount;
+    /// Number of terms in the word.
+    public $iTermCount;
 
-    public function __construct($iId, $bPartial, $iSearchNameCount)
+    public function __construct($iId, $bPartial, $iSearchNameCount, $iTermCount)
     {
         $this->iId = $iId;
         $this->bPartial = $bPartial;
         $this->iSearchNameCount = $iSearchNameCount;
+        $this->iTermCount = $iTermCount;
     }
 
     public function debugInfo()

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -121,6 +121,6 @@ class TokenTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(new Token\HouseNumber(999, '1051')), $TL->get('1051'));
         $this->assertEquals(array(new Token\Country(999, 'de')), $TL->get('alemagne'));
         $this->assertEquals(array(new Token\Postcode(999, '64286')), $TL->get('64286'));
-        $this->assertEquals(array(new Token\Word(999, true, 533)), $TL->get('darmstadt'));
+        $this->assertEquals(array(new Token\Word(999, true, 533, 0)), $TL->get('darmstadt'));
     }
 }


### PR DESCRIPTION
Multi-word partial terms had an undue advantage over separate partial terms because they only need to pay the penalty once. This changes the behaviour by setting the penalty according to the number of words in the token. This should get rid of search interpretations with low chance of matching.

This also fixes handling of exact term matching. We now match against all exact terms of the query, not just a couple of them collectedwhile building the interpretations. 

Also adds a penalty to very short postcodes.