### PR TITLE
Use a typed record for place info in get_addressdata

### DIFF
--- a/.github/actions/setup-postgresql/action.yml
+++ b/.github/actions/setup-postgresql/action.yml
@@ -1,26 +1,45 @@
 name: 'Setup Postgresql and Postgis'
 
+inputs:
+    postgresql-version:
+        description: 'Version of PostgreSQL to install'
+        required: true
+    postgis-version:
+        description: 'Version of Postgis to install'
+        required: true
+
 runs:
     using: "composite"
 
     steps:
-        - name: Install postgis
+        - name: Remove existing PostgreSQL
           run: |
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq postgresql-13-postgis-3 postgresql-13-postgis-3-scripts postgresql-server-dev-13
+              sudo apt-get update -qq
+              sudo apt-get purge -yq postgresql*
           shell: bash
+
+        - name: Install PostgreSQL
+          run: |
+              sudo apt-get install -y -qq --no-install-suggests --no-install-recommends postgresql-client-${PGVER} postgresql-${PGVER}-postgis-${POSTGISVER} postgresql-${PGVER}-postgis-${POSTGISVER}-scripts postgresql-contrib-${PGVER} postgresql-${PGVER} postgresql-server-dev-${PGVER}
+          shell: bash
+          env:
+              PGVER: ${{ inputs.postgresql-version }}
+              POSTGISVER: ${{ inputs.postgis-version }}
 
         - name: Adapt postgresql configuration
           run: |
-              echo 'fsync = off' | sudo tee /etc/postgresql/13/main/conf.d/local.conf
-              echo 'synchronous_commit = off' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
-              echo 'full_page_writes = off' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
-              echo 'shared_buffers = 1GB' | sudo tee -a /etc/postgresql/13/main/conf.d/local.conf
+              echo 'fsync = off' | sudo tee /etc/postgresql/${PGVER}/main/conf.d/local.conf
+              echo 'synchronous_commit = off' | sudo tee -a /etc/postgresql/${PGVER}/main/conf.d/local.conf
+              echo 'full_page_writes = off' | sudo tee -a /etc/postgresql/${PGVER}/main/conf.d/local.conf
+              echo 'shared_buffers = 1GB' | sudo tee -a /etc/postgresql/${PGVER}/main/conf.d/local.conf
+              echo 'port = 5432' | sudo tee -a /etc/postgresql/${PGVER}/main/conf.d/local.conf
           shell: bash
+          env:
+              PGVER: ${{ inputs.postgresql-version }}
 
         - name: Setup database
           run: |
-              sudo systemctl start postgresql
+              sudo systemctl restart postgresql
               sudo -u postgres createuser -S www-data
               sudo -u postgres createuser -s runner
           shell: bash

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,6 +6,15 @@ jobs:
     tests:
         runs-on: ubuntu-20.04
 
+        strategy:
+            matrix:
+                postgresql: [9.5, 13]
+                include:
+                    - postgresql: 9.5
+                      postgis: 2.5
+                    - postgresql: 13
+                      postgis: 3
+
         steps:
             - uses: actions/checkout@v2
               with:
@@ -25,6 +34,9 @@ jobs:
                   key: nominatim-data-${{ steps.get-date.outputs.date }}
 
             - uses: ./.github/actions/setup-postgresql
+              with:
+                  postgresql-version: ${{ matrix.postgresql }}
+                  postgis-version: ${{ matrix.postgis }}
             - uses: ./.github/actions/build-nominatim
 
             - name: Install test prerequsites
@@ -65,6 +77,9 @@ jobs:
                   key: nominatim-data-${{ steps.get-date.outputs.date }}
 
             - uses: ./.github/actions/setup-postgresql
+              with:
+                  postgresql-version: 13
+                  postgis-version: 3
             - uses: ./.github/actions/build-nominatim
 
             - name: Create configuration


### PR DESCRIPTION
Older versions of Postgresql cannot handle an untyped record for INTO. We could have caught that with our test suite. I've extended actions to run the tests now against postgres 9.5 and 13.

Fixes #2100.