### PR TITLE
Do not return POIs when dropping house number in query

### DIFF
--- a/lib-php/Result.php
+++ b/lib-php/Result.php
@@ -55,6 +55,27 @@ class Result
             }
         )));
     }
+
+    public static function joinIdsByTableMinRank($aResults, $iTable, $iMinAddressRank)
+    {
+        return join(',', array_keys(array_filter(
+            $aResults,
+            function ($aValue) use ($iTable, $iMinAddressRank) {
+                return $aValue->iTable == $iTable && $aValue->iAddressRank >= $iMinAddressRank;
+            }
+        )));
+    }
+
+    public static function joinIdsByTableMaxRank($aResults, $iTable, $iMaxAddressRank)
+    {
+        return join(',', array_keys(array_filter(
+            $aResults,
+            function ($aValue) use ($iTable, $iMaxAddressRank) {
+                return $aValue->iTable == $iTable && $aValue->iAddressRank <= $iMaxAddressRank;
+            }
+        )));
+    }
+
     public static function sqlHouseNumberTable($aResults, $iTable)
     {
         $sHousenumbers = '';

--- a/test/bdd/db/query/search_simple.feature
+++ b/test/bdd/db/query/search_simple.feature
@@ -45,3 +45,30 @@ Feature: Searching of simple objects
         Then result addresses contain
          | amenity | road |
          | Bean    | The build |
+
+    Scenario: when missing housenumbers in search don't return a POI
+        Given the places
+         | osm | class   | type       | name        |
+         | N3  | amenity | restaurant | Wood Street |
+        And the places
+         | osm | class   | type       | name        | housenr |
+         | N20 | amenity | restaurant | Red Way     | 34      |
+        When importing
+        And sending search query "Wood Street 45"
+        Then exactly 0 results are returned
+        When sending search query "Red Way 34"
+        Then results contain
+         | osm |
+         | N20 |
+
+     Scenario: when the housenumber is missing the stret is still returned
+        Given the grid
+         | 1 |  | 2 |
+        Given the places
+         | osm | class   | type        | name        | geometry |
+         | W1  | highway | residential | Wood Street | 1, 2     |
+        When importing
+        And sending search query "Wood Street"
+        Then results contain
+         | osm |
+         | W1  |


### PR DESCRIPTION
We've previously added searching through rank 30 in a house
number search to enable searches for house number + name.
This had the unintended side effect that rank 30 objects
are also returned in s search that dropped the house number
from the query. This is wrong because POIs cannot function
as a parent to a house number.

This fix drops all rank 30 objects from the results for a
house number search if they do not match the requested house
number.

Fixes #2364.