### PR TITLE
Create postcode id index earlier

### DIFF
--- a/lib-sql/indices.sql
+++ b/lib-sql/indices.sql
@@ -35,9 +35,6 @@ CREATE INDEX {{sql.if_index_not_exists}} idx_osmline_parent_place_id
 CREATE INDEX {{sql.if_index_not_exists}} idx_osmline_parent_osm_id
   ON location_property_osmline USING BTREE (osm_id) {{db.tablespace.search_index}};
 
-CREATE UNIQUE INDEX {{sql.if_index_not_exists}} idx_postcode_id
-  ON location_postcode USING BTREE (place_id) {{db.tablespace.search_index}};
-
 CREATE INDEX {{sql.if_index_not_exists}} idx_postcode_postcode
   ON location_postcode USING BTREE (postcode) {{db.tablespace.search_index}};
 

--- a/lib-sql/tables.sql
+++ b/lib-sql/tables.sql
@@ -209,6 +209,7 @@ CREATE TABLE location_postcode (
   postcode TEXT,
   geometry GEOMETRY(Geometry, 4326)
   );
+CREATE UNIQUE INDEX idx_postcode_id ON location_postcode USING BTREE (place_id) {{db.tablespace.search_index}};
 CREATE INDEX idx_postcode_geometry ON location_postcode USING GIST (geometry) {{db.tablespace.address_index}};
 GRANT SELECT ON location_postcode TO "{{config.DATABASE_WEBUSER}}" ;
 


### PR DESCRIPTION
Now that the indexer takes care of indexing the postcode tables, the id index is needed to find the rows to index.