### PR TITLE
Implemented auto update of special phrases while importing them

### DIFF
--- a/test/python/test_tools_import_special_phrases.py
+++ b/test/python/test_tools_import_special_phrases.py
@@ -2,6 +2,7 @@
     Tests for import special phrases methods
     of the class SpecialPhrasesImporter.
 """
+from mocks import MockParamCapture
 from nominatim.errors import UsageError
 from pathlib import Path
 import tempfile
@@ -10,6 +11,72 @@ import pytest
 from nominatim.tools.special_phrases import SpecialPhrasesImporter
 
 TEST_BASE_DIR = Path(__file__) / '..' / '..'
+
+def test_fetch_existing_words_phrases_basic(special_phrases_importer, word_table,
+                                            temp_db_conn):
+    """
+        Check for the fetch_existing_words_phrases() method.
+        It should return special phrase term added to the word
+        table.
+    """
+    with temp_db_conn.cursor() as temp_db_cursor:
+        query ="""
+            INSERT INTO word VALUES(99999, 'lookup_token', 'normalized_word',
+            'class', 'type', null, 0, 'near');
+        """
+        temp_db_cursor.execute(query)
+
+    assert not special_phrases_importer.words_phrases_to_delete
+    special_phrases_importer._fetch_existing_words_phrases()
+    contained_phrase = special_phrases_importer.words_phrases_to_delete.pop()
+    assert contained_phrase == ('normalized_word', 'class', 'type', 'near')
+
+def test_fetch_existing_words_phrases_housenumber(special_phrases_importer, word_table,
+                                                  temp_db_conn):
+    """
+        Check for the fetch_existing_words_phrases() method.
+        It should return nothing as the term added correspond
+        to a housenumber term.
+    """
+    with temp_db_conn.cursor() as temp_db_cursor:
+        query ="""
+            INSERT INTO word VALUES(99999, 'lookup_token', 'normalized_word',
+            'place', 'house', null, 0, 'near');
+        """
+        temp_db_cursor.execute(query)
+
+    special_phrases_importer._fetch_existing_words_phrases()
+    assert not special_phrases_importer.words_phrases_to_delete
+
+def test_fetch_existing_words_phrases_postcode(special_phrases_importer, word_table,
+                                               temp_db_conn):
+    """
+        Check for the fetch_existing_words_phrases() method.
+        It should return nothing as the term added correspond
+        to a postcode term.
+    """
+    with temp_db_conn.cursor() as temp_db_cursor:
+        query ="""
+            INSERT INTO word VALUES(99999, 'lookup_token', 'normalized_word',
+            'place', 'postcode', null, 0, 'near');
+        """
+        temp_db_cursor.execute(query)
+
+    special_phrases_importer._fetch_existing_words_phrases()
+    assert not special_phrases_importer.words_phrases_to_delete
+
+def test_fetch_existing_place_classtype_tables(special_phrases_importer, temp_db_conn):
+    """
+        Check for the fetch_existing_place_classtype_tables() method.
+        It should return the table just created.
+    """
+    with temp_db_conn.cursor() as temp_db_cursor:
+        query = 'CREATE TABLE place_classtype_testclasstypetable()'
+        temp_db_cursor.execute(query)
+
+    special_phrases_importer._fetch_existing_place_classtype_tables()
+    contained_table = special_phrases_importer.table_phrases_to_delete.pop()
+    assert contained_table == 'place_classtype_testclasstypetable'
 
 def test_check_sanity_class(special_phrases_importer):
     """
