### PR TITLE
work around failing CI tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,6 +20,12 @@ jobs:
               with:
                   submodules: true
 
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  tools: phpunit, phpcs
+
             - name: Get Date
               id: get-date
               run: |


### PR DESCRIPTION
Github Actions have helpfully changed the default php version to 8 in their last minor update of the ubuntu-20.04 image. So now we know that there are some issues. This just patches up the CI runs to use phpunit7 to get them working again. Looking into the actual issues has to wait until I'm not in the middle of a big refactoring.

Maybe we do have to start providing our own Docker images for the CI test runs. These sudden software changes in the base images are a real pain.