### PR TITLE
Add generic loader for YAML configuration files

### DIFF
--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -55,7 +55,7 @@ class SetupAll:
         from ..tools import database_import, refresh, postcodes, freeze, country_info
         from ..indexer.indexer import Indexer
 
-        country_info.setup_country_config(args.config.config_dir / 'country_settings.yaml')
+        country_info.setup_country_config(args.config)
 
         if args.continue_at is None:
             files = args.get_osm_file_list()

--- a/nominatim/config.py
+++ b/nominatim/config.py
@@ -172,7 +172,7 @@ class Configuration:
 
         search_paths = [self.project_dir, self.config_dir]
         for path in search_paths:
-            if (path / filename).is_file():
+            if path is not None and (path / filename).is_file():
                 return path / filename
 
         LOG.fatal("Configuration file '%s' not found.\nDirectories searched: %s",

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -49,7 +49,7 @@ class LegacyICUTokenizer(AbstractTokenizer):
             sure the tokenizer remains stable even over updates.
         """
         loader = ICURuleLoader(config.load_sub_configuration('icu_tokenizer.yaml',
-                                              config='TOKENIZER_CONFIG'))
+                                                             config='TOKENIZER_CONFIG'))
         self.naming_rules = ICUNameProcessorRules(loader=loader)
         self.term_normalization = config.TERM_NORMALIZATION
         self.max_word_frequency = config.MAX_WORD_FREQUENCY

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -8,7 +8,6 @@ import json
 import logging
 import re
 from textwrap import dedent
-from pathlib import Path
 
 from nominatim.db.connection import connect
 from nominatim.db.properties import set_property, get_property
@@ -49,12 +48,8 @@ class LegacyICUTokenizer(AbstractTokenizer):
             This copies all necessary data in the project directory to make
             sure the tokenizer remains stable even over updates.
         """
-        if config.TOKENIZER_CONFIG:
-            cfgfile = Path(config.TOKENIZER_CONFIG)
-        else:
-            cfgfile = config.config_dir / 'icu_tokenizer.yaml'
-
-        loader = ICURuleLoader(cfgfile)
+        loader = ICURuleLoader(config.load_sub_configuration('icu_tokenizer.yaml',
+                                              config='TOKENIZER_CONFIG'))
         self.naming_rules = ICUNameProcessorRules(loader=loader)
         self.term_normalization = config.TERM_NORMALIZATION
         self.max_word_frequency = config.MAX_WORD_FREQUENCY

--- a/nominatim/tools/country_info.py
+++ b/nominatim/tools/country_info.py
@@ -2,7 +2,6 @@
 Functions for importing and managing static country information.
 """
 import psycopg2.extras
-import yaml
 
 from nominatim.db import utils as db_utils
 from nominatim.db.connection import connect
@@ -14,12 +13,12 @@ class _CountryInfo:
     def __init__(self):
         self._info = {}
 
-    def load(self, configfile):
+    def load(self, config):
         """ Load the country properties from the configuration files,
             if they are not loaded yet.
         """
         if not self._info:
-            self._info = yaml.safe_load(configfile.read_text(encoding='utf-8'))
+            self._info = config.load_sub_configuration('country_settings.yaml')
 
     def items(self):
         """ Return tuples of (country_code, property dict) as iterable.
@@ -29,12 +28,12 @@ class _CountryInfo:
 
 _COUNTRY_INFO = _CountryInfo()
 
-def setup_country_config(configfile):
+def setup_country_config(config):
     """ Load country properties from the configuration file.
         Needs to be called before using any other functions in this
         file.
     """
-    _COUNTRY_INFO.load(configfile)
+    _COUNTRY_INFO.load(config)
 
 
 def setup_country_tables(dsn, sql_dir, ignore_partitions=False):

--- a/test/python/test_tokenizer_icu.py
+++ b/test/python/test_tokenizer_icu.py
@@ -67,13 +67,10 @@ def analyzer(tokenizer_factory, test_config, monkeypatch,
 
     def _mk_analyser(norm=("[[:Punctuation:][:Space:]]+ > ' '",), trans=(':: upper()',),
                      variants=('~gasse -> gasse', 'street => st', )):
-        cfgfile = tmp_path / 'analyser_test_config.yaml'
-        with cfgfile.open('w') as stream:
-            cfgstr = {'normalization' : list(norm),
-                       'transliteration' : list(trans),
-                       'variants' : [ {'words': list(variants)}]}
-            yaml.dump(cfgstr, stream)
-        tok.naming_rules = ICUNameProcessorRules(loader=ICURuleLoader(cfgfile))
+        cfgstr = {'normalization' : list(norm),
+                   'transliteration' : list(trans),
+                   'variants' : [ {'words': list(variants)}]}
+        tok.naming_rules = ICUNameProcessorRules(loader=ICURuleLoader(cfgstr))
 
         return tok.name_analyzer()
 

--- a/test/python/test_tokenizer_icu_name_processor.py
+++ b/test/python/test_tokenizer_icu_name_processor.py
@@ -4,6 +4,7 @@ Tests for import name normalisation and variant generation.
 from textwrap import dedent
 
 import pytest
+import yaml
 
 from nominatim.tokenizer.icu_rule_loader import ICURuleLoader
 from nominatim.tokenizer.icu_name_processor import ICUNameProcessor, ICUNameProcessorRules
@@ -11,7 +12,7 @@ from nominatim.tokenizer.icu_name_processor import ICUNameProcessor, ICUNameProc
 from nominatim.errors import UsageError
 
 @pytest.fixture
-def cfgfile(tmp_path, suffix='.yaml'):
+def cfgfile():
     def _create_config(*variants, **kwargs):
         content = dedent("""\
         normalization:
@@ -29,9 +30,7 @@ def cfgfile(tmp_path, suffix='.yaml'):
         content += '\n'.join(("      - " + s for s in variants)) + '\n'
         for k, v in kwargs:
             content += "    {}: {}\n".format(k, v)
-        fpath = tmp_path / ('test_config' + suffix)
-        fpath.write_text(dedent(content))
-        return fpath
+        return yaml.safe_load(content)
 
     return _create_config
 

--- a/test/python/test_tools_country_info.py
+++ b/test/python/test_tools_country_info.py
@@ -8,7 +8,7 @@ from nominatim.tools import country_info
 
 @pytest.fixture(autouse=True)
 def read_config(def_config):
-    country_info.setup_country_config(def_config.config_dir / 'country_settings.yaml')
+    country_info.setup_country_config(def_config)
 
 @pytest.mark.parametrize("no_partitions", (True, False))
 def test_setup_country_tables(src_dir, temp_db_with_extensions, dsn, temp_db_cursor,


### PR DESCRIPTION
Given that we likely will have more configurable modules in the future, this introduces a generic mechanism to read configuration from YAML files. Used by the ICU tokenizer to load its configuration and the country property loader.

From the user side this also means that searching for configuration files is now standardized: the file is first searched in the project directory, then in the global configuration directory. This means that users can easily customize configuration: simply copy the configuration file into the project directory, adapt and use.