### PR TITLE
Indexing: move linking of places to the preparation stage

### DIFF
--- a/test/bdd/db/query/linking.feature
+++ b/test/bdd/db/query/linking.feature
@@ -1,0 +1,22 @@
+@DB
+Feature: Searching linked places
+    Tests that information from linked places can be searched correctly
+
+    Scenario: Additional names from linked places are searchable
+        Given the places
+         | osm  | class    | type           | admin | name  | geometry |
+         | R13  | boundary | administrative | 6     | Garbo | poly-area:0.1 |
+        Given the places
+         | osm  | class    | type           | admin | name+name:it | geometry |
+         | N2   | place    | hamlet         | 15    | Vario        | 0.006 0.00001 |
+        And the relations
+         | id | members       | tags+type |
+         | 13 | N2:label      | boundary |
+        When importing
+        Then placex contains
+         | object  | linked_place_id |
+         | N2      | R13 |
+        When sending search query "Vario"
+        Then results contain
+         | osm |
+         | R13 |

--- a/test/python/test_indexing.py
+++ b/test/python/test_indexing.py
@@ -19,8 +19,10 @@ class IndexerTestDB:
         with self.conn.cursor() as cur:
             cur.execute('CREATE EXTENSION hstore')
             cur.execute("""CREATE TABLE placex (place_id BIGINT,
+                                                name HSTORE,
                                                 class TEXT,
                                                 type TEXT,
+                                                linked_place_id BIGINT,
                                                 rank_address SMALLINT,
                                                 rank_search SMALLINT,
                                                 indexed_status SMALLINT,
@@ -55,11 +57,12 @@ class IndexerTestDB:
             cur.execute("""CREATE OR REPLACE FUNCTION placex_prepare_update(p placex,
                                                       OUT name HSTORE,
                                                       OUT address HSTORE,
-                                                      OUT country_feature VARCHAR)
+                                                      OUT country_feature VARCHAR,
+                                                      OUT linked_place_id BIGINT)
                            AS $$
                            BEGIN
                             address := p.address;
-                            name := p.address;
+                            name := p.name;
                            END;
                            $$ LANGUAGE plpgsql STABLE;
                         """)


### PR DESCRIPTION
Linked places may bring in extra names. These names need to be processed by the tokenizer. That means that the linking needs
to be done before the data is handed to the tokenizer. Move finding the linked place into the preparation stage and update the name fields. Everything else is still done in the indexing stage.