### PR TITLE
Don't penalize French 'bis' housenumbers

### DIFF
--- a/lib-php/TokenHousenumber.php
+++ b/lib-php/TokenHousenumber.php
@@ -58,7 +58,7 @@ class HouseNumber
         // up of numbers, add a penalty
         $iSearchCost = 1;
         if (preg_match('/\\d/', $this->sToken) === 0
-            || preg_match_all('/[^0-9]/', $this->sToken, $aMatches) > 2) {
+            || preg_match_all('/[^0-9 ]/', $this->sToken, $aMatches) > 3) {
             $iSearchCost += strlen($this->sToken) - 1;
         }
         if (!$oSearch->hasOperator(\Nominatim\Operator::NONE)) {


### PR DESCRIPTION
House numbers of the form '9 bis' are usual in France. So be a bit more lenient before adding penalties to house numbers
with letters in them.

Fixes #2527.