### PR TITLE
Fixed `postalCode` parameter case

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -37,7 +37,7 @@ The search term may be specified with two different sets of parameters:
 * `county=<county>`
 * `state=<state>`
 * `country=<country>`
-* `postalcode=<postalcode>`
+* `postalCode=<postalcode>`
 
     Alternative query string format split into several parameters for structured requests.
     Structured requests are faster but are less robust against alternative


### PR DESCRIPTION
The `postalCode` parameter seems to be case sensitive. Without the CamelCase writing the results from OSM are empty.

[working request](https://nominatim.openstreetmap.org/search?city=Dresden&format=json&accept-Language=de&postalCode=01328&country=DE)

[failing Request](https://nominatim.openstreetmap.org/search?city=Dresden&format=json&accept-Language=de&postalcode=01328&country=DE)