### PR TITLE
Further tweaking of search cost

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -348,8 +348,6 @@ class Geocode
                         foreach ($oValidTokens->get(' '.$sToken) as $oSearchTerm) {
                             $aNewSearches = $oCurrentSearch->extendWithFullTerm(
                                 $oSearchTerm,
-                                $oValidTokens->contains($sToken)
-                                  && strpos($sToken, ' ') === false,
                                 $sPhraseType,
                                 $iToken == 0 && $iPhrase == 0,
                                 $iPhrase == 0,

--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -153,8 +153,6 @@ class SearchDescription
      * Derive new searches by adding a full term to the existing search.
      *
      * @param object $oSearchTerm  Description of the token.
-     * @param bool   $bHasPartial  True if there are also tokens of partial terms
-     *                             with the same name.
      * @param string $sPhraseType  Type of phrase the token is contained in.
      * @param bool   $bFirstToken  True if the token is at the beginning of the
      *                             query.
@@ -164,7 +162,7 @@ class SearchDescription
      *
      * @return SearchDescription[] List of derived search descriptions.
      */
-    public function extendWithFullTerm($oSearchTerm, $bHasPartial, $sPhraseType, $bFirstToken, $bFirstPhrase, $bLastToken)
+    public function extendWithFullTerm($oSearchTerm, $sPhraseType, $bFirstToken, $bFirstPhrase, $bLastToken)
     {
         $aNewSearches = array();
 
@@ -244,6 +242,7 @@ class SearchDescription
                 $oSearch->iNamePhrase = -1;
                 $oSearch->sHouseNumber = $oSearchTerm->sToken;
                 $aNewSearches[] = $oSearch;
+
                 // Housenumbers may appear in the name when the place has its own
                 // address terms.
                 if ($oSearchTerm->iId !== null
@@ -297,10 +296,10 @@ class SearchDescription
             // the first phrase. In unstructured search it may be in a later
             // phrase when the first phrase is a house number.
             if (!empty($this->aName) || !($bFirstPhrase || $sPhraseType == '')) {
-                if (($sPhraseType == '' || !$bFirstPhrase) && !$bHasPartial) {
+                if (($sPhraseType == '' || !$bFirstPhrase) && $oSearchTerm->iTermCount > 1) {
                     $oSearch = clone $this;
                     $oSearch->iNamePhrase = -1;
-                    $oSearch->iSearchRank += 3 * $oSearchTerm->iTermCount;
+                    $oSearch->iSearchRank += 1;
                     $oSearch->aAddress[$iWordID] = $iWordID;
                     $aNewSearches[] = $oSearch;
                 }


### PR DESCRIPTION
With the switch to using full word terms for multi-word terms in #2346, such words must no longer penalized.

Also increases the penalty for housenumber-as-name searches to match the penalty for regular searches with housenumber.

Fixes #2372.