### PR TITLE
documentation: 2020 TIGER data got released

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -284,12 +284,12 @@ address set to complement the OSM house number data in the US. You can add
 TIGER data to your own Nominatim instance by following these steps. The
 entire US adds about 10GB to your database.
 
-  1. Get preprocessed TIGER 2019 data and unpack it into your project
+  1. Get preprocessed TIGER 2020 data and unpack it into your project
      directory:
 
         cd $PROJECT_DIR
-        wget https://nominatim.org/data/tiger2019-nominatim-preprocessed.tar.gz
-        tar xf tiger2019-nominatim-preprocessed.tar.gz
+        wget https://nominatim.org/data/tiger2020-nominatim-preprocessed.tar.gz
+        tar xf tiger2020-nominatim-preprocessed.tar.gz
 
   2. Import the data into your Nominatim database:
 


### PR DESCRIPTION
[rebased, reprocessed data due to https://github.com/osm-search/TIGER-data/pull/4]

New data got released two days ago ftp://ftp2.census.gov/geo/tiger/TIGER2020/EDGES/ (mirror https://downloads.opencagedata.com/public/tiger2020_census_gov_mirror.combined/)

I converted it using https://github.com/osm-search/TIGER-data

You can find the converted file at https://downloads.opencagedata.com/public/tiger2020-nominatim-preprocessed.tar.gz (1.7GB)

2019 - 3233 files - 33,967,042 lines
2020 - 3234 files - 34,265,546 lines (+0.8%)

The extra file is due to "Alaska has announced the split of 02261 Valdez-Cordova borough into two new census areas, 02063 Chugach and 02066 Copper River. These changes will first appear in the 2020 ACS products." https://www.census.gov/programs-surveys/acs/technical-documentation/table-and-geography-changes/2019/geography-changes.html (very end of the page)

Attached comparing file sizes by county. While in general there's more data, those in 55xxx (Puerto Rico) and 72xxx (Wisconsin) lost data. With spot checks I couldn't see any systematic processing errors.
[TIGER-2019-vs-2020.xlsx](https://github.com/osm-search/Nominatim/files/5974672/TIGER-2019-vs-2020.xlsx)

