### PR TITLE
Some more tweaks for search interpretation

### DIFF
--- a/lib-php/TokenHousenumber.php
+++ b/lib-php/TokenHousenumber.php
@@ -59,7 +59,7 @@ class HouseNumber
         $iSearchCost = 1;
         if (preg_match('/\\d/', $this->sToken) === 0
             || preg_match_all('/[^0-9]/', $this->sToken, $aMatches) > 2) {
-            $iSearchCost++;
+            $iSearchCost += strlen($this->sToken) - 1;
         }
         if (!$oSearch->hasOperator(\Nominatim\Operator::NONE)) {
             $iSearchCost++;

--- a/lib-php/TokenSpecialTerm.php
+++ b/lib-php/TokenSpecialTerm.php
@@ -44,7 +44,10 @@ class SpecialTerm
      */
     public function isExtendable($oSearch, $oPosition)
     {
-        return !$oSearch->hasOperator() && $oPosition->isPhrase('');
+        return !$oSearch->hasOperator()
+               && $oPosition->isPhrase('')
+               && ($this->iOperator != \Nominatim\Operator::NONE
+                  || (!$oSearch->hasAddress() && !$oSearch->hasHousenumber() && !$oSearch->hasCountry()));
     }
 
     /**
@@ -66,8 +69,8 @@ class SpecialTerm
                 $iOp = \Nominatim\Operator::NAME;
             } else {
                 $iOp = \Nominatim\Operator::NEAR;
+                $iSearchCost += 2;
             }
-            $iSearchCost += 2;
         } elseif (!$oPosition->isFirstToken() && !$oPosition->isLastToken()) {
             $iSearchCost += 2;
         }


### PR DESCRIPTION
* increase penalty for housenumbers without digits even more
* decrease penalty for searches with category name (e.g. "Bakery Happy Day")
* enforce that such category names are next to the name

Fixes #2433.