### PR TITLE
icu: normalise simplified to traditional chinese

### DIFF
--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -1,5 +1,6 @@
 normalization:
     - ":: lower ()"
+    - ":: Hans-Hant"
     - !include icu-rules/unicode-digits-to-decimal.yaml
     - "'№' > 'no'"
     - "'n°' > 'no'"


### PR DESCRIPTION
The conversion is unambigious in most cases, so that the information loss is minimal but it makes the word table a bit smaller.