@@ -80,7 +147,7 @@ def test_convert_settings_giving_json(special_phrases_importer):
     assert returned == json_file
 
 def test_process_amenity_with_operator(special_phrases_importer, getorcreate_amenityoperator_funcs,
-                                       word_table, temp_db_conn):
+                                       temp_db_conn):
     """
         Test that _process_amenity() execute well the 
         getorcreate_amenityoperator() SQL function and that
@@ -188,13 +255,72 @@ def test_process_xml_content(temp_db_conn, def_config, special_phrases_importer,
     assert check_amenities_without_op(temp_db_conn)
     assert results[class_test] and type_test in results.values()
 
+def test_remove_non_existent_phrases_from_db(special_phrases_importer, default_phrases,
+                                             temp_db_conn):
+    """
+        Check for the remove_non_existent_phrases_from_db() method.
+
+        It should removed entries from the word table which are contained
+        in the words_phrases_to_delete set and not those also contained
+        in the words_phrases_still_exist set.
+
+        place_classtype tables contained in table_phrases_to_delete should
+        be deleted.
+    """
+    with temp_db_conn.cursor() as temp_db_cursor:
+        to_delete_phrase_tuple = ('normalized_word', 'class', 'type', 'near')
+        to_keep_phrase_tuple = (
+            'normalized_word_exists', 'class_exists', 'type_exists', 'near'
+        )
+        special_phrases_importer.words_phrases_to_delete = {
+            to_delete_phrase_tuple,
+            to_keep_phrase_tuple
+        }
+        special_phrases_importer.words_phrases_still_exist = {
+            to_keep_phrase_tuple
+        }
+        special_phrases_importer.table_phrases_to_delete = {
+            'place_classtype_testclasstypetable_to_delete'
+        }
+
+        query_words = 'SELECT word, class, type, operator FROM word;'
+        query_tables = """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema='public'
+            AND table_name like 'place_classtype_%';
+        """
+
+        special_phrases_importer._remove_non_existent_phrases_from_db()
+
+        temp_db_cursor.execute(query_words)
+        words_result = temp_db_cursor.fetchall()
+        temp_db_cursor.execute(query_tables)
+        tables_result = temp_db_cursor.fetchall()
+        assert len(words_result) == 1 and words_result[0] == [
+            'normalized_word_exists', 'class_exists', 'type_exists', 'near'
+        ]
+        assert (len(tables_result) == 1 and
+            tables_result[0][0] == 'place_classtype_testclasstypetable_to_keep'
+        )
+
 def test_import_from_wiki(monkeypatch, temp_db_conn, def_config, special_phrases_importer, placex_table, 
-                          getorcreate_amenity_funcs, getorcreate_amenityoperator_funcs):
+                          getorcreate_amenity_funcs, getorcreate_amenityoperator_funcs, word_table):
     """
         Check that the main import_from_wiki() method is well executed.
         It should create the place_classtype table, the place_id and centroid indexes,
         grand access to the web user and executing the SQL functions for amenities.
     """
+    mock_fetch_existing_words_phrases = MockParamCapture()
+    mock_fetch_existing_place_classtype_tables = MockParamCapture()
+    mock_remove_non_existent_phrases_from_db = MockParamCapture()
+
+    monkeypatch.setattr('nominatim.tools.special_phrases.SpecialPhrasesImporter._fetch_existing_words_phrases',
+                        mock_fetch_existing_words_phrases)
+    monkeypatch.setattr('nominatim.tools.special_phrases.SpecialPhrasesImporter._fetch_existing_place_classtype_tables',
+                        mock_fetch_existing_place_classtype_tables)
+    monkeypatch.setattr('nominatim.tools.special_phrases.SpecialPhrasesImporter._remove_non_existent_phrases_from_db',
+                        mock_remove_non_existent_phrases_from_db)
     monkeypatch.setattr('nominatim.tools.special_phrases.SpecialPhrasesImporter._get_wiki_content', mock_get_wiki_content)
     special_phrases_importer.import_from_wiki(['en'])
 
@@ -206,6 +332,9 @@ def test_import_from_wiki(monkeypatch, temp_db_conn, def_config, special_phrases
     assert check_grant_access(temp_db_conn, def_config.DATABASE_WEBUSER, class_test, type_test)
     assert check_amenities_with_op(temp_db_conn)
     assert check_amenities_without_op(temp_db_conn)
+    assert mock_fetch_existing_words_phrases.called == 1
+    assert mock_fetch_existing_place_classtype_tables.called == 1
+    assert mock_remove_non_existent_phrases_from_db.called == 1
 
 def mock_get_wiki_content(lang):
     """
@@ -304,6 +433,18 @@ def temp_phplib_dir_with_migration():
         copyfile(migration_file, migration_dest_path)
 
         yield Path(phpdir)
+
+@pytest.fixture
+def default_phrases(word_table, temp_db_cursor):
+    temp_db_cursor.execute("""
+        INSERT INTO word VALUES(99999, 'lookup_token', 'normalized_word',
+        'class', 'type', null, 0, 'near');
+
+        INSERT INTO word VALUES(99999, 'lookup_token', 'normalized_word_exists',
+        'class_exists', 'type_exists', null, 0, 'near');
+
+        CREATE TABLE place_classtype_testclasstypetable_to_delete();
+        CREATE TABLE place_classtype_testclasstypetable_to_keep();""")
 
 @pytest.fixture
 def make_strandard_name_func(temp_db_cursor):


### PR DESCRIPTION
Fix #1362

### What has been added with this PR:

Special phrases are now automatically updated when `nominatim special-phrases --import-from-wiki` is called.
The algorithm does the following when initializing:
- Retrieve and store into the set `words_phrases_to_delete` all special phrases entries from the word tables.
- Retrieve and store into the set `table_phrases_to_delete` all `place_classtype_` tables names from the database.

Then, while handling each entries of the wiki it does:
- Ignore the entry if it is contained in the `words_phrases_to_delete` set.
- Add the entry to the `words_phrases_still_exist`.
(This 2 set mechanism is necessary as there is duplicate entries among the whole wiki).

When looping on each class/type to create the tables it does:
- Ignore the creation of the table and creation of indexes and access-granting, if the table name is already contained in the `words_phrases_to_delete` set.
- Remove the table name entry from the `table_phrases_to_delete` set.

When every phrase has been processed:
- Entries of the `words_phrases_still_exist` are removed from `words_phrases_to_delete`.
- Remove all entries contained in `words_phrases_to_delete` from the word table.
- Remove all tables from the database which are contained in `table_phrases_to_delete`.

I discovered that, for example, Vietnamese phrases contains operator not written in English (so not "in" or "near"). As we only handle english operators, those phrases were never used. It conducted me to add this code: 
`phrase_operator = '-' if phrase_operator not in ('near', 'in') else phrase_operator`
 
I might need to open an issue for that. I didn't as I am not sure if we should handle this or if it should be written in english on the wiki.

- Tests were also added to cover new behaviors.