### PR TITLE
Disable JIT and parallel execution for osm2pgsql updates again

### DIFF
--- a/nominatim/db/connection.py
+++ b/nominatim/db/connection.py
@@ -50,6 +50,15 @@ class _Connection(psycopg2.extensions.connection):
                                 WHERE tablename = %s""", (table, ))
             return num == 1
 
+    def server_version_tuple(self):
+        """ Return the server version as a tuple of (major, minor).
+            Converts correctly for pre-10 and post-10 PostgreSQL versions.
+        """
+        version = self.server_version
+        if version < 100000:
+            return (version / 10000, (version % 10000) / 100)
+
+        return (version / 10000, version % 10000)
 
 def connect(dsn):
     """ Open a connection to the database using the specialised connection

--- a/nominatim/tools/exec_utils.py
+++ b/nominatim/tools/exec_utils.py
@@ -127,6 +127,9 @@ def run_osm2pgsql(options):
         if param in dsn:
             cmd.extend(('--' + param, dsn[param]))
 
+    if options.get('disable_jit', False):
+        env['PGOPTIONS'] = '-c jit=off -c max_parallel_workers_per_gather=0'
+
     cmd.append(str(options['import_file']))
 
     subprocess.run(cmd, cwd=options.get('cwd', '.'), env=env, check=True)

--- a/nominatim/tools/replication.py
+++ b/nominatim/tools/replication.py
@@ -115,6 +115,7 @@ def update(conn, options):
 
     # Consume updates with osm2pgsql.
     options['append'] = True
+    options['disable_jit'] = conn.server_version_tuple() >= (11, 0)
     run_osm2pgsql(options)
 
     # Write the current status to the file


### PR DESCRIPTION
The gazetteer output doesn't disable these functions when writing to the place table but the triggers may containoperations that cause misplanning for the query planner.