### PR TITLE
Fix template expressions for tablespaces

### DIFF
--- a/nominatim/db/sql_preprocessor.py
+++ b/nominatim/db/sql_preprocessor.py
@@ -36,7 +36,7 @@ def _setup_tablespace_sql(config):
             tspace = getattr(config, 'TABLESPACE_{}_{}'.format(subset, kind))
             if tspace:
                 tspace = 'TABLESPACE "{}"'.format(tspace)
-            out['{}_{}'.format(subset.lower, kind.lower())] = tspace
+            out['{}_{}'.format(subset.lower(), kind.lower())] = tspace
 
     return out
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -226,14 +226,19 @@ def osm2pgsql_options(temp_db):
                 tablespaces=dict(slim_data='', slim_index='',
                                  main_data='', main_index=''))
 
+
 @pytest.fixture
-def sql_preprocessor(temp_db_conn, tmp_path, table_factory, temp_db_with_extensions):
+def sql_preprocessor_cfg(tmp_path, table_factory, temp_db_with_extensions):
     table_factory('country_name', 'partition INT', ((0, ), (1, ), (2, )))
     cfg = Configuration(None, SRC_DIR.resolve() / 'settings')
     cfg.set_libdirs(module='.', osm2pgsql='.', php=SRC_DIR / 'lib-php',
                     sql=tmp_path, data=SRC_DIR / 'data')
+    return cfg
 
-    return SQLPreprocessor(temp_db_conn, cfg)
+
+@pytest.fixture
+def sql_preprocessor(sql_preprocessor_cfg, temp_db_conn):
+    return SQLPreprocessor(temp_db_conn, sql_preprocessor_cfg)
 
 
 @pytest.fixture


### PR DESCRIPTION
A rather unfortunate combination of automatic string conversion of functions in Python and ignoring of unknown attributes in jinja meant that tablespace settings were simply ignored.