### PR TITLE
Adjust address ranks for Spain

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -174,6 +174,20 @@
           "administrative10" : 16
       }
   }
+},
+{ "countries" : ["es"],
+  "tags" : {
+      "place" : {
+          "province" : 10,
+          "civil_parish" : 18
+      },
+      "boundary" : {
+          "administrative5" : [10, 0],
+          "administrative6" : 10,
+          "administrative7" : 12,
+          "administrative10" : 22
+      }
+  }
 }
 ]
 


### PR DESCRIPTION
Adjusts levels for boundaries according to the list on
https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative

* no admin_level 5, so drop that from addresses
* admin_level 6 has the province
* admin_level 7 has the county when it exists

Also reranks place=province so that it matches up with
admin_level 6 and introduces place=civil_parish which
is used as a place node for some admin_level=9 boundaries
in Galicia.