### PR TITLE
Improve finding addresses that have their own search_name entry because of unknown addr:* parts

### DIFF
--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -247,6 +247,15 @@ class SearchDescription
                     $oSearch->iSearchRank++;
                 }
                 $aNewSearches[] = $oSearch;
+                // Housenumbers may appear in the name when the place has its own
+                // address terms.
+                if (($this->iNamePhrase >= 0 || empty($this->aName)) && empty($this->aAddress)) {
+                    $oSearch = clone $this;
+                    $oSearch->iSearchRank++;
+                    $oSearch->aAddress = $this->aName;
+                    $oSearch->aName = array($oSearchTerm->iId => $oSearchTerm->iId);
+                    $aNewSearches[] = $oSearch;
+                }
             }
         } elseif ($sPhraseType == ''
                   && is_a($oSearchTerm, '\Nominatim\Token\SpecialTerm')

--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -249,7 +249,10 @@ class SearchDescription
                 $aNewSearches[] = $oSearch;
                 // Housenumbers may appear in the name when the place has its own
                 // address terms.
-                if (($this->iNamePhrase >= 0 || empty($this->aName)) && empty($this->aAddress)) {
+                if ($oSearchTerm->iId !== null
+                    && ($this->iNamePhrase >= 0 || empty($this->aName))
+                    && empty($this->aAddress)
+                   ) {
                     $oSearch = clone $this;
                     $oSearch->iSearchRank++;
                     $oSearch->aAddress = $this->aName;

--- a/test/bdd/steps/db_ops.py
+++ b/test/bdd/steps/db_ops.py
@@ -487,8 +487,8 @@ def check_search_name_contents(context, exclude):
                                    """,
                                    (terms, words))
                     if not exclude:
-                        ok_(subcur.rowcount >= len(terms),
-                            "No word entry found for " + row[h])
+                        ok_(subcur.rowcount >= len(terms) + len(words),
+                            "No word entry found for " + row[h] + ". Entries found: " + str(subcur.rowcount))
                     for wid in subcur:
                         if exclude:
                             assert_not_in(wid[0], res[h],

--- a/utils/query.php
+++ b/utils/query.php
@@ -58,6 +58,7 @@ if (!$oParams->hasSetAny($aSearchParams)) {
 $oGeocode = new Nominatim\Geocode($oDB);
 
 $oGeocode->setLanguagePreference($oParams->getPreferredLanguages(false));
+$oGeocode->setReverseInPlan(true);
 $oGeocode->loadParamArray($oParams);
 
 if ($oParams->getBool('search')) {


### PR DESCRIPTION
So far, when adding a rank-30 term to the search_name table because it has addr: parts that differ from its parent street, we have added the house number as the 'name term' to search for. Turns out that this is not the best of ideas. House numbers need special handling because they may appear after the street term. So they may appear in second position in the search query while normal names can never do that. Consequently, we are able to find '40, Main St, Town' but not 'Main St 40, Town' right now.

This switches to using the housenumber token as the name term instead. House number tokens can get special handling when building the search query and we can explicitly cover the case where they come after the street.

The main disadvantage is that this once more increases the numbers of possible search interpretation of which we have already too many.

Added test cases that now hopefully cover all the different ways an address with unknown addr:* parts may be searched for.