### PR TITLE
fix: add the missing question mark

### DIFF
--- a/lib-php/website/search.php
+++ b/lib-php/website/search.php
@@ -74,7 +74,7 @@ if (isset($_SERVER['REQUEST_SCHEME'])
                 .$_SERVER['HTTP_HOST'].$_SERVER['DOCUMENT_URI'].'/?'
                 .http_build_query($aMoreParams);
 } else {
-    $sMoreURL = '/search.php'.http_build_query($aMoreParams);
+    $sMoreURL = '/search.php?'.http_build_query($aMoreParams);
 }
 
 if (CONST_Debug) exit;


### PR DESCRIPTION
I found this missing question mark on the "else" branch and added it back.

I caught this problem when using the latest version of the containerized Nominatim from here https://github.com/mediagis/nominatim-docker. The response caused an error in my OSM instance thus it led to the code in this PR.

Meanwhile I found the related problem of using `$_SERVER['DOCUMENT_URI']` which is not a standard PHP server env var and, to my understanding, it just doesn't exist when using an Apache server. I'll open another PR for it.

Thanks for reviewing.