### PR TITLE
Call freeze after running and non-updateable import

### DIFF
--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -52,10 +52,8 @@ class SetupAll:
 
     @staticmethod
     def run(args): # pylint: disable=too-many-statements
-        from ..tools import database_import
-        from ..tools import refresh
+        from ..tools import database_import, refresh, postcodes, freeze
         from ..indexer.indexer import Indexer
-        from ..tools import postcodes
         from ..tokenizer import factory as tokenizer_factory
 
         if args.osm_file and not Path(args.osm_file).is_file():
@@ -135,7 +133,11 @@ class SetupAll:
             LOG.warning('Create search index for default country names.')
             database_import.create_country_names(conn, tokenizer,
                                                  args.config.LANGUAGES)
+            conn.commit()
+            if args.no_updates:
+                freeze.drop_update_tables(conn)
         tokenizer.finalize_import(args.config)
+
 
         webdir = args.project_dir / 'website'
         LOG.warning('Setup website at %s', webdir)

--- a/nominatim/db/status.py
+++ b/nominatim/db/status.py
@@ -17,7 +17,10 @@ def compute_database_date(conn):
     """
     # First, find the node with the highest ID in the database
     with conn.cursor() as cur:
-        osmid = cur.scalar("SELECT max(osm_id) FROM place WHERE osm_type='N'")
+        if conn.table_exists('place'):
+            osmid = cur.scalar("SELECT max(osm_id) FROM place WHERE osm_type='N'")
+        else:
+            osmid = cur.scalar("SELECT max(osm_id) FROM placex WHERE osm_type='N'")
 
         if osmid is None:
             LOG.fatal("No data found in the database.")


### PR DESCRIPTION
Some of the tables will have already been removed but the tables for indexing are still there and should be dropped.

Fixes #2354.