### PR TITLE
Increase minimum required Python version to 3.6

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -126,7 +126,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                python-version: 3.5
+                python-version: 3.6
               if: matrix.ubuntu == 18
 
             - uses: ./Nominatim/.github/actions/setup-postgresql

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -39,7 +39,7 @@ For running Nominatim:
 
   * [PostgreSQL](https://www.postgresql.org) (9.3+ will work, 11+ strongly recommended)
   * [PostGIS](https://postgis.net) (2.2+)
-  * [Python 3](https://www.python.org/) (3.5+)
+  * [Python 3](https://www.python.org/) (3.6+)
   * [Psycopg2](https://www.psycopg.org) (2.7+)
   * [Python Dotenv](https://github.com/theskumar/python-dotenv)
   * [psutil](https://github.com/giampaolo/psutil)


### PR DESCRIPTION
Python 3.6 introduces formatted string literals and flag enums as well as a much faster dict implementation. These changes make the code so much simpler as to warrant dropping Python 3.5 support.

Affected distributions are Ubuntu 16.04 and Debian Stretch. The former is EOL already and the latter will have ceased to be oldstable by the time we do the next release.