### PR TITLE
Vagrant ubuntu: install dotenv package

### DIFF
--- a/vagrant/Install-on-Ubuntu-18.sh
+++ b/vagrant/Install-on-Ubuntu-18.sh
@@ -29,7 +29,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                         libbz2-dev libpq-dev libproj-dev \
                         postgresql-server-dev-10 postgresql-10-postgis-2.4 \
                         postgresql-contrib-10 postgresql-10-postgis-scripts \
-                        php php-pgsql php-intl \
+                        php php-pgsql php-intl php-symfony-dotenv \
                         python3-psycopg2 git
 
 

--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -32,7 +32,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
                         libbz2-dev libpq-dev libproj-dev \
                         postgresql-server-dev-12 postgresql-12-postgis-3 \
                         postgresql-contrib-12 postgresql-12-postgis-3-scripts \
-                        php php-pgsql php-intl \
+                        php php-pgsql php-intl php-symfony-dotenv \
                         python3-psycopg2 git
 
 #


### PR DESCRIPTION
Followup to https://github.com/osm-search/Nominatim/pull/2115/ where `php-symfony-dotenv` was added to Vagrant for CentOS, but not Ubuntu.