### PR TITLE
Fix boolean combination of NeedsAddress flag

### DIFF
--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -257,7 +257,7 @@ class SearchDescription
         if (empty($this->aName)) {
             $this->bNameNeedsAddress = $bNeedsAddress;
         } else {
-            $this->bNameNeedsAddress |= $bNeedsAddress;
+            $this->bNameNeedsAddress &= $bNeedsAddress;
         }
         if ($bSearchable) {
             $this->aName[$iId] = $iId;


### PR DESCRIPTION
When dealing with multiple partial terms, only keep the flag, when all partial terms are so frequent as to need an address. That requires a boolean and combination not an or.

Fixes #2510.