### PR TITLE
Update vagrant scripts for make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #-----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 
@@ -238,7 +238,14 @@ if (BUILD_IMPORTER)
 endif()
 
 if (BUILD_OSM2PGSQL)
-    install(TARGETS osm2pgsql RUNTIME DESTINATION ${NOMINATIM_LIBDIR})
+    if (${CMAKE_VERSION} VERSION_LESS 3.13)
+        # Installation of subdirectory targets was only introduced in 3.13.
+        # So just copy the osm2pgsql file for older versions.
+        install(PROGRAMS ${PROJECT_BINARY_DIR}/osm2pgsql/osm2pgsql
+                DESTINATION ${NOMINATIM_LIBDIR})
+    else()
+        install(TARGETS osm2pgsql RUNTIME DESTINATION ${NOMINATIM_LIBDIR})
+    endif()
 endif()
 
 if (BUILD_MODULE)

--- a/vagrant/Install-on-Centos-8.sh
+++ b/vagrant/Install-on-Centos-8.sh
@@ -101,36 +101,6 @@ sudo chown vagrant /srv/nominatim  #DOCS:
     sudo -u postgres createuser apache
 
 #
-# Setting up the Apache Webserver
-# -------------------------------
-#
-# You need to create an alias to the website directory in your apache
-# configuration. Add a separate nominatim configuration to your webserver:
-
-#DOCS:```sh
-sudo tee /etc/httpd/conf.d/nominatim.conf << EOFAPACHECONF
-<Directory "$USERHOME/build/website">
-  Options FollowSymLinks MultiViews
-  AddType text/html   .php
-  DirectoryIndex search.php
-  Require all granted
-</Directory>
-
-Alias /nominatim $USERHOME/build/website
-EOFAPACHECONF
-#DOCS:```
-
-sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
-
-#
-# Then reload apache
-#
-
-    sudo systemctl enable httpd
-    sudo systemctl restart httpd
-
-
-#
 # Installing Nominatim
 # ====================
 #
@@ -158,11 +128,48 @@ fi                                 #DOCS:
 # then configure and build Nominatim in there:
 
 #DOCS:    :::sh
-    cd $USERHOME
-    mkdir build
-    cd build
+    mkdir $USERHOME/build
+    cd $USERHOME/build
     cmake $USERHOME/Nominatim
     make
+    sudo make install
+
+#
+# Setting up the Apache Webserver
+# -------------------------------
+#
+# The webserver should serve the php scripts from the website directory of your
+# [project directory](../admin/import.md#creating-the-project-directory).
+# Therefore set up a project directory and populate the website directory:
+#
+    mkdir $USERHOME/nominatim-project
+    cd $USERHOME/nominatim-project
+    nominatim refresh --website
+#
+# You need to create an alias to the website directory in your apache
+# configuration. Add a separate nominatim configuration to your webserver:
+
+#DOCS:```sh
+sudo tee /etc/httpd/conf.d/nominatim.conf << EOFAPACHECONF
+<Directory "$USERHOME/nominatim-project/website">
+  Options FollowSymLinks MultiViews
+  AddType text/html   .php
+  DirectoryIndex search.php
+  Require all granted
+</Directory>
+
+Alias /nominatim $USERHOME/nominatim-project/website
+EOFAPACHECONF
+#DOCS:```
+
+sudo sed -i 's:#.*::' /etc/httpd/conf.d/nominatim.conf #DOCS:
+
+#
+# Then reload apache
+#
+
+    sudo systemctl enable httpd
+    sudo systemctl restart httpd
 
 #
 # Adding SELinux Security Settings
@@ -172,11 +179,11 @@ fi                                 #DOCS:
 # with a web server accessible from the Internet. At a minimum the
 # following SELinux labeling should be done for Nominatim:
 
-    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/Nominatim/(website|lib|settings)(/.*)?"
-    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/build/(website|lib|settings)(/.*)?"
-    sudo semanage fcontext -a -t lib_t "$USERHOME/build/module/nominatim.so"
-    sudo restorecon -R -v $USERHOME/Nominatim
-    sudo restorecon -R -v $USERHOME/build
+    sudo semanage fcontext -a -t httpd_sys_content_t "/usr/local/nominatim/lib/lib-php(/.*)?"
+    sudo semanage fcontext -a -t httpd_sys_content_t "$USERHOME/nominatim-project/website(/.*)?"
+    sudo semanage fcontext -a -t lib_t "$USERHOME/nominatim-project/module/nominatim.so"
+    sudo restorecon -R -v /usr/local/lib/nominatim
+    sudo restorecon -R -v $USERHOME/nominatim-project
 
 
 # You need to create a minimal configuration file that tells nominatim

--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -115,11 +115,11 @@ fi                                 #DOCS:
 # The code must be built in a separate directory. Create this directory,
 # then configure and build Nominatim in there:
 
-    cd $USERHOME
-    mkdir build
-    cd build
+    mkdir $USERHOME/build
+    cd $USERHOME/build
     cmake $USERHOME/Nominatim
     make
+    sudo make install
 
 # Nominatim is now ready to use. You can continue with
 # [importing a database from OSM data](../admin/Import.md). If you want to set up
@@ -127,6 +127,15 @@ fi                                 #DOCS:
 #
 # Setting up a webserver
 # ======================
+#
+# The webserver should serve the php scripts from the website directory of your
+# [project directory](../admin/import.md#creating-the-project-directory).
+# Therefore set up a project directory and populate the website directory:
+
+    mkdir $USERHOME/nominatim-project
+    cd $USERHOME/nominatim-project
+    nominatim refresh --website
+
 #
 # Option 1: Using Apache
 # ----------------------
@@ -143,14 +152,14 @@ if [ "x$2" == "xinstall-apache" ]; then #DOCS:
 
 #DOCS:```sh
 sudo tee /etc/apache2/conf-available/nominatim.conf << EOFAPACHECONF
-<Directory "$USERHOME/build/website">
+<Directory "$USERHOME/nominatim-project/website">
   Options FollowSymLinks MultiViews
   AddType text/html   .php
   DirectoryIndex search.php
   Require all granted
 </Directory>
 
-Alias /nominatim $USERHOME/build/website
+Alias /nominatim $USERHOME/nominatim-project/website
 EOFAPACHECONF
 #DOCS:```
 
@@ -207,7 +216,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    root $USERHOME/build/website;
+    root $USERHOME/nominatim-project/website;
     index search.php index.html;
     location / {
         try_files \$uri \$uri/ @php;


### PR DESCRIPTION
The vagrant scripts now install nominatim in /usr/local.

Also adds two minor fixes:
* cmake cannot install subdirectory targets before 3.13 (fixes #2170)
* python-dotenv is too old on Ubuntu 18.04, so install via pip instead