### PR TITLE
Update instructions for importing multiple regions

### DIFF
--- a/lib-php/tokenizer/legacy_icu_tokenizer.php
+++ b/lib-php/tokenizer/legacy_icu_tokenizer.php
@@ -19,7 +19,7 @@ class Tokenizer
 
     public function checkStatus()
     {
-        $sSQL = 'SELECT word_id FROM word limit 1';
+        $sSQL = 'SELECT word_id FROM word WHERE word_id is not null limit 1';
         $iWordID = $this->oDB->getOne($sSQL);
         if ($iWordID === false) {
             throw new \Exception('Query failed', 703);

--- a/nominatim/clicmd/args.py
+++ b/nominatim/clicmd/args.py
@@ -1,7 +1,12 @@
 """
 Provides custom functions over command-line arguments.
 """
+import logging
+from pathlib import Path
 
+from nominatim.errors import UsageError
+
+LOG = logging.getLogger()
 
 class NominatimArgs:
     """ Customized namespace class for the nominatim command line tool
@@ -25,3 +30,20 @@ class NominatimArgs:
                                      main_index=self.config.TABLESPACE_PLACE_INDEX
                                     )
                    )
+
+
+    def get_osm_file_list(self):
+        """ Return the --osm-file argument as a list of Paths or None
+            if no argument was given. The function also checks if the files
+            exist and raises a UsageError if one cannot be found.
+        """
+        if not self.osm_file:
+            return None
+
+        files = [Path(f) for f in self.osm_file]
+        for fname in files:
+            if not fname.is_file():
+                LOG.fatal("OSM file '%s' does not exist.", fname)
+                raise UsageError('Cannot access file.')
+
+        return files

--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -9,7 +9,6 @@ import psutil
 from nominatim.db.connection import connect
 from nominatim.db import status, properties
 from nominatim.version import NOMINATIM_VERSION
-from nominatim.errors import UsageError
 
 # Do not repeat documentation of subcommand classes.
 # pylint: disable=C0111
@@ -52,19 +51,13 @@ class SetupAll:
 
 
     @staticmethod
-    def run(args): # pylint: disable=too-many-statements
+    def run(args):
         from ..tools import database_import, refresh, postcodes, freeze
         from ..indexer.indexer import Indexer
-        from ..tokenizer import factory as tokenizer_factory
-
-        if args.osm_file:
-            files = [Path(f) for f in args.osm_file]
-            for fname in files:
-                if not fname.is_file():
-                    LOG.fatal("OSM file '%s' does not exist.", fname)
-                    raise UsageError('Cannot access file.')
 
         if args.continue_at is None:
+            files = args.get_osm_file_list()
+
             database_import.setup_database_skeleton(args.config.get_libpq_dsn(),
                                                     args.data_dir,
                                                     args.no_partitions,
@@ -76,21 +69,7 @@ class SetupAll:
                                             drop=args.no_updates,
                                             ignore_errors=args.ignore_errors)
 
-            with connect(args.config.get_libpq_dsn()) as conn:
-                LOG.warning('Create functions (1st pass)')
-                refresh.create_functions(conn, args.config, False, False)
-                LOG.warning('Create tables')
-                database_import.create_tables(conn, args.config,
-                                              reverse_only=args.reverse_only)
-                refresh.load_address_levels_from_file(conn, Path(args.config.ADDRESS_LEVEL_CONFIG))
-                LOG.warning('Create functions (2nd pass)')
-                refresh.create_functions(conn, args.config, False, False)
-                LOG.warning('Create table triggers')
-                database_import.create_table_triggers(conn, args.config)
-                LOG.warning('Create partition tables')
-                database_import.create_partition_tables(conn, args.config)
-                LOG.warning('Create functions (3rd pass)')
-                refresh.create_functions(conn, args.config, False, False)
+            SetupAll._setup_tables(args.config, args.reverse_only)
 
             LOG.warning('Importing wikipedia importance data')
             data_path = Path(args.config.WIKIPEDIA_DATA_PATH or args.project_dir)
@@ -109,12 +88,7 @@ class SetupAll:
                                       args.threads or psutil.cpu_count() or 1)
 
         LOG.warning("Setting up tokenizer")
-        if args.continue_at is None or args.continue_at == 'load-data':
-            # (re)initialise the tokenizer data
-            tokenizer = tokenizer_factory.create_tokenizer(args.config)
-        else:
-            # just load the tokenizer
-            tokenizer = tokenizer_factory.get_tokenizer_for_db(args.config)
+        tokenizer = SetupAll._get_tokenizer(args.continue_at, args.config)
 
         if args.continue_at is None or args.continue_at == 'load-data':
             LOG.warning('Calculate postcodes')
@@ -149,18 +123,47 @@ class SetupAll:
             refresh.setup_website(webdir, args.config, conn)
 
         with connect(args.config.get_libpq_dsn()) as conn:
-            try:
-                dbdate = status.compute_database_date(conn)
-                status.set_status(conn, dbdate)
-                LOG.info('Database is at %s.', dbdate)
-            except Exception as exc: # pylint: disable=broad-except
-                LOG.error('Cannot determine date of database: %s', exc)
-
+            SetupAll._set_database_date(conn)
             properties.set_property(conn, 'database_version',
                                     '{0[0]}.{0[1]}.{0[2]}-{0[3]}'.format(NOMINATIM_VERSION))
 
         return 0
 
+
+    @staticmethod
+    def _setup_tables(config, reverse_only):
+        """ Set up the basic database layout: tables, indexes and functions.
+        """
+        from ..tools import database_import, refresh
+
+        with connect(config.get_libpq_dsn()) as conn:
+            LOG.warning('Create functions (1st pass)')
+            refresh.create_functions(conn, config, False, False)
+            LOG.warning('Create tables')
+            database_import.create_tables(conn, config, reverse_only=reverse_only)
+            refresh.load_address_levels_from_file(conn, Path(config.ADDRESS_LEVEL_CONFIG))
+            LOG.warning('Create functions (2nd pass)')
+            refresh.create_functions(conn, config, False, False)
+            LOG.warning('Create table triggers')
+            database_import.create_table_triggers(conn, config)
+            LOG.warning('Create partition tables')
+            database_import.create_partition_tables(conn, config)
+            LOG.warning('Create functions (3rd pass)')
+            refresh.create_functions(conn, config, False, False)
+
+
+    @staticmethod
+    def _get_tokenizer(continue_at, config):
+        """ Set up a new tokenizer or load an already initialised one.
+        """
+        from ..tokenizer import factory as tokenizer_factory
+
+        if continue_at is None or continue_at == 'load-data':
+            # (re)initialise the tokenizer data
+            return tokenizer_factory.create_tokenizer(config)
+
+        # just load the tokenizer
+        return tokenizer_factory.get_tokenizer_for_db(config)
 
     @staticmethod
     def _create_pending_index(conn, tablespace):
@@ -182,3 +185,15 @@ class SetupAll:
                            {} WHERE indexed_status > 0
                         """.format(tablespace))
         conn.commit()
+
+
+    @staticmethod
+    def _set_database_date(conn):
+        """ Determine the database date and set the status accordingly.
+        """
+        try:
+            dbdate = status.compute_database_date(conn)
+            status.set_status(conn, dbdate)
+            LOG.info('Database is at %s.', dbdate)
+        except Exception as exc: # pylint: disable=broad-except
+            LOG.error('Cannot determine date of database: %s', exc)

--- a/nominatim/tools/database_import.py
+++ b/nominatim/tools/database_import.py
@@ -103,11 +103,11 @@ def import_base_data(dsn, sql_dir, ignore_partitions=False):
             conn.commit()
 
 
-def import_osm_data(osm_file, options, drop=False, ignore_errors=False):
-    """ Import the given OSM file. 'options' contains the list of
+def import_osm_data(osm_files, options, drop=False, ignore_errors=False):
+    """ Import the given OSM files. 'options' contains the list of
         default settings for osm2pgsql.
     """
-    options['import_file'] = osm_file
+    options['import_file'] = osm_files
     options['append'] = False
     options['threads'] = 1
 
@@ -115,7 +115,12 @@ def import_osm_data(osm_file, options, drop=False, ignore_errors=False):
         # Make some educated guesses about cache size based on the size
         # of the import file and the available memory.
         mem = psutil.virtual_memory()
-        fsize = os.stat(str(osm_file)).st_size
+        fsize = 0
+        if isinstance(osm_files, list):
+            for fname in osm_files:
+                fsize += os.stat(str(fname)).st_size
+        else:
+            fsize = os.stat(str(osm_files)).st_size
         options['osm2pgsql_cache'] = int(min((mem.available + mem.cached) * 0.75,
                                              fsize * 2) / 1024 / 1024) + 1
 

--- a/nominatim/tools/exec_utils.py
+++ b/nominatim/tools/exec_utils.py
@@ -130,6 +130,9 @@ def run_osm2pgsql(options):
 
     if 'import_data' in options:
         cmd.extend(('-r', 'xml', '-'))
+    elif isinstance(options['import_file'], list):
+        for fname in options['import_file']:
+            cmd.append(str(fname))
     else:
         cmd.append(str(options['import_file']))
 

--- a/test/python/test_tools_database_import.py
+++ b/test/python/test_tools_database_import.py
@@ -98,14 +98,25 @@ def test_import_base_data_ignore_partitions(dsn, src_dir, temp_db_with_extension
 def test_import_osm_data_simple(table_factory, osm2pgsql_options):
     table_factory('place', content=((1, ), ))
 
-    database_import.import_osm_data('file.pdf', osm2pgsql_options)
+    database_import.import_osm_data(Path('file.pbf'), osm2pgsql_options)
+
+
+def test_import_osm_data_multifile(table_factory, tmp_path, osm2pgsql_options):
+    table_factory('place', content=((1, ), ))
+    osm2pgsql_options['osm2pgsql_cache'] = 0
+
+    files = [tmp_path / 'file1.osm', tmp_path / 'file2.osm']
+    for f in files:
+        f.write_text('test')
+
+    database_import.import_osm_data(files, osm2pgsql_options)
 
 
 def test_import_osm_data_simple_no_data(table_factory, osm2pgsql_options):
     table_factory('place')
 
     with pytest.raises(UsageError, match='No data.*'):
-        database_import.import_osm_data('file.pdf', osm2pgsql_options)
+        database_import.import_osm_data(Path('file.pbf'), osm2pgsql_options)
 
 
 def test_import_osm_data_drop(table_factory, temp_db_conn, tmp_path, osm2pgsql_options):
@@ -117,7 +128,7 @@ def test_import_osm_data_drop(table_factory, temp_db_conn, tmp_path, osm2pgsql_o
 
     osm2pgsql_options['flatnode_file'] = str(flatfile.resolve())
 
-    database_import.import_osm_data('file.pdf', osm2pgsql_options, drop=True)
+    database_import.import_osm_data(Path('file.pbf'), osm2pgsql_options, drop=True)
 
     assert not flatfile.exists()
     assert not temp_db_conn.table_exists('planet_osm_nodes')

--- a/utils/import_multiple_regions.sh
+++ b/utils/import_multiple_regions.sh
@@ -8,8 +8,6 @@
 
 #     *) Set up sequence.state for updates
 
-#     *) Merge the pbf files into a single file.
-
 #     *) Setup nominatim db using 'setup.php --osm-file'
 
 # Hint:
@@ -28,16 +26,6 @@ touch2() { mkdir -p "$(dirname "$1")" && touch "$1" ; }
 
 COUNTRIES="europe/monaco europe/andorra"
 
-# SET TO YOUR NOMINATIM build FOLDER PATH:
-
-NOMINATIMBUILD="/srv/nominatim/build"
-SETUPFILE="$NOMINATIMBUILD/utils/setup.php"
-UPDATEFILE="$NOMINATIMBUILD/utils/update.php"
-
-# SET TO YOUR update FOLDER PATH:
-
-UPDATEDIR="/srv/nominatim/update"
-
 # SET TO YOUR replication server URL:
 
 BASEURL="https://download.geofabrik.de"
@@ -46,27 +34,24 @@ DOWNCOUNTRYPOSTFIX="-latest.osm.pbf"
 # End of configuration section
 # ******************************************************************************
 
-COMBINEFILES="osmium merge"
+UPDATEDIR=update
+IMPORT_CMD="nominatim import"
 
 mkdir -p ${UPDATEDIR}
-cd ${UPDATEDIR}
+pushd ${UPDATEDIR}
 rm -rf tmp
 mkdir -p tmp
-cd tmp
+popd
 
 for COUNTRY in $COUNTRIES;
 do
-    
     echo "===================================================================="
     echo "$COUNTRY"
     echo "===================================================================="
     DIR="$UPDATEDIR/$COUNTRY"
-    FILE="$DIR/configuration.txt"
     DOWNURL="$BASEURL/$COUNTRY$DOWNCOUNTRYPOSTFIX"
     IMPORTFILE=$COUNTRY$DOWNCOUNTRYPOSTFIX
     IMPORTFILEPATH=${UPDATEDIR}/tmp/${IMPORTFILE}
-    FILENAME=${COUNTRY//[\/]/_}
-    
 
     touch2 $IMPORTFILEPATH
     wget ${DOWNURL} -O $IMPORTFILEPATH
@@ -74,18 +59,12 @@ do
     touch2 ${DIR}/sequence.state
     pyosmium-get-changes -O $IMPORTFILEPATH -f ${DIR}/sequence.state -v
 
-    COMBINEFILES="${COMBINEFILES} ${IMPORTFILEPATH}"
+    IMPORT_CMD="${IMPORT_CMD} --osm-file ${IMPORTFILEPATH}"
     echo $IMPORTFILE
     echo "===================================================================="
 done
 
-
-echo "${COMBINEFILES} -o combined.osm.pbf"
-${COMBINEFILES} -o combined.osm.pbf
-
 echo "===================================================================="
 echo "Setting up nominatim db"
-${SETUPFILE} --osm-file ${UPDATEDIR}/tmp/combined.osm.pbf --all 2>&1
-
-# ${UPDATEFILE} --import-file ${UPDATEDIR}/tmp/combined.osm.pbf 2>&1
+${IMPORT_CMD} 2>&1
 echo "===================================================================="

--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -22,25 +22,14 @@
 
 # REPLACE WITH LIST OF YOUR "COUNTRIES":
 #
-
-
 COUNTRIES="europe/monaco europe/andorra"
-
-# SET TO YOUR NOMINATIM build FOLDER PATH:
-#
-NOMINATIMBUILD="/srv/nominatim/build"
-UPDATEFILE="$NOMINATIMBUILD/utils/update.php"
-
-# SET TO YOUR update data FOLDER PATH:
-#
-UPDATEDIR="/srv/nominatim/update"
 
 UPDATEBASEURL="https://download.geofabrik.de"
 UPDATECOUNTRYPOSTFIX="-updates"
 
 # If you do not use Photon, let Nominatim handle (re-)indexing:
 #
-FOLLOWUP="$UPDATEFILE --index"
+FOLLOWUP="nominatim index"
 #
 # If you use Photon, update Photon and let it handle the index
 # (Photon server must be running and must have been started with "-database",
@@ -49,11 +38,10 @@ FOLLOWUP="$UPDATEFILE --index"
 #FOLLOWUP="curl http://localhost:2322/nominatim-update"
 
 # ******************************************************************************
-
+UPDATEDIR="update"
 
 for COUNTRY in $COUNTRIES;
 do
-    
     echo "===================================================================="
     echo "$COUNTRY"
     echo "===================================================================="
@@ -61,17 +49,13 @@ do
     FILE="$DIR/sequence.state"
     BASEURL="$UPDATEBASEURL/$COUNTRY$UPDATECOUNTRYPOSTFIX"
     FILENAME=${COUNTRY//[\/]/_}
-    
-    # mkdir -p ${DIR}
-    cd ${DIR}
 
     echo "Attempting to get changes"
+    rm -f ${DIR}/${FILENAME}.osc.gz
     pyosmium-get-changes -o ${DIR}/${FILENAME}.osc.gz -f ${FILE} --server $BASEURL -v
 
     echo "Attempting to import diffs"
-    ${NOMINATIMBUILD}/utils/update.php --import-diff ${DIR}/${FILENAME}.osc.gz
-    rm ${DIR}/${FILENAME}.osc.gz
-
+    nominatim add-data --diff ${DIR}/${FILENAME}.osc.gz
 done
 
 echo "===================================================================="


### PR DESCRIPTION
Three important changes here:
* Changes the Import command, so that multiple import files may be given. osm2pgsql handles the situation correctly now, so we can get rid of the recommendation to merge files.
* Correct the instructions to add another region to an existing database, as per #2421.
* Update the multi-region scripts to use nominatim tool. It now also expects to be executed from the project directory and also puts its data there. This further simplifies matters for the script and the user.

Fixes #2365.