### PR TITLE
Exclude name:etymology and name:signed

### DIFF
--- a/settings/import-address.style
+++ b/settings/import-address.style
@@ -12,7 +12,7 @@
 },
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
-              "name:botanical", "*wikidata"],
+              "name:etymology", "name:signed", "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }

--- a/settings/import-admin.style
+++ b/settings/import-admin.style
@@ -6,7 +6,7 @@
 },
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
-              "name:botanical", "*wikidata"],
+              "name:etymology", "name:signed", "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }

--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -7,7 +7,7 @@
 },
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
-              "name:botanical", "wikidata", "*:wikidata"],
+              "name:etymology", "name:signed", "name:botanical", "wikidata", "*:wikidata"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -7,7 +7,7 @@
 },
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
-              "name:botanical", "wikidata", "*:wikidata"],
+              "name:etymology", "name:signed", "name:botanical", "wikidata", "*:wikidata"],
     "values" : {
         "" : "extra"
     }

--- a/settings/import-street.style
+++ b/settings/import-street.style
@@ -6,7 +6,7 @@
 },
 {
     "keys" : ["name:prefix", "name:suffix", "name:prefix:*", "name:suffix:*",
-              "name:botanical", "*wikidata"],
+              "name:etymology", "name:signed", "name:botanical", "*wikidata"],
     "values" : {
         "" : "skip"
     }


### PR DESCRIPTION
name:etymology contains a description of the name origin and is thus more informative than search-worthy.

name:signed only indicates that the feature does not have a name.