### PR TITLE
pylint: disable too-few-public-methods check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,3 +10,4 @@ ignored-modules=icu
 # closing added here because it sometimes triggers a false positive with
 # 'with' statements.
 ignored-classes=NominatimArgs,closing
+disable=too-few-public-methods

--- a/nominatim/clicmd/args.py
+++ b/nominatim/clicmd/args.py
@@ -3,7 +3,7 @@ Provides custom functions over command-line arguments.
 """
 
 
-class NominatimArgs: # pylint: disable=too-few-public-methods
+class NominatimArgs:
     """ Customized namespace class for the nominatim command line tool
         to receive the command-line arguments.
     """

--- a/nominatim/config.py
+++ b/nominatim/config.py
@@ -39,7 +39,7 @@ class Configuration:
             self._config['NOMINATIM_ADDRESS_LEVEL_CONFIG'] = \
                 str(config_dir / 'address-levels.json')
 
-        class _LibDirs: # pylint: disable=too-few-public-methods
+        class _LibDirs:
             pass
 
         self.lib_dir = _LibDirs()

--- a/nominatim/db/sql_preprocessor.py
+++ b/nominatim/db/sql_preprocessor.py
@@ -64,7 +64,7 @@ def _setup_postgresql_features(conn):
         'has_index_non_key_column' : pg_version >= (11, 0, 0)
     }
 
-class SQLPreprocessor: # pylint: disable=too-few-public-methods
+class SQLPreprocessor:
     """ A environment for preprocessing SQL files from the
         lib-sql directory.
 

--- a/nominatim/tools/check_database.py
+++ b/nominatim/tools/check_database.py
@@ -47,7 +47,7 @@ def _check(hint=None):
 
     return decorator
 
-class _BadConnection: # pylint: disable=R0903
+class _BadConnection:
 
     def __init__(self, msg):
         self.msg = msg

--- a/nominatim/tools/special_phrases.py
+++ b/nominatim/tools/special_phrases.py
@@ -3,13 +3,15 @@
 """
 import logging
 import os
+from os.path import isfile
 from pathlib import Path
 import re
 import subprocess
 import json
-from os.path import isfile
+
 from icu import Transliterator
 from psycopg2.sql import Identifier, Literal, SQL
+
 from nominatim.tools.exec_utils import get_url
 from nominatim.errors import UsageError
 
@@ -151,7 +153,7 @@ class SpecialPhrasesImporter():
         type_matchs = self.sanity_check_pattern.findall(phrase_type)
         class_matchs = self.sanity_check_pattern.findall(phrase_class)
 
-        if len(class_matchs) < 1 or len(type_matchs) < 1:
+        if not class_matchs or not type_matchs:
             LOG.warning("Bad class/type for language %s: %s=%s. It will not be imported",
                         lang, phrase_class, phrase_type)
             return False

--- a/nominatim/tools/special_phrases.py
+++ b/nominatim/tools/special_phrases.py
@@ -16,7 +16,6 @@ from nominatim.errors import UsageError
 LOG = logging.getLogger()
 class SpecialPhrasesImporter():
     # pylint: disable-msg=too-many-instance-attributes
-    # pylint: disable-msg=too-few-public-methods
     """
         Class handling the process of special phrases importations.
     """


### PR DESCRIPTION
This warning has now been disabled often enough and is only of limited use, so switch it off completely.

This also fixes three linting issues in `special_phrases.py` which are not marked by newer versions of pylint anymore but still look like they are worth fixing.