### PR TITLE
Increase penalty for places without housenumber 

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -778,13 +778,17 @@ class Geocode
                 if (!empty($aResults)) {
                     $aSplitResults = Result::splitResults($aResults);
                     Debug::printVar('Split results', $aSplitResults);
-                    if ($iGroupLoop <= 4 && empty($aSplitResults['tail'])
+                    if ($iGroupLoop <= 4
                         && reset($aSplitResults['head'])->iResultRank > 0) {
                         // Haven't found an exact match for the query yet.
                         // Therefore add result from the next group level.
                         $aNextResults = $aSplitResults['head'];
                         foreach ($aNextResults as $oRes) {
                             $oRes->iResultRank--;
+                        }
+                        foreach ($aSplitResults['tail'] as $oRes) {
+                            $oRes->iResultRank--;
+                            $aNextResults[$oRes->iId] = $oRes;
                         }
                         $aResults = array();
                     } else {

--- a/lib-php/Result.php
+++ b/lib-php/Result.php
@@ -26,6 +26,8 @@ class Result
     public $iExactMatches = 0;
     /// Subranking within the results (the higher the worse).
     public $iResultRank = 0;
+    /// Address rank of the result.
+    public $iAddressRank;
 
     public function debugInfo()
     {
@@ -84,7 +86,7 @@ class Result
 
         foreach ($aResults as $oRes) {
             if ($oRes->iResultRank < $iMinRank) {
-                $aTail = array_merge($aTail, $aHead);
+                $aTail += $aHead;
                 $aHead = array($oRes->iId => $oRes);
                 $iMinRank = $oRes->iResultRank;
             } elseif ($oRes->iResultRank == $iMinRank) {

--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -450,7 +450,11 @@ class SearchDescription
                 // Downgrade the rank of the street results, they are missing
                 // the housenumber.
                 foreach ($aResults as $oRes) {
-                    $oRes->iResultRank++;
+                    if ($oRes->iAddressRank >= 26) {
+                        $oRes->iResultRank++;
+                    } else {
+                        $oRes->iResultRank += 2;
+                    }
                 }
 
                 $aHnResults = $this->queryHouseNumber($oDB, $aResults);
@@ -715,7 +719,7 @@ class SearchDescription
         $aResults = array();
 
         if (!empty($aTerms)) {
-            $sSQL = 'SELECT place_id,'.$sExactMatchSQL;
+            $sSQL = 'SELECT place_id, address_rank,'.$sExactMatchSQL;
             $sSQL .= ' FROM search_name';
             $sSQL .= ' WHERE '.join(' and ', $aTerms);
             $sSQL .= ' ORDER BY '.join(', ', $aOrder);
@@ -728,6 +732,7 @@ class SearchDescription
             foreach ($aDBResults as $aResult) {
                 $oResult = new Result($aResult['place_id']);
                 $oResult->iExactMatches = $aResult['exactmatch'];
+                $oResult->iAddressRank = $aResult['address_rank'];
                 $aResults[$aResult['place_id']] = $oResult;
             }
         }

--- a/test/php/Nominatim/ResultTest.php
+++ b/test/php/Nominatim/ResultTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Nominatim;
+
+require_once(CONST_LibDir.'/Result.php');
+
+function mkRankedResult($iId, $iResultRank)
+{
+    $oResult = new Result($iId);
+    $oResult->iResultRank = $iResultRank;
+
+    return $oResult;
+}
+
+
+class ResultTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSplitResults()
+    {
+        $aSplitResults = Result::splitResults(array(
+            mkRankedResult(1, 2),
+            mkRankedResult(2, 0),
+            mkRankedResult(3, 0),
+            mkRankedResult(4, 2),
+            mkRankedResult(5, 1)
+        ));
+
+
+        $aHead = array_keys($aSplitResults['head']);
+        $aTail = array_keys($aSplitResults['tail']);
+
+        $this->assertEquals($aHead, array(2, 3));
+        $this->assertEquals($aTail, array(1, 4, 5));
+    }
+}


### PR DESCRIPTION
Results where the housenumber was dropped are an unlikely result when they refer to something other than a street. Therefore
increase their result rank so that other matches are tried first before choosing them as a result.

Improves #2167.