### PR TITLE
Adjust address levels for boundaries in Slovakia

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -188,6 +188,20 @@
           "administrative10" : 22
       }
   }
+},
+{ "countries" : ["sk"],
+  "tags" : {
+      "boundary" : {
+          "administrative5" : [10, 0],
+          "administrative6" : 11,
+          "administrative7" : [11, 0],
+          "administrative8" : 12,
+          "administrative9" : 16,
+          "administrative10" : 18,
+          "administrative11" : 20
+      }
+  }
 }
+
 ]
 


### PR DESCRIPTION
Levels chosen according to [OSM wiki](https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative#10_admin_level_values_for_specific_countries). Mainly moves admin_level 6 to county level and admin_level 8 to city/town level. Higher levels are adjusted accordingly.

This looks to work well for most of the country. Bratislava is a bit of an exception because it has a rather creative tagging. It has no less than three boundaries for the city (https://www.openstreetmap.org/relation/3992676, https://www.openstreetmap.org/relation/1702499, https://www.openstreetmap.org/way/293814124). Place tagging deviates from the rest of the country, too: suburbs are tagged as place=town (corresponding to admin_level 9). There are also place=suburb which may or may not relate to the admin_level 10 boundaries. That is unclear.

Fixes #2453.