### PR TITLE
Fix old paths for `phpcs` when using `make test`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if (BUILD_TESTS)
     if (PHPCS)
         message(STATUS "Using phpcs binary ${PHPCS}")
         add_test(NAME phpcs
-                 COMMAND ${PHPCS} --report-width=120 --colors lib website utils
+                 COMMAND ${PHPCS} --report-width=120 --colors lib-php
                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     else()
         message(WARNING "phpcs not found. PHP linting tests disabled." )


### PR DESCRIPTION
* `utils` no longer contains `PHP` code since Jan 13, 2021 (ff5a2372001b024e2e11d6d4db8d69809b1e5d29)
* `website` was moved to `lib/website` on Feb 8, 2021 (a759c5b75b66894b1902327097185840a2557f86)
* `lib` was renamed to `lib-php` on Feb 9, 2021 (db3ced17bbfff00411f506d8c84419c875959d5e)