### PR TITLE
Reverse: add index hints

### DIFF
--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -111,6 +111,7 @@ class ReverseGeocode
                 $sSQL .= ' FROM placex';
                 $sSQL .= ' WHERE osm_type = \'N\'';
                 $sSQL .= ' AND country_code = \''.$sCountryCode.'\'';
+                $sSQL .= ' AND rank_search < 26 '; // needed to select right index
                 $sSQL .= ' AND rank_search between 5 and ' .min(25, $iMaxRank);
                 $sSQL .= ' AND class = \'place\' AND type != \'postcode\'';
                 $sSQL .= ' AND name IS NOT NULL ';
@@ -206,6 +207,7 @@ class ReverseGeocode
                 // for place nodes at rank_address 16
                 $sSQL .= ' AND rank_search > '.$iRankSearch;
                 $sSQL .= ' AND rank_search <= '.$iMaxRank;
+                $sSQL .= ' AND rank_search < 26 '; // needed to select right index
                 $sSQL .= ' AND rank_address > 0';
                 $sSQL .= ' AND class = \'place\'';
                 $sSQL .= ' AND type != \'postcode\'';


### PR DESCRIPTION
The fairly complex where condition of idx_placex_geometry_placenode
won't always be matched by the query planner if the condition
part doesn't appear verbatim in the query.

Fixes #2480.