### PR TITLE
fix: a more compatible way to get request path without the query string

### DIFF
--- a/lib-php/website/search.php
+++ b/lib-php/website/search.php
@@ -66,12 +66,14 @@ if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
     $aMoreParams['accept-language'] = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
 }
 
+$documentURI = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
 if (isset($_SERVER['REQUEST_SCHEME'])
     && isset($_SERVER['HTTP_HOST'])
-    && isset($_SERVER['DOCUMENT_URI'])
+    && isset($documentURI)
 ) {
     $sMoreURL = $_SERVER['REQUEST_SCHEME'].'://'
-                .$_SERVER['HTTP_HOST'].$_SERVER['DOCUMENT_URI'].'/?'
+                .$_SERVER['HTTP_HOST'].$documentURI.'/?'
                 .http_build_query($aMoreParams);
 } else {
     $sMoreURL = '/search.php'.http_build_query($aMoreParams);


### PR DESCRIPTION
This PR fixes the problem of using Nominatim behind the Apache server can cause variable `$_SERVER['DOCUMENT_URI']` being empty.

A little details on this: `DOCUMENT_URI` is not a standard PHP server environment variable making the `if` statement unreliable. To get a clean path of the request without query string, PHP offers a built-in function [`parse_url()`](https://www.php.net/manual/en/function.parse-url.php).

This is a related problem to https://github.com/osm-search/Nominatim/pull/2337

Thanks for the review!