### PR TITLE
Allow for truely independent project directory

### DIFF
--- a/cmake/script.tmpl
+++ b/cmake/script.tmpl
@@ -1,5 +1,7 @@
 #!@PHP_BIN@ -Cq
 <?php
+@define('CONST_Default_ModulePath', '@CMAKE_BINARY_DIR@/module');
+@define('CONST_Default_Osm2pgsql', '@CMAKE_BINARY_DIR@/osm2pgsql/osm2pgsql');
 @define('CONST_BinDir', '@CMAKE_SOURCE_DIR@/utils');
 @define('CONST_LibDir', '@CMAKE_SOURCE_DIR@/lib');
 @define('CONST_DataDir', '@CMAKE_SOURCE_DIR@');

--- a/lib/setup/SetupClass.php
+++ b/lib/setup/SetupClass.php
@@ -42,7 +42,7 @@ class SetupFunctions
             $this->iCacheMemory = getCacheMemoryMB();
         }
 
-        $this->sModulePath = getSetting('DATABASE_MODULE_PATH', CONST_InstallDir.'/module');
+        $this->sModulePath = getSetting('DATABASE_MODULE_PATH', CONST_Default_ModulePath);
         info('module path: ' . $this->sModulePath);
 
         // parse database string
@@ -736,9 +736,6 @@ class SetupFunctions
             fwriteConstDef($rFile, 'LibDir', CONST_LibDir);
             fwriteConstDef($rFile, 'DataDir', CONST_DataDir);
             fwriteConstDef($rFile, 'InstallDir', CONST_InstallDir);
-
-            fwrite($rFile, "if (file_exists(getenv('NOMINATIM_SETTINGS'))) require_once(getenv('NOMINATIM_SETTINGS'));\n\n");
-
             fwriteConstDef($rFile, 'Database_DSN', getSetting('DATABASE_DSN'));
             fwriteConstDef($rFile, 'Default_Language', getSetting('DEFAULT_LANGUAGE'));
             fwriteConstDef($rFile, 'Log_DB', getSettingBool('LOG_DB'));

--- a/lib/setup_functions.php
+++ b/lib/setup_functions.php
@@ -17,12 +17,7 @@ function checkInFile($sOSMFile)
 
 function getOsm2pgsqlBinary()
 {
-    $sBinary = getSetting('OSM2PGSQL_BINARY');
-    if (!$sBinary) {
-        $sBinary = CONST_InstallDir.'/osm2pgsql/osm2pgsql';
-    }
-
-    return $sBinary;
+    return getSetting('OSM2PGSQL_BINARY', CONST_Default_Osm2pgsql);
 }
 
 function getImportStyle()

--- a/test/bdd/steps/queries.py
+++ b/test/bdd/steps/queries.py
@@ -302,10 +302,9 @@ def send_api_query(endpoint, params, fmt, context):
 
     env['SCRIPT_NAME'] = '/%s.php' % endpoint
     env['REQUEST_URI'] = '%s?%s' % (env['SCRIPT_NAME'], env['QUERY_STRING'])
-    env['CONTEXT_DOCUMENT_ROOT'] = os.path.join(context.nominatim.build_dir, 'website')
+    env['CONTEXT_DOCUMENT_ROOT'] = os.path.join(context.nominatim.website_dir.name, 'website')
     env['SCRIPT_FILENAME'] = os.path.join(env['CONTEXT_DOCUMENT_ROOT'],
                                           '%s.php' % endpoint)
-    env['NOMINATIM_SETTINGS'] = context.nominatim.local_settings_file
 
     logger.debug("Environment:" + json.dumps(env, sort_keys=True, indent=2))
 
@@ -327,7 +326,7 @@ def send_api_query(endpoint, params, fmt, context):
     for k,v in params.items():
         cmd.append("%s=%s" % (k, v))
 
-    proc = subprocess.Popen(cmd, cwd=context.nominatim.build_dir, env=env,
+    proc = subprocess.Popen(cmd, cwd=context.nominatim.website_dir.name, env=env,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     (outp, err) = proc.communicate()


### PR DESCRIPTION
With this change it is now possible to set up a project directory for a Nominatim installation outside the build directory. The one thing that needed changing is that the default location of osm2pgsql and the postgresql module need to be determined at compile time to be in the build directory.

The project directory is directly used by the tests now to have a setup that is now truly independent from any configuration found in the build directory. They create their own set of website scripts with the appropriate settings, so that we can get rid of the ugly hack that injects extra settings via an environment variable.