### PR TITLE
Force update of surrounding houses when street or place name changes

### DIFF
--- a/test/bdd/db/update/parenting.feature
+++ b/test/bdd/db/update/parenting.feature
@@ -35,6 +35,7 @@ Feature: Update parenting of objects
          | N2     | W3              | 3 |
          | N3     | W3              | 3 |
 
+
     Scenario: Housenumber is reparented when street gets name matching addr:street
         Given the grid
          | 1 |    |   | 2 |
@@ -58,3 +59,107 @@ Feature: Update parenting of objects
         Then placex contains
          | object | parent_place_id |
          | N1     | W2              |
+
+
+    Scenario: Housenumber is reparented when street looses name matching addr:street
+        Given the grid
+         | 1 |    |   | 2 |
+         |   | 10 |   |   |
+         |   |    |   |   |
+         | 3 |    |   | 4 |
+        And the places
+         | osm | class   | type        | name     | geometry |
+         | W1  | highway | residential | A street | 1,2      |
+         | W2  | highway | residential | X street | 3,4      |
+        And the places
+         | osm | class    | type | housenr | street   | geometry |
+         | N1  | building | yes  | 3       | X street | 10       |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W2              |
+        When updating places
+         | osm | class   | type        | name     | geometry |
+         | W2  | highway | residential | B street | 3,4      |
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W1              |
+
+
+    Scenario: Housenumber is reparented when street gets name matching addr:street
+        Given the grid
+         | 1 |    |   | 2 |
+         |   | 10 |   |   |
+         |   |    |   |   |
+         | 3 |    |   | 4 |
+        And the places
+         | osm | class   | type        | name     | geometry |
+         | W1  | highway | residential | A street | 1,2      |
+         | W2  | highway | residential | B street | 3,4      |
+        And the places
+         | osm | class    | type | housenr | street   | geometry |
+         | N1  | building | yes  | 3       | X street | 10       |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W1              |
+        When updating places
+         | osm | class   | type        | name     | geometry |
+         | W2  | highway | residential | X street | 3,4      |
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W2              |
+
+
+    # Invalidation of geometries currently disabled for addr:place matches.
+    @Fail
+    Scenario: Housenumber is reparented when place is renamed to matching addr:place
+        Given the grid
+         | 1 |    |   | 2 |
+         |   | 10 | 4 |   |
+         |   |    |   |   |
+         |   |    | 5 |   |
+        And the places
+         | osm | class   | type        | name     | geometry |
+         | W1  | highway | residential | A street | 1,2      |
+         | N5  | place   | village     | Bdorf    | 5        |
+         | N4  | place   | village     | Other    | 4        |
+        And the places
+         | osm | class    | type | housenr | addr_place | geometry |
+         | N1  | building | yes  | 3       | Cdorf      | 10       |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | N4              |
+        When updating places
+         | osm | class   | type        | name     | geometry |
+         | N5  | place   | village     | Cdorf    | 5        |
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | N5              |
+
+
+    Scenario: Housenumber is reparented when it looses a matching addr:place
+        Given the grid
+         | 1 |    |   | 2 |
+         |   | 10 | 4 |   |
+         |   |    |   |   |
+         |   |    | 5 |   |
+        And the places
+         | osm | class   | type        | name     | geometry |
+         | W1  | highway | residential | A street | 1,2      |
+         | N5  | place   | village     | Bdorf    | 5        |
+         | N4  | place   | village     | Other    | 4        |
+        And the places
+         | osm | class    | type | housenr | addr_place | geometry |
+         | N1  | building | yes  | 3       | Bdorf      | 10       |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | N5              |
+        When updating places
+         | osm | class   | type        | name     | geometry |
+         | N5  | place   | village     | Cdorf    | 5        |
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | N4              |

--- a/test/bdd/db/update/parenting.feature
+++ b/test/bdd/db/update/parenting.feature
@@ -1,7 +1,7 @@
 @DB
 Feature: Update parenting of objects
 
-Scenario: POI inside building inherits addr:street change
+    Scenario: POI inside building inherits addr:street change
         Given the scene building-on-street-corner
         And the named places
          | osm | class   | type       | geometry |
@@ -34,3 +34,27 @@ Scenario: POI inside building inherits addr:street change
          | N1     | W3              | 3 |
          | N2     | W3              | 3 |
          | N3     | W3              | 3 |
+
+    Scenario: Housenumber is reparented when street gets name matching addr:street
+        Given the grid
+         | 1 |    |   | 2 |
+         |   | 10 |   |   |
+         |   |    |   |   |
+         | 3 |    |   | 4 |
+        And the places
+         | osm | class   | type        | name     | geometry |
+         | W1  | highway | residential | A street | 1,2      |
+         | W2  | highway | residential | B street | 3,4      |
+        And the places
+         | osm | class    | type | housenr | street   | geometry |
+         | N1  | building | yes  | 3       | X street | 10       |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W1              |
+        When updating places
+         | osm | class   | type        | name     | geometry |
+         | W2  | highway | residential | X street | 3,4      |
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W2              |


### PR DESCRIPTION
When the street changes its name then this may cause changes in the parenting of rank-30 objects with an addr:street tag. Force an update on these objects in that case. For addr:place this change only works for rank-30 objects already parented (i.e. only changes are caught where the name change means the connection via addr:place is no longer valid). Looking up all rank-30 objects within a boundary can potentially be rather expensive. We'd probably need an extra index for that. (And even with an index, this can become a very expensive operation in places like Denmark where (ab)use of addr:place is very wide-spread.)

Fixes #2242.