### PR TITLE
Filter postcodes by search rank when adding to address list

### DIFF
--- a/sql/partition-functions.src.sql
+++ b/sql/partition-functions.src.sql
@@ -47,6 +47,9 @@ BEGIN
       WHERE geometry && feature
         AND is_relevant_geometry(ST_Relate(geometry, feature), ST_GeometryType(feature))
         AND rank_address < maxrank
+            -- Postcodes currently still use rank_search to define for which
+            -- features they are relevant.
+        AND not (rank_address in (5, 11) and rank_search > maxrank)
       GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
     LOOP
       RETURN NEXT r;


### PR DESCRIPTION
The post codes are the last items that do not fit the new address ranking scheme. In particular, the search rank is still relevant for choosing if a postcode should be included into the address terms. Filter out irrelevant postcodes in getNearFeatures() already, to avoid having to check for geometry relation.

Not having this check causes a bit of an update havoc for existing installations in conjunction with the fact that until recently all place=postcode ended up in the location_area_large_* tables. If you have updated to master in the last couple of weeks on an _existing database_, then you'll definitely need this change as well or the location_area_large_* tables will start to collect a lot of garbage postcodes.