### PR TITLE
Place nodes can only be linked once against boundaries

### DIFF
--- a/sql/functions/placex_triggers.sql
+++ b/sql/functions/placex_triggers.sql
@@ -183,6 +183,7 @@ BEGIN
       WHERE make_standard_name(name->'name') = bnd_name
         AND placex.class = 'place' AND placex.type = bnd.extratags->'place'
         AND placex.osm_type = 'N'
+        AND placex.linked_place_id is null
         AND placex.rank_search < 26 -- needed to select the right index
         AND _st_covers(bnd.geometry, placex.geometry)
     LOOP
@@ -197,6 +198,7 @@ BEGIN
       WHERE placex.class = 'place' AND placex.osm_type = 'N'
         AND placex.extratags ? 'wikidata' -- needed to select right index
         AND placex.extratags->'wikidata' = bnd.extratags->'wikidata'
+        AND placex.linked_place_id is null
         AND placex.rank_search < 26
         AND _st_covers(bnd.geometry, placex.geometry)
       ORDER BY make_standard_name(name->'name') = bnd_name desc
@@ -219,6 +221,7 @@ BEGIN
                                                          false, placex.postcode)).address_rank)
              OR (bnd.rank_address = 0 and placex.rank_search = bnd.rank_search))
         AND placex.osm_type = 'N'
+        AND placex.linked_place_id is null
         AND placex.rank_search < 26 -- needed to select the right index
         AND _st_covers(bnd.geometry, placex.geometry)
     LOOP

--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -231,3 +231,21 @@ Feature: Linking of places
         And placex contains
          | object | centroid |
          | R13    | in geometry  |
+
+    Scenario: Place nodes can only be linked once
+        Given the named places
+         | osm  | class    | type | extra+wikidata | geometry |
+         | N2   | place    | city | Q1234          | 0 0 |
+        And the named places
+         | osm  | class    | type           | extra+wikidata | admin | geometry |
+         | R1   | boundary | administrative | Q1234          | 8     | poly-area:0.1 |
+         | R2   | boundary | administrative | Q1234          | 9     | poly-area:0.01 |
+        When importing
+        Then placex contains
+         | object | linked_place_id |
+         | N2     | R1              |
+        And placex contains
+         | object | extratags                |
+         | R1     | 'linked_place' : 'city', 'wikidata': 'Q1234'  |
+         | R2     | 'wikidata': 'Q1234'                     |
+


### PR DESCRIPTION
If a place node is already linked against a boundary, it should not be used for linking again. It is usually a sign of a mapping error,
when there are multiple boundary candidates. This change just avoids inconsistent data in the database, it does not guarantee that the linking is against the more correct boundary.