### PR TITLE
Fix warming for ICU tokenizer

### DIFF
--- a/lib-php/admin/warm.php
+++ b/lib-php/admin/warm.php
@@ -86,8 +86,13 @@ if (!$aResult['reverse-only']) {
     if ($bVerbose) {
         echo "\n";
     }
+
+    $oTokenizer = new \Nominatim\Tokenizer($oDB);
+
+    $aWords = $oTokenizer->mostFrequentWords(1000);
+
     $sSQL = 'SELECT word FROM word WHERE word is not null ORDER BY search_name_count DESC LIMIT 1000';
-    foreach ($oDB->getCol($sSQL) as $sWord) {
+    foreach ($aWords as $sWord) {
         if ($bVerbose) {
             echo "$sWord = ";
         }

--- a/lib-php/tokenizer/icu_tokenizer.php
+++ b/lib-php/tokenizer/icu_tokenizer.php
@@ -40,6 +40,15 @@ class Tokenizer
         return $this->oNormalizer->transliterate($sTerm);
     }
 
+
+    public function mostFrequentWords($iNum)
+    {
+        $sSQL = "SELECT word FROM word WHERE type = 'W'";
+        $sSQL .= "ORDER BY info->'count' DESC LIMIT ".$iNum;
+        return $this->oDB->getCol($sSQL);
+    }
+
+
     private function makeStandardWord($sTerm)
     {
         return trim($this->oTransliterator->transliterate(' '.$sTerm.' '));

--- a/lib-php/tokenizer/legacy_tokenizer.php
+++ b/lib-php/tokenizer/legacy_tokenizer.php
@@ -48,6 +48,14 @@ class Tokenizer
     }
 
 
+    public function mostFrequentWords($iNum)
+    {
+        $sSQL = 'SELECT word FROM word WHERE word is not null ';
+        $sSQL .= 'ORDER BY search_name_count DESC LIMIT '.$iNum;
+        return $this->oDB->getCol($sSQL);
+    }
+
+
     public function tokensForSpecialTerm($sTerm)
     {
         $aResults = array();


### PR DESCRIPTION
Running the warm-up search requests requires querying the most frequent words. This must be done via the tokenizer
to honour the different formats of the word table.