### PR TITLE
Compute address for POIs on the fly

### DIFF
--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -397,3 +397,35 @@ Feature: Address computation
         Then results contain
            | osm_type | osm_id | name                    |
            | N        | 1      | Bolder, Wonderway, Left |
+
+    Scenario: POIs can correct address parts on the fly
+        Given the grid
+            | 1 |   |   |   |  2 |   | 5 |
+            |   |   |   | 9 |    | 8 |   |
+            | 4 |   |   |   |  3 |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | name      | geometry |
+            | W1  | highway | primary | Wonderway | 2,3      |
+            | N1  | amenity | cafe    | Bolder    | 9        |
+            | N2  | amenity | cafe    | Leftside  | 8        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | False     |
+           | W1     | R2      | True      |
+        And place_addressline doesn't contain
+           | object | address |
+           | N1     | R1      |
+           | N2     | R2      |
+        When searching for "Bolder"
+        Then results contain
+           | osm_type | osm_id | name                    |
+           | N        | 1      | Bolder, Wonderway, Left |
+        When searching for "Leftside"
+        Then results contain
+           | osm_type | osm_id | name                       |
+           | N        | 2      | Leftside, Wonderway, Right |

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -5,11 +5,11 @@ Feature: Address computation
     Scenario: place nodes are added to the address when they are close enough
         Given the 0.002 grid
             | 2 |  |  |  |  |  | 1 |  | 3 |
-        And the named places
-            | osm | class | type     | geometry |
-            | N1  | place | square   | 1 |
-            | N2  | place | hamlet   | 2 |
-            | N3  | place | hamlet   | 3 |
+        And the places
+            | osm | class | type     | name      | geometry |
+            | N1  | place | square   | Square    | 1 |
+            | N2  | place | hamlet   | West Farm | 2 |
+            | N3  | place | hamlet   | East Farm | 3 |
         When importing
         Then place_addressline contains
             | object | address | fromarea |
@@ -17,6 +17,10 @@ Feature: Address computation
         Then place_addressline doesn't contain
             | object | address |
             | N1     | N2      |
+        When searching for "Square"
+        Then results contain
+           | osm_type | osm_id | name              |
+           | N        | 1      | Square, East Farm |
 
     Scenario: given two place nodes, the closer one wins for the address
         Given the grid


### PR DESCRIPTION
Rank 30 objects usually use the address parts of their parent. When the parent has address parts that are areas but not marked as isaddress, then the parent might go through multiple administrative areas. In that case recheck if the right area has been chosen for the object in question instead of relying on isaddress. Note that we really only have to do the recomputation in the
case of 'isarea = True and isaddress = False' which hopefully keeps the number of additional geometric operations we have to do
to a minimum.

There is one more special case to be taken into account here: a street may go through two administrative areas and a house along that street is placed in one of the area while the addr:* tags says it belongs to the other. In that case we must not switch the isaddress to the one it is situated. To avoid that recheck the address names against the name of the ara. That is not perfect but should cover most cases.

There is still a bit of a pathological case where a POI is completely contained in a different administrative area than the street it belongs to. `addr:*` tags will help in this case to correct the address of the POI but all boundaries that are not explicitly mentioned in the address tags still appear wrongly. See the case of the [Monningstraße 126, 45478 Mülheim](https://nominatim.openstreetmap.org/search.php?q=Monningstra%C3%9Fe+126%2C+45478+M%C3%BClheim) from #950. The city part is now correctly shown as 'Mülheim' but there is still 'Duisburg-Mitte' in the address from its parent street.

Fixes #328.