### PR TITLE
Cleanup use of partial words in legacy tokenizers

### DIFF
--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -333,7 +333,9 @@ class SearchDescription
     public function extendWithPartialTerm($sToken, $oSearchTerm, $bStructuredPhrases, $iPhrase, $aFullTokens)
     {
         // Only allow name terms.
-        if (!(is_a($oSearchTerm, '\Nominatim\Token\Word'))) {
+        if (!(is_a($oSearchTerm, '\Nominatim\Token\Word'))
+            || strpos($sToken, ' ') !== false
+        ) {
             return array();
         }
 
@@ -361,7 +363,6 @@ class SearchDescription
 
         if ((!$this->sPostcode && !$this->aAddress && !$this->aAddressNonSearch)
             && ((empty($this->aName) && empty($this->aNameNonSearch)) || $this->iNamePhrase == $iPhrase)
-            && strpos($sToken, ' ') === false
         ) {
             $oSearch = clone $this;
             $oSearch->iSearchRank++;

--- a/nominatim/tokenizer/legacy_icu_tokenizer.py
+++ b/nominatim/tokenizer/legacy_icu_tokenizer.py
@@ -537,8 +537,6 @@ class _TokenInfo:
         """
         # Start with all partial names
         terms = set((part for ns in names for part in ns.split()))
-        # Add partials for the full terms (TO BE REMOVED)
-        terms.update((n for n in names))
         # Add the full names
         terms.update((' ' + n for n in names))
 

--- a/nominatim/tokenizer/legacy_icu_tokenizer.py
+++ b/nominatim/tokenizer/legacy_icu_tokenizer.py
@@ -423,8 +423,7 @@ class LegacyICUNameAnalyzer:
         names = place.get('name')
 
         if names:
-            full_names = set((self.make_standard_word(name) for name in names.values()))
-            full_names.discard('')
+            full_names = self._compute_full_names(names)
 
             token_info.add_names(self.conn, full_names)
 
@@ -459,6 +458,25 @@ class LegacyICUNameAnalyzer:
                 token_info.add_address_terms(self.conn, addr_terms)
 
         return token_info.data
+
+
+    def _compute_full_names(self, names):
+        """ Return the set of all full name word ids to be used with the
+            given dictionary of names.
+        """
+        full_names = set()
+        for name in (n for ns in names.values() for n in re.split('[;,]', ns)):
+            word = self.make_standard_word(name)
+            if word:
+                full_names.add(word)
+
+                brace_split = name.split('(', 2)
+                if len(brace_split) > 1:
+                    word = self.make_standard_word(brace_split[0])
+                    if word:
+                        full_names.add(word)
+
+        return full_names
 
 
     def _add_postcode(self, postcode):

--- a/nominatim/tokenizer/legacy_tokenizer.py
+++ b/nominatim/tokenizer/legacy_tokenizer.py
@@ -513,10 +513,9 @@ class _TokenInfo:
         """
         def _get_place(name):
             with conn.cursor() as cur:
-                cur.execute("""SELECT (addr_ids_from_name(%s)
-                                       || getorcreate_name_id(make_standard_name(%s), ''))::text,
+                cur.execute("""SELECT make_keywords(hstore('name' , %s))::text,
                                       word_ids_from_name(%s)::text""",
-                            (name, name, name))
+                            (name, name))
                 return cur.fetchone()
 
         self.data['place_search'], self.data['place_match'] = \

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,8 +4,8 @@ no-test-db: bdd-no-test-db php
 bdd:
 	cd bdd && behave -DREMOVE_TEMPLATE=1
 
-bdd-no-test-db:
-	cd bdd && behave -DREMOVE_TEMPLATE=1 db osm2pgsql
+icu:
+	cd bdd && behave -DREMOVE_TEMPLATE=1 -DTOKENIZER=legacy_icu
 
 php:
 	cd php && phpunit ./

--- a/test/bdd/db/import/search_name.feature
+++ b/test/bdd/db/import/search_name.feature
@@ -2,6 +2,29 @@
 Feature: Creation of search terms
     Tests that search_name table is filled correctly
 
+    Scenario Outline: Comma- and semicolon separated names appear as full names
+        Given the places
+         | osm | class   | type | name+alt_name |
+         | N1  | place   | city | New York<sep>Big Apple |
+        When importing
+        Then search_name contains
+         | object | name_vector |
+         | N1     | #New York, #Big Apple |
+
+    Examples:
+         | sep |
+         | ,   |
+         | ;   |
+
+    Scenario Outline: Name parts before brackets appear as full names
+        Given the places
+         | osm | class   | type | name+name |
+         | N1  | place   | city | Halle (Saale) |
+        When importing
+        Then search_name contains
+         | object | name_vector |
+         | N1     | #Halle Saale, #Halle |
+
     Scenario: Unnamed POIs have no search entry
         Given the scene roads-with-pois
         And the places
@@ -49,7 +72,7 @@ Feature: Creation of search terms
         When importing
         Then search_name contains
          | object | nameaddress_vector |
-         | N1     | Rose Street, Little, Big, Town |
+         | N1     | #Rose Street, rose, Little, Big, Town |
         When searching for "23 Rose Street, Little Big Town"
         Then results contain
          | osm_type | osm_id | name |

--- a/test/python/test_tokenizer_legacy_icu.py
+++ b/test/python/test_tokenizer_legacy_icu.py
@@ -223,11 +223,32 @@ def test_update_special_phrase_modify(analyzer, word_table):
 
 
 def test_process_place_names(analyzer, getorcreate_term_id):
-
     with analyzer() as anl:
         info = anl.process_place({'name' : {'name' : 'Soft bAr', 'ref': '34'}})
 
-    assert info['names'] == '{1,2,3,4,5,6}'
+    assert info['names'] == '{1,2,3,4,5}'
+
+
+@pytest.mark.parametrize('sep', [',' , ';'])
+def test_full_names_with_separator(analyzer, getorcreate_term_id, sep):
+    with analyzer() as anl:
+        full_names =
+            anl._compute_full_names({'name' : sep.join(('New York', 'Big Apple'))})
+
+        expect = set((anl.make_standard_word(w) for w in ('New York', 'Big Apple')))
+
+    assert full_names == expect
+
+
+def test_process_place_names_with_bracket(analyzer, getorcreate_term_id):
+    with analyzer() as anl:
+        info = anl.process_place({'name' :
+                                   {'name' : 'Houseboat (left)'}})
+
+        expect = set((anl.make_standard_word(w) for w in
+                       (' houseboat', ' houseboat left', 'houseboat', 'left')))
+
+    assert eval(info['names']) == expect
 
 
 @pytest.mark.parametrize('pcode', ['12345', 'AB 123', '34-345'])

--- a/test/python/test_tokenizer_legacy_icu.py
+++ b/test/python/test_tokenizer_legacy_icu.py
@@ -232,23 +232,16 @@ def test_process_place_names(analyzer, getorcreate_term_id):
 @pytest.mark.parametrize('sep', [',' , ';'])
 def test_full_names_with_separator(analyzer, getorcreate_term_id, sep):
     with analyzer() as anl:
-        full_names =
-            anl._compute_full_names({'name' : sep.join(('New York', 'Big Apple'))})
+        names = anl._compute_full_names({'name' : sep.join(('New York', 'Big Apple'))})
 
-        expect = set((anl.make_standard_word(w) for w in ('New York', 'Big Apple')))
-
-    assert full_names == expect
+    assert names == set(('NEW YORK', 'BIG APPLE'))
 
 
-def test_process_place_names_with_bracket(analyzer, getorcreate_term_id):
+def test_full_names_with_bracket(analyzer, getorcreate_term_id):
     with analyzer() as anl:
-        info = anl.process_place({'name' :
-                                   {'name' : 'Houseboat (left)'}})
+        names = anl._compute_full_names({'name' : 'Houseboat (left)'})
 
-        expect = set((anl.make_standard_word(w) for w in
-                       (' houseboat', ' houseboat left', 'houseboat', 'left')))
-
-    assert eval(info['names']) == expect
+    assert names == set(('HOUSEBOAT (LEFT)', 'HOUSEBOAT'))
 
 
 @pytest.mark.parametrize('pcode', ['12345', 'AB 123', '34-345'])


### PR DESCRIPTION
Partial words should only ever comprise single-word terms. This cleans up import and search use in that regard. make_keywords was still creating multi-word partials from the full names, which was never really used in search and just doubles the size of the word table. The terms used for place address terms have also been adapted.

As part of this cleanup, names with commas, semi-colons and brackets are handled now slightly different on import: commas and semicolons are now considered to split a name into full words. Also a part before an opening bracket is considered an additional full word. The latter means that now town names like 'Halle (Saale)' will be found as 'Halle' and 'Halle Saale' equally well and the additional `short_name` tag is no longer necessary.