### PR TITLE
Correctly catch the exception when import date is missing

### DIFF
--- a/lib-php/Status.php
+++ b/lib-php/Status.php
@@ -37,7 +37,7 @@ class Status
         $iDataDateEpoch = $this->oDB->getOne($sSQL);
 
         if ($iDataDateEpoch === false) {
-            throw Exception('Data date query failed '.$iDataDateEpoch->getMessage(), 705);
+            throw new Exception('Import date is not available', 705);
         }
 
         return $iDataDateEpoch;

--- a/lib-php/website/status.php
+++ b/lib-php/website/status.php
@@ -17,6 +17,23 @@ if ($sOutputFormat == 'json') {
 try {
     $oStatus = new Nominatim\Status($oDB);
     $oStatus->status();
+
+    if ($sOutputFormat == 'json') {
+        $epoch = $oStatus->dataDate();
+        $aResponse = array(
+                      'status' => 0,
+                      'message' => 'OK',
+                      'data_updated' => (new DateTime('@'.$epoch))->format(DateTime::RFC3339),
+                      'software_version' => CONST_NominatimVersion
+                     );
+        $sDatabaseVersion = $oStatus->databaseVersion();
+        if ($sDatabaseVersion) {
+            $aResponse['database_version'] = $sDatabaseVersion;
+        }
+        javascript_renderData($aResponse);
+    } else {
+        echo 'OK';
+    }
 } catch (Exception $oErr) {
     if ($sOutputFormat == 'json') {
         $aResponse = array(
@@ -28,25 +45,4 @@ try {
         header('HTTP/1.0 500 Internal Server Error');
         echo 'ERROR: '.$oErr->getMessage();
     }
-    exit;
 }
-
-
-if ($sOutputFormat == 'json') {
-    $epoch = $oStatus->dataDate();
-    $aResponse = array(
-                  'status' => 0,
-                  'message' => 'OK',
-                  'data_updated' => (new DateTime('@'.$epoch))->format(DateTime::RFC3339),
-                  'software_version' => CONST_NominatimVersion
-                 );
-    $sDatabaseVersion = $oStatus->databaseVersion();
-    if ($sDatabaseVersion) {
-        $aResponse['database_version'] = $sDatabaseVersion;
-    }
-    javascript_renderData($aResponse);
-} else {
-    echo 'OK';
-}
-
-exit;


### PR DESCRIPTION
When the import date was missing for some reason, status in JSON format did return a PHP error: `{"error":{"code":0,"message":"Call to undefined function Nominatim\Exception()"}}`. This fixes the PHP and also makes sure that the usual status message is returned.