### PR TITLE
Feat: Disabled search API for --reverse-only imports

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -252,6 +252,9 @@ to verify that your installation is working. Go to
 `http://localhost:8088/status.php` and you should see the message `OK`.
 You can also run a search query, e.g. `http://localhost:8088/search.php?q=Berlin`.
 
+Note that search query is not supported for reverse-only imports. You can run a
+reverse query, e.g. `http://localhost:8088/reverse.php?lat=27.1750090510034&lon=78.04209025`.
+
 To run Nominatim via webservers like Apache or nginx, please read the
 [Deployment chapter](Deployment.md).
 

--- a/lib-php/website/reverse-only-search.php
+++ b/lib-php/website/reverse-only-search.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once(CONST_LibDir.'/init-website.php');
+require_once(CONST_LibDir.'/ParameterParser.php');
+
+$oParams = new Nominatim\ParameterParser();
+
+// Format for output
+$sOutputFormat = $oParams->getSet('format', array('xml', 'json', 'jsonv2', 'geojson', 'geocodejson'), 'jsonv2');
+set_exception_handler_by_format($sOutputFormat);
+
+throw new Exception('Reverse-only import does not support forward searching.', 404);

--- a/nominatim/clicmd/refresh.py
+++ b/nominatim/clicmd/refresh.py
@@ -94,6 +94,6 @@ class UpdateRefresh:
         if args.website:
             webdir = args.project_dir / 'website'
             LOG.warning('Setting up website directory at %s', webdir)
-            refresh.setup_website(webdir, args.config)
-
+            with connect(args.config.get_libpq_dsn()) as conn:
+                refresh.setup_website(webdir, args.config, conn)
         return 0

--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -139,7 +139,8 @@ class SetupAll:
 
         webdir = args.project_dir / 'website'
         LOG.warning('Setup website at %s', webdir)
-        refresh.setup_website(webdir, args.config)
+        with connect(args.config.get_libpq_dsn()) as conn:
+            refresh.setup_website(webdir, args.config, conn)
 
         with connect(args.config.get_libpq_dsn()) as conn:
             try:

--- a/nominatim/tools/refresh.py
+++ b/nominatim/tools/refresh.py
@@ -155,7 +155,7 @@ def recompute_importance(conn):
     conn.commit()
 
 
-def setup_website(basedir, config):
+def setup_website(basedir, config, conn):
     """ Create the website script stubs.
     """
     if not basedir.exists():
@@ -187,5 +187,10 @@ def setup_website(basedir, config):
 
     template += "\nrequire_once('{}/website/{{}}');\n".format(config.lib_dir.php)
 
+    search_name_table_exists = bool(conn and conn.table_exists('search_name'))
+
     for script in WEBSITE_SCRIPTS:
-        (basedir / script).write_text(template.format(script), 'utf-8')
+        if not search_name_table_exists and script == 'search.php':
+            (basedir / script).write_text(template.format('reverse-only-search.php'), 'utf-8')
+        else:
+            (basedir / script).write_text(template.format(script), 'utf-8')

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -9,6 +9,7 @@ sys.path.insert(1, str((Path(__file__) / '..' / '..' / '..' / '..').resolve()))
 
 from nominatim import cli
 from nominatim.config import Configuration
+from nominatim.db.connection import _Connection
 from nominatim.tools import refresh
 from nominatim.tokenizer import factory as tokenizer_factory
 from steps.utils import run_script
@@ -54,7 +55,7 @@ class NominatimEnvironment:
             dbargs['user'] = self.db_user
         if self.db_pass:
             dbargs['password'] = self.db_pass
-        conn = psycopg2.connect(**dbargs)
+        conn = psycopg2.connect(connection_factory=_Connection, **dbargs)
         return conn
 
     def next_code_coverage_file(self):
@@ -110,8 +111,13 @@ class NominatimEnvironment:
             self.website_dir.cleanup()
 
         self.website_dir = tempfile.TemporaryDirectory()
+
+        try:
+            conn = self.connect_database(dbname)
+        except:
+            conn = False
         refresh.setup_website(Path(self.website_dir.name) / 'website',
-                              self.get_test_config())
+                              self.get_test_config(), conn)
 
 
     def get_test_config(self):
