### PR TITLE
Reorganise code that build the SearchDescription

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -363,7 +363,6 @@ class Geocode
                     foreach ($aWordsetSearches as $oCurrentSearch) {
                         foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
                             $aNewSearches = $oCurrentSearch->extendWithSearchTerm(
-                                $sToken,
                                 $oSearchTerm,
                                 $oPosition
                             );

--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -362,8 +362,8 @@ class Geocode
 
                     foreach ($aWordsetSearches as $oCurrentSearch) {
                         foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
-                            $aNewSearches = $oCurrentSearch->extendWithSearchTerm(
-                                $oSearchTerm,
+                            $aNewSearches = $oSearchTerm->extendSearch(
+                                $oCurrentSearch,
                                 $oPosition
                             );
 

--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -7,6 +7,7 @@ require_once(CONST_LibDir.'/Phrase.php');
 require_once(CONST_LibDir.'/ReverseGeocode.php');
 require_once(CONST_LibDir.'/SearchDescription.php');
 require_once(CONST_LibDir.'/SearchContext.php');
+require_once(CONST_LibDir.'/SearchPosition.php');
 require_once(CONST_LibDir.'/TokenList.php');
 require_once(CONST_TokenizerDir.'/tokenizer.php');
 
@@ -345,7 +346,11 @@ class Geocode
          */
         foreach ($aPhrases as $iPhrase => $oPhrase) {
             $aNewPhraseSearches = array();
-            $sPhraseType = $oPhrase->getPhraseType();
+            $oPosition = new SearchPosition(
+                $oPhrase->getPhraseType(),
+                $iPhrase,
+                count($aPhrases)
+            );
 
             foreach ($oPhrase->getWordSets() as $aWordset) {
                 $aWordsetSearches = $aSearches;
@@ -353,17 +358,14 @@ class Geocode
                 // Add all words from this wordset
                 foreach ($aWordset as $iToken => $sToken) {
                     $aNewWordsetSearches = array();
+                    $oPosition->setTokenPosition($iToken, count($aWordset));
 
                     foreach ($aWordsetSearches as $oCurrentSearch) {
                         foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
                             $aNewSearches = $oCurrentSearch->extendWithSearchTerm(
                                 $sToken,
                                 $oSearchTerm,
-                                $sPhraseType,
-                                $iToken == 0 && $iPhrase == 0,
-                                $iToken + 1 == count($aWordset)
-                                  && $iPhrase + 1 == count($aPhrases),
-                                $iPhrase
+                                $oPosition
                             );
 
                             foreach ($aNewSearches as $oSearch) {

--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -555,15 +555,15 @@ class Geocode
 
                 if (!empty($aTokens)) {
                     $aNewSearches = array();
+                    $oPosition = new SearchPosition('', 0, 1);
+                    $oPosition->setTokenPosition(0, 1);
+
                     foreach ($aSearches as $oSearch) {
                         foreach ($aTokens as $oToken) {
-                            $oNewSearch = clone $oSearch;
-                            $oNewSearch->setPoiSearch(
-                                $oToken->iOperator,
-                                $oToken->sClass,
-                                $oToken->sType
+                            $aNewSearches = array_merge(
+                                $aNewSearches,
+                                $oToken->extendSearch($oSearch, $oPosition)
                             );
-                            $aNewSearches[] = $oNewSearch;
                         }
                     }
                     $aSearches = $aNewSearches;

--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -362,14 +362,16 @@ class Geocode
 
                     foreach ($aWordsetSearches as $oCurrentSearch) {
                         foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
-                            $aNewSearches = $oSearchTerm->extendSearch(
-                                $oCurrentSearch,
-                                $oPosition
-                            );
+                            if ($oSearchTerm->isExtendable($oCurrentSearch, $oPosition)) {
+                                $aNewSearches = $oSearchTerm->extendSearch(
+                                    $oCurrentSearch,
+                                    $oPosition
+                                );
 
-                            foreach ($aNewSearches as $oSearch) {
-                                if ($oSearch->getRank() < $this->iMaxRank) {
-                                    $aNewWordsetSearches[] = $oSearch;
+                                foreach ($aNewSearches as $oSearch) {
+                                    if ($oSearch->getRank() < $this->iMaxRank) {
+                                        $aNewWordsetSearches[] = $oSearch;
+                                    }
                                 }
                             }
                         }

--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -355,41 +355,20 @@ class Geocode
                     $aNewWordsetSearches = array();
 
                     foreach ($aWordsetSearches as $oCurrentSearch) {
-                        // Tokens with full name matches.
-                        foreach ($oValidTokens->get(' '.$sToken) as $oSearchTerm) {
-                            $aNewSearches = $oCurrentSearch->extendWithFullTerm(
+                        foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
+                            $aNewSearches = $oCurrentSearch->extendWithSearchTerm(
+                                $sToken,
                                 $oSearchTerm,
                                 $sPhraseType,
                                 $iToken == 0 && $iPhrase == 0,
-                                $iPhrase == 0,
                                 $iToken + 1 == count($aWordset)
-                                  && $iPhrase + 1 == count($aPhrases)
+                                  && $iPhrase + 1 == count($aPhrases),
+                                $iPhrase
                             );
 
                             foreach ($aNewSearches as $oSearch) {
                                 if ($oSearch->getRank() < $this->iMaxRank) {
                                     $aNewWordsetSearches[] = $oSearch;
-                                }
-                            }
-                        }
-                        // Look for partial matches.
-                        // Note that there is no point in adding country terms here
-                        // because country is omitted in the address.
-                        if ($sPhraseType != 'country') {
-                            // Allow searching for a word - but at extra cost
-                            foreach ($oValidTokens->get($sToken) as $oSearchTerm) {
-                                $aNewSearches = $oCurrentSearch->extendWithPartialTerm(
-                                    $sToken,
-                                    $oSearchTerm,
-                                    (bool) $sPhraseType,
-                                    $iPhrase,
-                                    $oValidTokens->get(' '.$sToken)
-                                );
-
-                                foreach ($aNewSearches as $oSearch) {
-                                    if ($oSearch->getRank() < $this->iMaxRank) {
-                                        $aNewWordsetSearches[] = $oSearch;
-                                    }
                                 }
                             }
                         }

--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -152,14 +152,13 @@ class SearchDescription
     /**
      * Derive new searches by adding a full term to the existing search.
      *
-     * @param string  $sToken       Term for the token.
      * @param object  $oSearchTerm  Description of the token.
      * @param object  $oPosition    Description of the token position within
                                     the query.
      *
      * @return SearchDescription[] List of derived search descriptions.
      */
-    public function extendWithSearchTerm($sToken, $oSearchTerm, $oPosition)
+    public function extendWithSearchTerm($oSearchTerm, $oPosition)
     {
         $aNewSearches = array();
 
@@ -315,10 +314,8 @@ class SearchDescription
             }
         } elseif (!$oPosition->isPhrase('country')
                   && is_a($oSearchTerm, '\Nominatim\Token\Partial')
-                  && strpos($sToken, ' ') === false
         ) {
             $aNewSearches = $this->extendWithPartialTerm(
-                $sToken,
                 $oSearchTerm,
                 $oPosition
             );
@@ -330,14 +327,13 @@ class SearchDescription
     /**
      * Derive new searches by adding a partial term to the existing search.
      *
-     * @param string  $sToken       Term for the token.
      * @param object  $oSearchTerm  Description of the token.
      * @param object  $oPosition    Description of the token position within
                                     the query.
      *
      * @return SearchDescription[] List of derived search descriptions.
      */
-    private function extendWithPartialTerm($sToken, $oSearchTerm, $oPosition)
+    private function extendWithPartialTerm($oSearchTerm, $oPosition)
     {
         $aNewSearches = array();
         $iWordID = $oSearchTerm->iId;
@@ -347,7 +343,7 @@ class SearchDescription
         ) {
             $oSearch = clone $this;
             $oSearch->iSearchRank++;
-            if (preg_match('#^[0-9 ]+$#', $sToken)) {
+            if (preg_match('#^[0-9 ]+$#', $oSearchTerm->sToken)) {
                 $oSearch->iSearchRank++;
             }
             if ($oSearchTerm->iSearchNameCount < CONST_Max_Word_Frequency) {
@@ -367,7 +363,7 @@ class SearchDescription
             if (empty($this->aName) && empty($this->aNameNonSearch)) {
                 $oSearch->iSearchRank++;
             }
-            if (preg_match('#^[0-9 ]+$#', $sToken)) {
+            if (preg_match('#^[0-9 ]+$#', $oSearchTerm->sToken)) {
                 $oSearch->iSearchRank++;
             }
             if ($oSearchTerm->iSearchNameCount < CONST_Max_Word_Frequency) {

--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -118,6 +118,14 @@ class SearchDescription
     }
 
     /////////// Search building functions
+
+    /**
+     * Create a copy of this search description adding to search rank.
+     *
+     * @param integer $iTermCost  Cost to add to the current search rank.
+     *
+     * @return object Cloned search description.
+     */
     public function clone($iTermCost)
     {
         $oSearch = clone $this;
@@ -126,37 +134,82 @@ class SearchDescription
         return $oSearch;
     }
 
+    /**
+     * Check if the search currently includes a name.
+     *
+     * @param bool bIncludeNonNames  If true stop-word tokens are taken into
+     *                               account, too.
+     *
+     * @return bool True, if search has a name.
+     */
     public function hasName($bIncludeNonNames = false)
     {
         return !empty($this->aName)
                || (!empty($this->aNameNonSearch) && $bIncludeNonNames);
     }
 
+    /**
+     * Check if the search currently includes an address term.
+     *
+     * @return bool True, if any address term is included, including stop-word
+     *              terms.
+     */
     public function hasAddress()
     {
         return !empty($this->aAddress) || !empty($this->aAddressNonSearch);
     }
 
+    /**
+     * Check if a country restriction is currently included in the search.
+     *
+     * @return bool True, if a country restriction is set.
+     */
     public function hasCountry()
     {
         return $this->sCountryCode !== '';
     }
 
+    /**
+     * Check if a postcode is currently included in the search.
+     *
+     * @return bool True, if a postcode is set.
+     */
     public function hasPostcode()
     {
         return $this->sPostcode !== '';
     }
 
+    /**
+     * Check if a house number is set for the search.
+     *
+     * @return bool True, if a house number is set.
+     */
     public function hasHousenumber()
     {
         return $this->sHouseNumber !== '';
     }
 
+    /**
+     * Check if a special type of place is requested.
+     *
+     * param integer iOperator  When set, check for the particular
+     *                          operator used for the special type.
+     *
+     * @return bool True, if speial type is requested or, if requested,
+     *              a special type with the given operator.
+     */
     public function hasOperator($iOperator = null)
     {
         return $iOperator === null ? $this->iOperator != Operator::NONE : $this->iOperator == $iOperator;
     }
 
+    /**
+     * Add the given token to the list of terms to search for in the address.
+     *
+     * @param integer iID       ID of term to add.
+     * @param bool bSearchable  Term should be used to search for result
+     *                          (i.e. term is not a stop word).
+     */
     public function addAddressToken($iId, $bSearchable = true)
     {
         if ($bSearchable) {
@@ -166,11 +219,27 @@ class SearchDescription
         }
     }
 
+    /**
+     * Add the given full-word token to the list of terms to search for in the
+     * name.
+     *
+     * @param interger iId  ID of term to add.
+     */
     public function addNameToken($iId)
     {
         $this->aName[$iId] = $iId;
     }
 
+    /**
+     * Add the given partial token to the list of terms to search for in
+     * the name.
+     *
+     * @param integer iID            ID of term to add.
+     * @param bool bSearchable       Term should be used to search for result
+     *                               (i.e. term is not a stop word).
+     * @param integer iPhraseNumber  Index of phrase, where the partial term
+     *                               appears.
+     */
     public function addPartialNameToken($iId, $bSearchable, $iPhraseNumber)
     {
         if ($bSearchable) {
@@ -186,18 +255,34 @@ class SearchDescription
         $this->bRareName = true;
     }
 
+    /**
+     * Set country restriction for the search.
+     *
+     * @param string sCountryCode  Country code of country to restrict search to.
+     */
     public function setCountry($sCountryCode)
     {
         $this->sCountryCode = $sCountryCode;
         $this->iNamePhrase = -1;
     }
 
+    /**
+     * Set postcode search constraint.
+     *
+     * @param string sPostcode  Postcode the result should have.
+     */
     public function setPostcode($sPostcode)
     {
         $this->sPostcode = $sPostcode;
         $this->iNamePhrase = -1;
     }
 
+    /**
+     * Make this search a search for a postcode object.
+     *
+     * @param integer iId       Token Id for the postcode.
+     * @param string sPostcode  Postcode to look for.
+     */
     public function setPostcodeAsName($iId, $sPostcode)
     {
         $this->iOperator = Operator::POSTCODE;
@@ -207,12 +292,22 @@ class SearchDescription
         $this->iNamePhrase = -1;
     }
 
+    /**
+     * Set house number search cnstraint.
+     *
+     * @param string sNumber  House number the result should have.
+     */
     public function setHousenumber($sNumber)
     {
         $this->sHouseNumber = $sNumber;
         $this->iNamePhrase = -1;
     }
 
+    /**
+     * Make this search a search for a house number.
+     *
+     * @param integer iId  Token Id for the house number.
+     */
     public function setHousenumberAsName($iId)
     {
         $this->aAddress = array_merge($this->aAddress, $this->aName);
@@ -246,6 +341,11 @@ class SearchDescription
         return $this->iNamePhrase;
     }
 
+    /**
+     * Get the global search context.
+     *
+     * @return object  Objects of global search constraints.
+     */
     public function getContext()
     {
         return $this->oContext;

--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -223,11 +223,14 @@ class SearchDescription
      * Add the given full-word token to the list of terms to search for in the
      * name.
      *
-     * @param interger iId  ID of term to add.
+     * @param interger iId    ID of term to add.
+     * @param bool bRareName  True if the term is infrequent enough to not
+     *                        require other constraints for efficient search.
      */
-    public function addNameToken($iId)
+    public function addNameToken($iId, $bRareName)
     {
         $this->aName[$iId] = $iId;
+        $this->bRareName = $bRareName;
     }
 
     /**
@@ -248,11 +251,6 @@ class SearchDescription
             $this->aNameNonSearch[$iId] = $iId;
         }
         $this->iNamePhrase = $iPhraseNumber;
-    }
-
-    public function markRareName()
-    {
-        $this->bRareName = true;
     }
 
     /**

--- a/lib-php/SearchPosition.php
+++ b/lib-php/SearchPosition.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Nominatim;
+
+/**
+ * Description of the position of a token within a query.
+ */
+class SearchPosition
+{
+    private $sPhraseType;
+
+    private $iPhrase;
+    private $iNumPhrases;
+
+    private $iToken;
+    private $iNumTokens;
+
+
+    public function __construct($sPhraseType, $iPhrase, $iNumPhrases)
+    {
+        $this->sPhraseType = $sPhraseType;
+        $this->iPhrase = $iPhrase;
+        $this->iNumPhrases = $iNumPhrases;
+    }
+
+    public function setTokenPosition($iToken, $iNumTokens)
+    {
+        $this->iToken = $iToken;
+        $this->iNumTokens = $iNumTokens;
+    }
+
+    /**
+     * Check if the phrase can be of the given type.
+     *
+     * @param string  $sType  Type of phrse requested.
+     *
+     * @return True if the phrase is untyped or of the given type.
+     */
+    public function maybePhrase($sType)
+    {
+        return $this->sPhraseType == '' || $this->sPhraseType == $sType;
+    }
+
+    /**
+     * Check if the phrase is exactly of the given type.
+     *
+     * @param string  $sType  Type of phrse requested.
+     *
+     * @return True if the phrase of the given type.
+     */
+    public function isPhrase($sType)
+    {
+        return $this->sPhraseType == $sType;
+    }
+
+    /**
+     * Return true if the token is the very first in the query.
+     */
+    public function isFirstToken()
+    {
+        return $this->iPhrase == 0 && $this->iToken == 0;
+    }
+
+    /**
+     * Check if the token is the final one in the query.
+     */
+    public function isLastToken()
+    {
+        return $this->iToken + 1 == $this->iNumTokens && $this->iPhrase + 1 == $this->iNumPhrases;
+    }
+
+    /**
+     * Check if the current token is part of the first phrase in the query.
+     */
+    public function isFirstPhrase()
+    {
+        return $this->iPhrase == 0;
+    }
+
+    /**
+     * Get the phrase position in the query.
+     */
+    public function getPhrase()
+    {
+        return $this->iPhrase;
+    }
+}

--- a/lib-php/TokenCountry.php
+++ b/lib-php/TokenCountry.php
@@ -8,14 +8,40 @@ namespace Nominatim\Token;
 class Country
 {
     /// Database word id, if available.
-    public $iId;
+    private $iId;
     /// Two-letter country code (lower-cased).
-    public $sCountryCode;
+    private $sCountryCode;
 
     public function __construct($iId, $sCountryCode)
     {
         $this->iId = $iId;
         $this->sCountryCode = $sCountryCode;
+    }
+
+    public function getId()
+    {
+        return $this->iId;
+    }
+
+    /**
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return SearchDescription[] List of derived search descriptions.
+     */
+    public function extendSearch($oSearch, $oPosition)
+    {
+        if ($oSearch->hasCountry() || !$oPosition->maybePhrase('country')) {
+            return array();
+        }
+
+        $oNewSearch = $oSearch->clone($oPosition->isLastToken() ? 1 : 6);
+        $oNewSearch->setCountry($this->sCountryCode);
+
+        return array($oNewSearch);
     }
 
     public function debugInfo()
@@ -25,5 +51,10 @@ class Country
                 'Type' => 'country',
                 'Info' => $this->sCountryCode
                );
+    }
+
+    public function debugCode()
+    {
+        return 'C';
     }
 }

--- a/lib-php/TokenCountry.php
+++ b/lib-php/TokenCountry.php
@@ -24,6 +24,22 @@ class Country
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oSearch->hasCountry() && $oPosition->maybePhrase('country');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -34,10 +50,6 @@ class Country
      */
     public function extendSearch($oSearch, $oPosition)
     {
-        if ($oSearch->hasCountry() || !$oPosition->maybePhrase('country')) {
-            return array();
-        }
-
         $oNewSearch = $oSearch->clone($oPosition->isLastToken() ? 1 : 6);
         $oNewSearch->setCountry($this->sCountryCode);
 

--- a/lib-php/TokenHousenumber.php
+++ b/lib-php/TokenHousenumber.php
@@ -24,6 +24,24 @@ class HouseNumber
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oSearch->hasHousenumber()
+               && !$oSearch->hasOperator(\Nominatim\Operator::POSTCODE)
+               && $oPosition->maybePhrase('street');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -35,13 +53,6 @@ class HouseNumber
     public function extendSearch($oSearch, $oPosition)
     {
         $aNewSearches = array();
-
-        if ($oSearch->hasHousenumber()
-            || $oSearch->hasOperator(\Nominatim\Operator::POSTCODE)
-            || !$oPosition->maybePhrase('street')
-        ) {
-            return $aNewSearches;
-        }
 
         // sanity check: if the housenumber is not mainly made
         // up of numbers, add a penalty

--- a/lib-php/TokenHousenumber.php
+++ b/lib-php/TokenHousenumber.php
@@ -8,15 +8,78 @@ namespace Nominatim\Token;
 class HouseNumber
 {
     /// Database word id, if available.
-    public $iId;
+    private $iId;
     /// Normalized house number.
-    public $sToken;
+    private $sToken;
 
     public function __construct($iId, $sToken)
     {
         $this->iId = $iId;
         $this->sToken = $sToken;
     }
+
+    public function getId()
+    {
+        return $this->iId;
+    }
+
+    /**
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return SearchDescription[] List of derived search descriptions.
+     */
+    public function extendSearch($oSearch, $oPosition)
+    {
+        $aNewSearches = array();
+
+        if ($oSearch->hasHousenumber()
+            || $oSearch->hasOperator(\Nominatim\Operator::POSTCODE)
+            || !$oPosition->maybePhrase('street')
+        ) {
+            return $aNewSearches;
+        }
+
+        // sanity check: if the housenumber is not mainly made
+        // up of numbers, add a penalty
+        $iSearchCost = 1;
+        if (preg_match('/\\d/', $this->sToken) === 0
+            || preg_match_all('/[^0-9]/', $this->sToken, $aMatches) > 2) {
+            $iSearchCost++;
+        }
+        if (!$oSearch->hasOperator(\Nominatim\Operator::NONE)) {
+            $iSearchCost++;
+        }
+        if (empty($this->iId)) {
+            $iSearchCost++;
+        }
+        // also must not appear in the middle of the address
+        if ($oSearch->hasAddress() || $oSearch->hasPostcode()) {
+            $iSearchCost++;
+        }
+
+        $oNewSearch = $oSearch->clone($iSearchCost);
+        $oNewSearch->setHousenumber($this->sToken);
+        $aNewSearches[] = $oNewSearch;
+
+        // Housenumbers may appear in the name when the place has its own
+        // address terms.
+        if ($this->iId !== null
+            && ($oSearch->getNamePhrase() >= 0 || !$oSearch->hasName())
+            && !$oSearch->hasAddress()
+        ) {
+            $oNewSearch = $oSearch->clone($iSearchCost);
+            $oNewSearch->setHousenumberAsName($this->iId);
+
+            $aNewSearches[] = $oNewSearch;
+        }
+
+        return $aNewSearches;
+    }
+
 
     public function debugInfo()
     {
@@ -25,5 +88,10 @@ class HouseNumber
                 'Type' => 'house number',
                 'Info' => array('nr' => $this->sToken)
                );
+    }
+
+    public function debugCode()
+    {
+        return 'H';
     }
 }

--- a/lib-php/TokenList.php
+++ b/lib-php/TokenList.php
@@ -7,6 +7,7 @@ require_once(CONST_LibDir.'/TokenHousenumber.php');
 require_once(CONST_LibDir.'/TokenPostcode.php');
 require_once(CONST_LibDir.'/TokenSpecialTerm.php');
 require_once(CONST_LibDir.'/TokenWord.php');
+require_once(CONST_LibDir.'/TokenPartial.php');
 require_once(CONST_LibDir.'/SpecialSearchOperator.php');
 
 /**

--- a/lib-php/TokenList.php
+++ b/lib-php/TokenList.php
@@ -79,7 +79,7 @@ class TokenList
         foreach ($this->aTokens as $aTokenList) {
             foreach ($aTokenList as $oToken) {
                 if (is_a($oToken, '\Nominatim\Token\Word')) {
-                    $ids[$oToken->iId] = $oToken->iId;
+                    $ids[$oToken->getId()] = $oToken->getId();
                 }
             }
         }
@@ -109,9 +109,9 @@ class TokenList
         $aWordsIDs = array();
         foreach ($this->aTokens as $sToken => $aWords) {
             foreach ($aWords as $aToken) {
-                if ($aToken->iId !== null) {
-                    $aWordsIDs[$aToken->iId] =
-                        '#'.$sToken.'('.$aToken->iId.')#';
+                $iId = $aToken->getId();
+                if ($iId !== null) {
+                    $aWordsIDs[$iId] = '#'.$sToken.'('.$aToken->debugCode().' '.$iId.')#';
                 }
             }
         }

--- a/lib-php/TokenList.php
+++ b/lib-php/TokenList.php
@@ -18,15 +18,6 @@ require_once(CONST_LibDir.'/SpecialSearchOperator.php');
  * tokens do not have a common base class. All tokens need to have a field
  * with the word id that points to an entry in the `word` database table
  * but otherwise the information saved about a token can be very different.
- *
- * There are two different kinds of token words: full words and partial terms.
- *
- * Full words start with a space. They represent a complete name of a place.
- * All special tokens are normally full words.
- *
- * Partial terms have no space at the beginning. They may represent a part of
- * a name of a place (e.g. in the name 'World Trade Center' a partial term
- * would be 'Trade' or 'Trade Center'). They are only used in TokenWord.
  */
 class TokenList
 {
@@ -65,7 +56,7 @@ class TokenList
      */
     public function containsAny($sWord)
     {
-        return isset($this->aTokens[$sWord]) || isset($this->aTokens[' '.$sWord]);
+        return isset($this->aTokens[$sWord]);
     }
 
     /**
@@ -87,7 +78,7 @@ class TokenList
 
         foreach ($this->aTokens as $aTokenList) {
             foreach ($aTokenList as $oToken) {
-                if (is_a($oToken, '\Nominatim\Token\Word') && !$oToken->bPartial) {
+                if (is_a($oToken, '\Nominatim\Token\Word')) {
                     $ids[$oToken->iId] = $oToken->iId;
                 }
             }

--- a/lib-php/TokenPartial.php
+++ b/lib-php/TokenPartial.php
@@ -8,18 +8,85 @@ namespace Nominatim\Token;
 class Partial
 {
     /// Database word id, if applicable.
-    public $iId;
+    private $iId;
     /// Number of appearances in the database.
-    public $iSearchNameCount;
-    /// Normalised version of the partial word.
-    public $sToken;
+    private $iSearchNameCount;
+    /// True, if the token consists exclusively of digits and spaces.
+    private $bNumberToken;
 
     public function __construct($iId, $sToken, $iSearchNameCount)
     {
         $this->iId = $iId;
-        $this->sToken = $sToken;
+        $this->bNumberToken = (bool) preg_match('#^[0-9 ]+$#', $sToken);
         $this->iSearchNameCount = $iSearchNameCount;
     }
+
+    public function getId()
+    {
+        return $this->iId;
+    }
+
+    /**
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return SearchDescription[] List of derived search descriptions.
+     */
+    public function extendSearch($oSearch, $oPosition)
+    {
+        if ($oPosition->isPhrase('country')) {
+            return array();
+        }
+
+        $aNewSearches = array();
+
+        // Partial token in Address.
+        if (($oPosition->isPhrase('') || !$oPosition->isFirstPhrase())
+            && $oSearch->hasName()
+        ) {
+            $iSearchCost = $this->bNumberToken ? 2 : 1;
+            if ($this->iSearchNameCount >= CONST_Max_Word_Frequency) {
+                $iSearchCost += 1;
+            }
+
+            $oNewSearch = $oSearch->clone($iSearchCost);
+            $oNewSearch->addAddressToken(
+                $this->iId,
+                $this->iSearchNameCount < CONST_Max_Word_Frequency
+            );
+
+            $aNewSearches[] = $oNewSearch;
+        }
+
+        // Partial token in Name.
+        if ((!$oSearch->hasPostcode() && !$oSearch->hasAddress())
+            && (!$oSearch->hasName(true)
+                || $oSearch->getNamePhrase() == $oPosition->getPhrase())
+        ) {
+            $iSearchCost = 1;
+            if (!$oSearch->hasName(true)) {
+                $iSearchCost += 1;
+            }
+            if ($this->bNumberToken) {
+                $iSearchCost += 1;
+            }
+
+            $oNewSearch = $oSearch->clone($iSearchCost);
+            $oNewSearch->addPartialNameToken(
+                $this->iId,
+                $this->iSearchNameCount < CONST_Max_Word_Frequency,
+                $oPosition->getPhrase()
+            );
+
+            $aNewSearches[] = $oNewSearch;
+        }
+
+        return $aNewSearches;
+    }
+
 
     public function debugInfo()
     {
@@ -30,5 +97,10 @@ class Partial
                            'count' => $this->iSearchNameCount
                           )
                );
+    }
+
+    public function debugCode()
+    {
+        return 'w';
     }
 }

--- a/lib-php/TokenPartial.php
+++ b/lib-php/TokenPartial.php
@@ -27,6 +27,22 @@ class Partial
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oPosition->isPhrase('country');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -37,10 +53,6 @@ class Partial
      */
     public function extendSearch($oSearch, $oPosition)
     {
-        if ($oPosition->isPhrase('country')) {
-            return array();
-        }
-
         $aNewSearches = array();
 
         // Partial token in Address.

--- a/lib-php/TokenPartial.php
+++ b/lib-php/TokenPartial.php
@@ -11,10 +11,13 @@ class Partial
     public $iId;
     /// Number of appearances in the database.
     public $iSearchNameCount;
+    /// Normalised version of the partial word.
+    public $sToken;
 
-    public function __construct($iId, $iSearchNameCount)
+    public function __construct($iId, $sToken, $iSearchNameCount)
     {
         $this->iId = $iId;
+        $this->sToken = $sToken;
         $this->iSearchNameCount = $iSearchNameCount;
     }
 

--- a/lib-php/TokenPartial.php
+++ b/lib-php/TokenPartial.php
@@ -5,30 +5,26 @@ namespace Nominatim\Token;
 /**
  * A standard word token.
  */
-class Word
+class Partial
 {
     /// Database word id, if applicable.
     public $iId;
     /// Number of appearances in the database.
     public $iSearchNameCount;
-    /// Number of terms in the word.
-    public $iTermCount;
 
-    public function __construct($iId, $iSearchNameCount, $iTermCount)
+    public function __construct($iId, $iSearchNameCount)
     {
         $this->iId = $iId;
         $this->iSearchNameCount = $iSearchNameCount;
-        $this->iTermCount = $iTermCount;
     }
 
     public function debugInfo()
     {
         return array(
                 'ID' => $this->iId,
-                'Type' => 'word',
+                'Type' => 'partial',
                 'Info' => array(
-                           'count' => $this->iSearchNameCount,
-                           'terms' => $this->iTermCount
+                           'count' => $this->iSearchNameCount
                           )
                );
     }

--- a/lib-php/TokenPostcode.php
+++ b/lib-php/TokenPostcode.php
@@ -27,6 +27,22 @@ class Postcode
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oSearch->hasPostcode() && $oPosition->maybePhrase('postalcode');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -38,10 +54,6 @@ class Postcode
     public function extendSearch($oSearch, $oPosition)
     {
         $aNewSearches = array();
-
-        if ($oSearch->hasPostcode() || !$oPosition->maybePhrase('postalcode')) {
-            return $aNewSearches;
-        }
 
         // If we have structured search or this is the first term,
         // make the postcode the primary search element.

--- a/lib-php/TokenPostcode.php
+++ b/lib-php/TokenPostcode.php
@@ -8,17 +8,66 @@ namespace Nominatim\Token;
 class Postcode
 {
     /// Database word id, if available.
-    public $iId;
+    private $iId;
     /// Full nomralized postcode (upper cased).
-    public $sPostcode;
+    private $sPostcode;
     // Optional country code the postcode belongs to (currently unused).
-    public $sCountryCode;
+    private $sCountryCode;
 
     public function __construct($iId, $sPostcode, $sCountryCode = '')
     {
         $this->iId = $iId;
         $this->sPostcode = $sPostcode;
         $this->sCountryCode = empty($sCountryCode) ? '' : $sCountryCode;
+    }
+
+    public function getId()
+    {
+        return $this->iId;
+    }
+
+    /**
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return SearchDescription[] List of derived search descriptions.
+     */
+    public function extendSearch($oSearch, $oPosition)
+    {
+        $aNewSearches = array();
+
+        if ($oSearch->hasPostcode() || !$oPosition->maybePhrase('postalcode')) {
+            return $aNewSearches;
+        }
+
+        // If we have structured search or this is the first term,
+        // make the postcode the primary search element.
+        if ($oSearch->hasOperator(\Nominatim\Operator::NONE) && $oPosition->isFirstToken()) {
+            $oNewSearch = $oSearch->clone(1);
+            $oNewSearch->setPostcodeAsName($this->iId, $this->sPostcode);
+
+            $aNewSearches[] = $oNewSearch;
+        }
+
+        // If we have a structured search or this is not the first term,
+        // add the postcode as an addendum.
+        if (!$oSearch->hasOperator(\Nominatim\Operator::POSTCODE)
+            && ($oPosition->isPhrase('postalcode') || $oSearch->hasName())
+        ) {
+            $iPenalty = 1;
+            if (strlen($this->sPostcode) < 4) {
+                $iPenalty += 4 - strlen($this->sPostcode);
+            }
+            $oNewSearch = $oSearch->clone($iPenalty);
+            $oNewSearch->setPostcode($this->sPostcode);
+
+            $aNewSearches[] = $oNewSearch;
+        }
+
+        return $aNewSearches;
     }
 
     public function debugInfo()
@@ -28,5 +77,10 @@ class Postcode
                 'Type' => 'postcode',
                 'Info' => $this->sPostcode.'('.$this->sCountryCode.')'
                );
+    }
+
+    public function debugCode()
+    {
+        return 'P';
     }
 }

--- a/lib-php/TokenSpecialTerm.php
+++ b/lib-php/TokenSpecialTerm.php
@@ -10,13 +10,13 @@ require_once(CONST_LibDir.'/SpecialSearchOperator.php');
 class SpecialTerm
 {
     /// Database word id, if applicable.
-    public $iId;
+    private $iId;
     /// Class (or OSM tag key) of the place to look for.
-    public $sClass;
+    private $sClass;
     /// Type (or OSM tag value) of the place to look for.
-    public $sType;
+    private $sType;
     /// Relationship of the operator to the object (see Operator class).
-    public $iOperator;
+    private $iOperator;
 
     public function __construct($iID, $sClass, $sType, $iOperator)
     {

--- a/lib-php/TokenSpecialTerm.php
+++ b/lib-php/TokenSpecialTerm.php
@@ -32,6 +32,22 @@ class SpecialTerm
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oSearch->hasOperator() && $oPosition->isPhrase('');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -42,10 +58,6 @@ class SpecialTerm
      */
     public function extendSearch($oSearch, $oPosition)
     {
-        if ($oSearch->hasOperator() || !$oPosition->isPhrase('')) {
-            return array();
-        }
-
         $iSearchCost = 2;
 
         $iOp = $this->iOperator;

--- a/lib-php/TokenWord.php
+++ b/lib-php/TokenWord.php
@@ -8,17 +8,68 @@ namespace Nominatim\Token;
 class Word
 {
     /// Database word id, if applicable.
-    public $iId;
+    private $iId;
     /// Number of appearances in the database.
-    public $iSearchNameCount;
+    private $iSearchNameCount;
     /// Number of terms in the word.
-    public $iTermCount;
+    private $iTermCount;
 
     public function __construct($iId, $iSearchNameCount, $iTermCount)
     {
         $this->iId = $iId;
         $this->iSearchNameCount = $iSearchNameCount;
         $this->iTermCount = $iTermCount;
+    }
+
+    public function getId()
+    {
+        return $this->iId;
+    }
+
+    /**
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return SearchDescription[] List of derived search descriptions.
+     */
+    public function extendSearch($oSearch, $oPosition)
+    {
+        if ($oPosition->isPhrase('country')) {
+            return array();
+        }
+
+        // Full words can only be a name if they appear at the beginning
+        // of the phrase. In structured search the name must forcably in
+        // the first phrase. In unstructured search it may be in a later
+        // phrase when the first phrase is a house number.
+        if ($oSearch->hasName()
+            || !($oPosition->isFirstPhrase() || $oPosition->isPhrase(''))
+        ) {
+            if ($this->iTermCount > 1
+                && ($oPosition->isPhrase('') || !$oPosition->isFirstPhrase())
+            ) {
+                $oNewSearch = $oSearch->clone(1);
+                $oNewSearch->addAddressToken($this->iId);
+
+                return array($oNewSearch);
+            }
+        } elseif (!$oSearch->hasName(true)) {
+            $oNewSearch = $oSearch->clone(1);
+            $oNewSearch->addNameToken($this->iId);
+            if (CONST_Search_NameOnlySearchFrequencyThreshold
+                && $this->iSearchNameCount
+                          < CONST_Search_NameOnlySearchFrequencyThreshold
+            ) {
+                $oNewSearch->markRareName();
+            }
+
+            return array($oNewSearch);
+        }
+
+        return array();
     }
 
     public function debugInfo()
@@ -31,5 +82,10 @@ class Word
                            'terms' => $this->iTermCount
                           )
                );
+    }
+
+    public function debugCode()
+    {
+        return 'W';
     }
 }

--- a/lib-php/TokenWord.php
+++ b/lib-php/TokenWord.php
@@ -70,13 +70,12 @@ class Word
             }
         } elseif (!$oSearch->hasName(true)) {
             $oNewSearch = $oSearch->clone(1);
-            $oNewSearch->addNameToken($this->iId);
-            if (CONST_Search_NameOnlySearchFrequencyThreshold
+            $oNewSearch->addNameToken(
+                $this->iId,
+                CONST_Search_NameOnlySearchFrequencyThreshold
                 && $this->iSearchNameCount
                           < CONST_Search_NameOnlySearchFrequencyThreshold
-            ) {
-                $oNewSearch->markRareName();
-            }
+            );
 
             return array($oNewSearch);
         }

--- a/lib-php/TokenWord.php
+++ b/lib-php/TokenWord.php
@@ -27,6 +27,22 @@ class Word
     }
 
     /**
+     * Check if the token can be added to the given search.
+     * Derive new searches by adding this token to an existing search.
+     *
+     * @param object  $oSearch      Partial search description derived so far.
+     * @param object  $oPosition    Description of the token position within
+                                    the query.
+     *
+     * @return True if the token is compatible with the search configuration
+     *         given the position.
+     */
+    public function isExtendable($oSearch, $oPosition)
+    {
+        return !$oPosition->isPhrase('country');
+    }
+
+    /**
      * Derive new searches by adding this token to an existing search.
      *
      * @param object  $oSearch      Partial search description derived so far.
@@ -37,10 +53,6 @@ class Word
      */
     public function extendSearch($oSearch, $oPosition)
     {
-        if ($oPosition->isPhrase('country')) {
-            return array();
-        }
-
         // Full words can only be a name if they appear at the beginning
         // of the phrase. In structured search the name must forcably in
         // the first phrase. In unstructured search it may be in a later

--- a/lib-php/tokenizer/legacy_icu_tokenizer.php
+++ b/lib-php/tokenizer/legacy_icu_tokenizer.php
@@ -205,6 +205,7 @@ class Tokenizer
             } else {
                 $oToken = new Token\Partial(
                     $iId,
+                    $aWord['word_token'],
                     (int) $aWord['count']
                 );
             }

--- a/lib-php/tokenizer/legacy_icu_tokenizer.php
+++ b/lib-php/tokenizer/legacy_icu_tokenizer.php
@@ -195,17 +195,27 @@ class Tokenizer
                 ) {
                     $oToken = new Token\Country($iId, $aWord['country_code']);
                 }
+            } elseif ($aWord['word_token'][0] == ' ') {
+                 $oToken = new Token\Word(
+                     $iId,
+                     $aWord['word_token'][0] != ' ',
+                     (int) $aWord['count'],
+                     substr_count($aWord['word_token'], ' ')
+                 );
             } else {
-                $oToken = new Token\Word(
+                $oToken = new Token\Partial(
                     $iId,
-                    $aWord['word_token'][0] != ' ',
-                    (int) $aWord['count'],
-                    substr_count($aWord['word_token'], ' ')
+                    (int) $aWord['count']
                 );
             }
 
             if ($oToken) {
-                $oValidTokens->addToken($aWord['word_token'], $oToken);
+                // remove any leading spaces
+                if ($aWord['word_token'][0] == ' ') {
+                    $oValidTokens->addToken(substr($aWord['word_token'], 1), $oToken);
+                } else {
+                    $oValidTokens->addToken($aWord['word_token'], $oToken);
+                }
             }
         }
     }

--- a/lib-php/tokenizer/legacy_icu_tokenizer.php
+++ b/lib-php/tokenizer/legacy_icu_tokenizer.php
@@ -120,14 +120,14 @@ class Tokenizer
 
             // Try more interpretations for Tokens that could not be matched.
             foreach ($aTokens as $sToken) {
-                if ($sToken[0] == ' ' && !$oValidTokens->contains($sToken)) {
-                    if (preg_match('/^ ([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
+                if ($sToken[0] != ' ' && !$oValidTokens->contains($sToken)) {
+                    if (preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
                         // US ZIP+4 codes - merge in the 5-digit ZIP code
                         $oValidTokens->addToken(
                             $sToken,
                             new Token\Postcode(null, $aData[1], 'us')
                         );
-                    } elseif (preg_match('/^ [0-9]+$/', $sToken)) {
+                    } elseif (preg_match('/^[0-9]+$/', $sToken)) {
                         // Unknown single word token with a number.
                         // Assume it is a house number.
                         $oValidTokens->addToken(

--- a/lib-php/tokenizer/legacy_tokenizer.php
+++ b/lib-php/tokenizer/legacy_tokenizer.php
@@ -137,14 +137,14 @@ class Tokenizer
 
             // Try more interpretations for Tokens that could not be matched.
             foreach ($aTokens as $sToken) {
-                if ($sToken[0] == ' ' && !$oValidTokens->contains($sToken)) {
-                    if (preg_match('/^ ([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
+                if ($sToken[0] != ' ' && !$oValidTokens->contains($sToken)) {
+                    if (preg_match('/^([0-9]{5}) [0-9]{4}$/', $sToken, $aData)) {
                         // US ZIP+4 codes - merge in the 5-digit ZIP code
                         $oValidTokens->addToken(
                             $sToken,
                             new Token\Postcode(null, $aData[1], 'us')
                         );
-                    } elseif (preg_match('/^ [0-9]+$/', $sToken)) {
+                    } elseif (preg_match('/^[0-9]+$/', $sToken)) {
                         // Unknown single word token with a number.
                         // Assume it is a house number.
                         $oValidTokens->addToken(

--- a/lib-php/tokenizer/legacy_tokenizer.php
+++ b/lib-php/tokenizer/legacy_tokenizer.php
@@ -218,9 +218,12 @@ class Tokenizer
                     (int) $aWord['count'],
                     substr_count($aWord['word_token'], ' ')
                 );
-            } else {
+            // For backward compatibility: ignore all partial tokens with more
+            // than one word.
+            } elseif (strpos($aWord['word_token'], ' ') === false) {
                 $oToken = new Token\Partial(
                     $iId,
+                    $aWord['word_token'],
                     (int) $aWord['count']
                 );
             }

--- a/lib-php/tokenizer/legacy_tokenizer.php
+++ b/lib-php/tokenizer/legacy_tokenizer.php
@@ -212,17 +212,26 @@ class Tokenizer
                 ) {
                     $oToken = new Token\Country($iId, $aWord['country_code']);
                 }
-            } else {
+            } elseif ($aWord['word_token'][0] == ' ') {
                 $oToken = new Token\Word(
                     $iId,
-                    $aWord['word_token'][0] != ' ',
                     (int) $aWord['count'],
                     substr_count($aWord['word_token'], ' ')
+                );
+            } else {
+                $oToken = new Token\Partial(
+                    $iId,
+                    (int) $aWord['count']
                 );
             }
 
             if ($oToken) {
-                $oValidTokens->addToken($aWord['word_token'], $oToken);
+                // remove any leading spaces
+                if ($aWord['word_token'][0] == ' ') {
+                    $oValidTokens->addToken(substr($aWord['word_token'], 1), $oToken);
+                } else {
+                    $oValidTokens->addToken($aWord['word_token'], $oToken);
+                }
             }
         }
     }


### PR DESCRIPTION
This change moves the code responsible for building up a SearchDescription object from the SearchDescription class to the Token classes. So instead of having a function that consecutively adds information from tokens to the SearchDescription, each Token now has a function that adds its own information to the SearchDescription. One advantage is that the code gets split up a bit. The other advantage is that custom tokenizers can create custom Token types in the future.

This also removes the special handling of partial terms within the WordToken. Instead a partial term is now its own token type and handled like any other token. This gets rid of the esoteric words with leading spaces to distinguish full and partial words. The distinction is still made in the word table (for backward-compatibility reasons) but no longer used in the PHP query building code.