### PR TITLE
US TIGER data 2021 released

### DIFF
--- a/docs/admin/Customization.md
+++ b/docs/admin/Customization.md
@@ -48,14 +48,14 @@ address set to complement the OSM house number data in the US. You can add
 TIGER data to your own Nominatim instance by following these steps. The
 entire US adds about 10GB to your database.
 
-  1. Get preprocessed TIGER 2020 data:
+  1. Get preprocessed TIGER 2021 data:
 
         cd $PROJECT_DIR
-        wget https://nominatim.org/data/tiger2020-nominatim-preprocessed.csv.tar.gz
+        wget https://nominatim.org/data/tiger2021-nominatim-preprocessed.csv.tar.gz
 
   2. Import the data into your Nominatim database:
 
-        nominatim add-data --tiger-data tiger2020-nominatim-preprocessed.csv.tar.gz
+        nominatim add-data --tiger-data tiger2021-nominatim-preprocessed.csv.tar.gz
 
   3. Enable use of the Tiger data in your `.env` by adding:
 


### PR DESCRIPTION
CSV files created with https://github.com/osm-search/TIGER-data/tree/2b55be34
SQL files created with https://github.com/osm-search/TIGER-data/tree/a5a233cd

Uploaded to https://downloads.opencagedata.com/public/

2020 and 2021 both have 3234 input and output files
2020 has 34,272,001 output lines, 2021 has 34,329,441 (+0.16%)
No individual file changes more than +/-5%