### PR TITLE
Updata Taiwan language usage

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1141,7 +1141,7 @@ tv:
 # Taiwan (臺灣)
 tw:
     partition: 25
-    languages: zh-hant
+    languages: zh-hant, zh, nan, hak
 
 # Tanzania (Tanzania)
 tz:


### PR DESCRIPTION
Including other National language in Taiwan: Taiwanese Hokkein, Taiwanese Hakka