### PR TITLE
Index for housenumber lookup

### DIFF
--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -37,7 +37,7 @@ For compiling:
 
 For running Nominatim:
 
-  * [PostgreSQL](https://www.postgresql.org) (9.3+)
+  * [PostgreSQL](https://www.postgresql.org) (9.3+ will work, 11+ strongly recommended)
   * [PostGIS](https://postgis.net) (2.2+)
   * [Python 3](https://www.python.org/) (3.5+)
   * [Psycopg2](https://www.psycopg.org) (2.7+)

--- a/lib-sql/indices.sql
+++ b/lib-sql/indices.sql
@@ -61,4 +61,11 @@ CREATE INDEX {{sql.if_index_not_exists}} idx_postcode_postcode
     ON search_name USING GIN (name_vector) WITH (fastupdate = off) {{db.tablespace.search_index}};
   CREATE INDEX {{sql.if_index_not_exists}} idx_search_name_centroid
     ON search_name USING GIST (centroid) {{db.tablespace.search_index}};
+
+  {% if postgres.has_index_non_key_column %}
+    CREATE INDEX {{sql.if_index_not_exists}} idx_placex_housenumber
+      ON placex USING btree (parent_place_id) INCLUDE (housenumber) WHERE housenumber is not null;
+    CREATE INDEX {{sql.if_index_not_exists}} idx_osmline_parent_osm_id_with_hnr
+      ON location_property_osmline USING btree(parent_place_id) INCLUDE (startnumber, endnumber);
+  {% endif %}
 {% endif %}

--- a/nominatim/db/sql_preprocessor.py
+++ b/nominatim/db/sql_preprocessor.py
@@ -49,11 +49,20 @@ def _setup_postgres_sql(conn):
     pg_version = conn.server_version_tuple()
     # CREATE INDEX IF NOT EXISTS was introduced in PG9.5.
     # Note that you need to ignore failures on older versions when
-    # unsing this construct.
+    # using this construct.
     out['if_index_not_exists'] = ' IF NOT EXISTS ' if pg_version >= (9, 5, 0) else ''
 
     return out
 
+
+def _setup_postgresql_features(conn):
+    """ Set up a dictionary with various optional Postgresql/Postgis features that
+        depend on the database version.
+    """
+    pg_version = conn.server_version_tuple()
+    return {
+        'has_index_non_key_column' : pg_version >= (11, 0, 0)
+    }
 
 class SQLPreprocessor: # pylint: disable=too-few-public-methods
     """ A environment for preprocessing SQL files from the
@@ -79,6 +88,7 @@ class SQLPreprocessor: # pylint: disable=too-few-public-methods
         self.env.globals['config'] = config
         self.env.globals['db'] = db_info
         self.env.globals['sql'] = _setup_postgres_sql(conn)
+        self.env.globals['postgres'] = _setup_postgresql_features(conn)
         self.env.globals['modulepath'] = config.DATABASE_MODULE_PATH or \
                                          str((config.project_dir / 'module').resolve())
 


### PR DESCRIPTION
Adds a special index for lookups of the form street+housenumber. The query planner does not handle the SQL for them well and the index makes them a bit faster. Eventually the whole SQL needs to be rewritten but that is a bigger project.

The index uses non-key columns that were only introduced in Postgresql 11, which means this optimisation will not be available with older versions. They'll still work, they will just be slower. I've added a recommendation for Postgresql 11+.