### PR TITLE
nominatim -h was printing wrong text for lookup and details

### DIFF
--- a/nominatim/clicmd/api.py
+++ b/nominatim/clicmd/api.py
@@ -154,7 +154,7 @@ class APIReverse:
 
 class APILookup:
     """\
-    Execute API reverse query.
+    Execute API lookup query.
     """
 
     @staticmethod
@@ -189,7 +189,7 @@ class APILookup:
 
 class APIDetails:
     """\
-    Execute API lookup query.
+    Execute API details query.
     """
 
     @staticmethod


### PR DESCRIPTION
fixes https://github.com/osm-search/Nominatim/issues/2229

```
vagrant@ubuntu2004:~/build$ nominatim -h
[...]
    serve               Start a simple web server for serving the API.
    search              Execute API search query.
    reverse             Execute API reverse query.
    lookup              Execute API lookup query.
    details             Execute API details query.
    status              Execute API status query.
    transition          Internal functions for code transition. Do not use.
```