### PR TITLE
when replication --once set and no new updates, then exit

### DIFF
--- a/nominatim/clicmd/replication.py
+++ b/nominatim/clicmd/replication.py
@@ -90,6 +90,7 @@ class UpdateReplication:
                       update_interval=args.config.get_int('REPLICATION_UPDATE_INTERVAL'),
                       import_file=args.project_dir / 'osmosischange.osc',
                       max_diff_size=args.config.get_int('REPLICATION_MAX_DIFF'),
+                      sleep_between_intervals=not args.once,
                       indexed_only=not args.once)
 
         # Sanity check to not overwhelm the Geofabrik servers.

--- a/nominatim/tools/replication.py
+++ b/nominatim/tools/replication.py
@@ -92,12 +92,13 @@ def update(conn, options):
         LOG.info("Skipping update. There is data that needs indexing.")
         return UpdateState.MORE_PENDING
 
-    last_since_update = dt.datetime.now(dt.timezone.utc) - startdate
-    update_interval = dt.timedelta(seconds=options['update_interval'])
-    if last_since_update < update_interval:
-        duration = (update_interval - last_since_update).seconds
-        LOG.warning("Sleeping for %s sec before next update.", duration)
-        time.sleep(duration)
+    if options['sleep_between_intervals']:
+        last_since_update = dt.datetime.now(dt.timezone.utc) - startdate
+        update_interval = dt.timedelta(seconds=options['update_interval'])
+        if last_since_update < update_interval:
+            duration = (update_interval - last_since_update).seconds
+            LOG.warning("Sleeping for %s sec before next update.", duration)
+            time.sleep(duration)
 
     if options['import_file'].exists():
         options['import_file'].unlink()

--- a/test/python/test_tools_replication.py
+++ b/test/python/test_tools_replication.py
@@ -90,6 +90,7 @@ def test_check_for_updates_no_new_data(monkeypatch, temp_db_conn,
 def update_options(tmpdir):
     return dict(base_url='https://test.io',
                 indexed_only=False,
+                sleep_between_intervals=True,
                 update_interval=3600,
                 import_file=tmpdir / 'foo.osm',
                 max_diff_size=1)


### PR DESCRIPTION
Scenario:
1. Database is several days behind, daily updates, no automatic updates (e.g. cronjob) set
2. Run `nominatim replication --once`. This will run all updates fine `Update completed. Import:
1:37:16. Indexing: 0:44:18 Total: 2:21:34. Remaining backlog: 14:37:50.`
3. Run `replication replication --check-for-updates`. Prints `Database is up to date` as expected.
4. Run `nominatim replication --once` again. It starts a long sleep `Sleeping for 33728 sec before
next update.`

I would expect `--once` doesn't sleep and exits immediately.