### PR TITLE
fix use of term count in partial terms

### DIFF
--- a/lib/SearchDescription.php
+++ b/lib/SearchDescription.php
@@ -344,7 +344,7 @@ class SearchDescription
         ) {
             if ($oSearchTerm->iSearchNameCount < CONST_Max_Word_Frequency) {
                 $oSearch = clone $this;
-                $oSearch->iSearchRank += $oSearchTerm->iTermCount;
+                $oSearch->iSearchRank += $oSearchTerm->iTermCount + 1;
                 if (empty($this->aName)) {
                     $oSearch->iSearchRank++;
                 }
@@ -355,7 +355,7 @@ class SearchDescription
                 $aNewSearches[] = $oSearch;
             } else {
                 $oSearch = clone $this;
-                $oSearch->iSearchRank++;
+                $oSearch->iSearchRank += $oSearchTerm->iTermCount + 1;
                 $oSearch->aAddressNonSearch[$iWordID] = $iWordID;
                 if (!empty($aFullTokens)) {
                     $oSearch->iSearchRank++;


### PR DESCRIPTION
Term count for partial words is one less than the actual number of words. Take that into account when adding to the search rank.

Fixes #2081.