### PR TITLE
Fix database check for reverse-only

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -159,7 +159,7 @@ jobs:
               run: nominatim special-phrases --import-from-wiki
               working-directory: data-env
 
-            - name: Check import
+            - name: Check full import
               run: nominatim admin --check-database
               working-directory: data-env
 
@@ -174,7 +174,11 @@ jobs:
               working-directory: data-env
 
             - name: Run reverse-only import
-              run : nominatim import --osm-file ../monaco-latest.osm.pbf --reverse-only
+              run : nominatim import --osm-file ../monaco-latest.osm.pbf --reverse-only --no-updates
               working-directory: data-env
               env:
                   NOMINATIM_DATABASE_DSN: pgsql:dbname=reverse
+
+            - name: Check reverse import
+              run: nominatim admin --check-database
+              working-directory: data-env

--- a/nominatim/tools/check_database.py
+++ b/nominatim/tools/check_database.py
@@ -94,14 +94,14 @@ def _get_indexes(conn):
         indexes.extend(('idx_search_name_nameaddress_vector',
                         'idx_search_name_name_vector',
                         'idx_search_name_centroid'))
+        if conn.server_version_tuple() >= (11, 0, 0):
+            indexes.extend(('idx_placex_housenumber',
+                            'idx_osmline_parent_osm_id_with_hnr'))
     if conn.table_exists('place'):
         indexes.extend(('idx_placex_pendingsector',
                         'idx_location_area_country_place_id',
                         'idx_place_osm_unique'
                        ))
-    if conn.server_version_tuple() >= (11, 0, 0):
-        indexes.extend(('idx_placex_housenumber',
-                        'idx_osmline_parent_osm_id_with_hnr'))
 
     return indexes
 


### PR DESCRIPTION
The extra include indexes are only needed for search. Also adds a database check for reverse only import to the CI.