### PR TITLE
fix index on location_property_tiger (parent_place_id)

### DIFF
--- a/lib-sql/tiger_import_finish.sql
+++ b/lib-sql/tiger_import_finish.sql
@@ -1,5 +1,5 @@
 --index only on parent_place_id
-CREATE INDEX {{sql.if_index_not_exists}} idx_location_property_tiger_place_id_imp
+CREATE INDEX {{sql.if_index_not_exists}} idx_location_property_tiger_parent_place_id_imp
   ON location_property_tiger_import (parent_place_id) {{db.tablespace.aux_index}};
 CREATE UNIQUE INDEX {{sql.if_index_not_exists}} idx_location_property_tiger_place_id_imp
   ON location_property_tiger_import (place_id) {{db.tablespace.aux_index}};


### PR DESCRIPTION
Looks like 2af82975cd968ec09683ae5b16a9aa157a7f2176
accidentally renamed an index. Because of the added "if not
exists" clause, the index doesn't get created. This
significantly slows down reverse queries because they now
require full scans on location_property_tiger.

Without this fix, reverse queries can take 8s on a full
planet install on an r5.8xlarge instance in EC2.