### PR TITLE
Add array_key_last function for PHP <7.3

### DIFF
--- a/lib-php/lib.php
+++ b/lib-php/lib.php
@@ -227,3 +227,11 @@ function closestHouseNumber($aRow)
 
     return max(min($aRow['endnumber'], $iHn), $aRow['startnumber']);
 }
+
+if (!function_exists('array_key_last'))
+{
+    function array_key_last(array $array) 
+    {
+        if (!empty($array)) return key(array_slice($array, -1, 1, true));
+    }
+}


### PR DESCRIPTION
This patch adds an array_key_last function if it doesn't yet exist, fixes #2316. It is tested on PHP 7.2.24 but not PHP 7.3.