### PR TITLE
Fix dynamic assignment of address parts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -185,7 +185,7 @@ jobs:
             - name: Prepare container (CentOS)
               run: |
                   dnf update -y
-                  dnf install -y sudo
+                  dnf install -y sudo glibc-langpack-en
               shell: bash
               if: matrix.flavour == 'centos'
 

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -433,3 +433,76 @@ Feature: Address computation
         Then results contain
            | osm | display_name               |
            | N2  | Leftside, Wonderway, Right |
+
+
+    Scenario: POIs can correct address parts on the fly (with partial unmatching address)
+        Given the grid
+            | 1 |   |   |   |  2 |   | 5 |
+            |   |   |   | 9 |    | 8 |   |
+            |   | 10| 11|   |    | 12|   |
+            | 4 |   |   |   |  3 |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | name      | geometry |
+            | W1  | highway | primary | Wonderway | 10,11,12 |
+        And the places
+            | osm | class   | type    | name      | addr+suburb | geometry |
+            | N1  | amenity | cafe    | Bolder    | Boring      | 9        |
+            | N2  | amenity | cafe    | Leftside  | Boring      | 8        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | True      |
+           | W1     | R2      | False     |
+        And place_addressline doesn't contain
+           | object | address |
+           | N1     | R1      |
+           | N2     | R2      |
+        When sending search query "Bolder"
+        Then results contain
+           | osm | display_name            |
+           | N1  | Bolder, Wonderway, Left |
+        When sending search query "Leftside"
+        Then results contain
+           | osm | display_name               |
+           | N2  | Leftside, Wonderway, Right |
+
+
+
+    Scenario: POIs can correct address parts on the fly (with partial matching address)
+        Given the grid
+            | 1 |   |   |   |  2 |   | 5 |
+            |   |   |   | 9 |    | 8 |   |
+            |   | 10| 11|   |    | 12|   |
+            | 4 |   |   |   |  3 |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Right | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | name      | geometry |
+            | W1  | highway | primary | Wonderway | 10,11,12 |
+        And the places
+            | osm | class   | type    | name      | addr+state | geometry |
+            | N1  | amenity | cafe    | Bolder    | Left       | 9        |
+            | N2  | amenity | cafe    | Leftside  | Left       | 8        |
+        When importing
+        Then place_addressline contains
+           | object | address | isaddress |
+           | W1     | R1      | True      |
+           | W1     | R2      | False     |
+        And place_addressline doesn't contain
+           | object | address |
+           | N1     | R1      |
+           | N2     | R2      |
+        When sending search query "Bolder"
+        Then results contain
+           | osm | display_name            |
+           | N1  | Bolder, Wonderway, Left |
+        When sending search query "Leftside"
+        Then results contain
+           | osm | display_name               |
+           | N2  | Leftside, Wonderway, Left |


### PR DESCRIPTION
A boolean check for dynamic changes of address parts introduced in #2082 is not sufficient. The order of choice should be:

 1. an addr:* part matches the name
 2. the address part surrounds the object
 3. the address part was declared as isaddress

The implementation uses a slightly different ordering to avoid geometry checks unless strictly necessary (isaddress is false and no matching address).

See #2446.