### PR TITLE
Fix default languages loading for special phrases import

### DIFF
--- a/nominatim/tools/special_phrases.py
+++ b/nominatim/tools/special_phrases.py
@@ -80,7 +80,7 @@ class SpecialPhrasesImporter():
             'et', 'eu', 'fa', 'fi', 'fr', 'gl', 'hr', 'hu',
             'ia', 'is', 'it', 'ja', 'mk', 'nl', 'no', 'pl',
             'ps', 'pt', 'ru', 'sk', 'sl', 'sv', 'uk', 'vi']
-        return self.config.LANGUAGES.split(',') or default_languages
+        return self.config.LANGUAGES.split(',') if self.config.LANGUAGES else default_languages
 
     @staticmethod
     def _get_wiki_content(lang):


### PR DESCRIPTION
This PR fix a bug when languages are load during the import of special phrases.

By splitting languages list from the config, a result is always returned even if the config is empty (return ['']), so default language was never returned.