@@ -231,13 +237,13 @@ class NominatimEnvironment:
         """ Setup a test against a fresh, empty test database.
         """
         self.setup_template_db()
-        self.write_nominatim_config(self.test_db)
         conn = self.connect_database(self.template_db)
         conn.set_isolation_level(0)
         cur = conn.cursor()
         cur.execute('DROP DATABASE IF EXISTS {}'.format(self.test_db))
         cur.execute('CREATE DATABASE {} TEMPLATE = {}'.format(self.test_db, self.template_db))
         conn.close()
+        self.write_nominatim_config(self.test_db)
         context.db = self.connect_database(self.test_db)
         context.db.autocommit = True
         psycopg2.extras.register_hstore(context.db, globally=False)

--- a/test/python/test_tools_refresh_setup_website.py
+++ b/test/python/test_tools_refresh_setup_website.py
@@ -18,16 +18,16 @@ def envdir(tmpdir):
 @pytest.fixture
 def test_script(envdir):
     def _create_file(code):
-        outfile = envdir / 'php' / 'website' / 'search.php'
+        outfile = envdir / 'php' / 'website' / 'reverse-only-search.php'
         outfile.write_text('<?php\n{}\n'.format(code), 'utf-8')
 
     return _create_file
 
 
-def run_website_script(envdir, config):
+def run_website_script(envdir, config, conn):
     config.lib_dir.php = envdir / 'php'
     config.project_dir = envdir
-    refresh.setup_website(envdir, config)
+    refresh.setup_website(envdir, config, conn)
 
     proc = subprocess.run(['/usr/bin/env', 'php', '-Cq',
                            envdir / 'search.php'], check=False)
@@ -37,36 +37,39 @@ def run_website_script(envdir, config):
 
 @pytest.mark.parametrize("setting,retval", (('yes', 10), ('no', 20)))
 def test_setup_website_check_bool(def_config, monkeypatch, envdir, test_script,
-                                  setting, retval):
+                                  setting, retval, temp_db_conn):
     monkeypatch.setenv('NOMINATIM_CORS_NOACCESSCONTROL', setting)
 
     test_script('exit(CONST_NoAccessControl ? 10 : 20);')
 
-    assert run_website_script(envdir, def_config) == retval
+    assert run_website_script(envdir, def_config, temp_db_conn) == retval
 
 
 @pytest.mark.parametrize("setting", (0, 10, 99067))
-def test_setup_website_check_int(def_config, monkeypatch, envdir, test_script, setting):
+def test_setup_website_check_int(def_config, monkeypatch, envdir, test_script, setting,
+                                 temp_db_conn):
     monkeypatch.setenv('NOMINATIM_LOOKUP_MAX_COUNT', str(setting))
 
     test_script('exit(CONST_Places_Max_ID_count == {} ? 10 : 20);'.format(setting))
 
-    assert run_website_script(envdir, def_config) == 10
+    assert run_website_script(envdir, def_config, temp_db_conn) == 10
 
 
-def test_setup_website_check_empty_str(def_config, monkeypatch, envdir, test_script):
+def test_setup_website_check_empty_str(def_config, monkeypatch, envdir, test_script,
+                                       temp_db_conn):
     monkeypatch.setenv('NOMINATIM_DEFAULT_LANGUAGE', '')
 
     test_script('exit(CONST_Default_Language === false ? 10 : 20);')
 
-    assert run_website_script(envdir, def_config) == 10
+    assert run_website_script(envdir, def_config, temp_db_conn) == 10
 
 
-def test_setup_website_check_str(def_config, monkeypatch, envdir, test_script):
+def test_setup_website_check_str(def_config, monkeypatch, envdir, test_script,
+                                 temp_db_conn):
     monkeypatch.setenv('NOMINATIM_DEFAULT_LANGUAGE', 'ffde 2')
 
     test_script('exit(CONST_Default_Language === "ffde 2" ? 10 : 20);')
 
-    assert run_website_script(envdir, def_config) == 10
+    assert run_website_script(envdir, def_config, temp_db_conn) == 10
 
 


### PR DESCRIPTION
Fixes: #2267 

### This PR involves the following changes:

- Removed search query when --reverse-only data is imported.
- Updated documentation for adding a note to use a reverse query for testing --reverse-only imports.