### PR TITLE
Take tiger housenumber into account when ranking street results

### DIFF
--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -591,8 +591,7 @@ class SearchDescription
             $sChildHnr .= '    AND housenumber ~* E'.$sHouseNumberRegex;
             // Interpolations on streets and places.
             if (preg_match('/^[0-9]+$/', $this->sHouseNumber)) {
-                $sIpolHnr = 'SELECT * FROM location_property_osmline ';
-                $sIpolHnr .= 'WHERE parent_place_id = search_name.place_id ';
+                $sIpolHnr = 'WHERE parent_place_id = search_name.place_id ';
                 $sIpolHnr .= '  AND startnumber is not NULL';
                 $sIpolHnr .= '    AND '.$this->sHouseNumber.'>=startnumber ';
                 $sIpolHnr .= '    AND '.$this->sHouseNumber.'<=endnumber ';
@@ -606,7 +605,11 @@ class SearchDescription
             $sSql = '(CASE WHEN address_rank = 30 THEN EXISTS('.$sSelfHnr.') ';
             $sSql .= ' ELSE EXISTS('.$sChildHnr.') ';
             if ($sIpolHnr) {
-                $sSql .= 'OR EXISTS('.$sIpolHnr.') ';
+                $sSql .= 'OR EXISTS(SELECT * FROM location_property_osmline '.$sIpolHnr.') ';
+                if (CONST_Use_US_Tiger_Data) {
+                    $sSql .= "OR (country_code = 'us' AND ";
+                    $sSql .= '    EXISTS(SELECT * FROM location_property_tiger '.$sIpolHnr.')) ';
+                }
             }
             $sSql .= 'END) DESC';
 

--- a/lib-sql/tiger_import_finish.sql
+++ b/lib-sql/tiger_import_finish.sql
@@ -1,6 +1,10 @@
 --index only on parent_place_id
 CREATE INDEX IF NOT EXISTS idx_location_property_tiger_parent_place_id_imp
-  ON location_property_tiger_import (parent_place_id) {{db.tablespace.aux_index}};
+  ON location_property_tiger_import (parent_place_id)
+{% if postgres.has_index_non_key_column %}
+  INCLUDE (startnumber, endnumber)
+{% endif %}
+  {{db.tablespace.aux_index}};
 CREATE UNIQUE INDEX IF NOT EXISTS idx_location_property_tiger_place_id_imp
   ON location_property_tiger_import (place_id) {{db.tablespace.aux_index}};
 

--- a/nominatim/tools/migration.py
+++ b/nominatim/tools/migration.py
@@ -192,3 +192,20 @@ def install_legacy_tokenizer(conn, config, **_):
                                                        module_name='legacy')
 
         tokenizer.migrate_database(config)
+
+
+@_migration(4, 0, 99, 0)
+def create_tiger_housenumber_index(conn, _, **_):
+    """ Create idx_location_property_tiger_parent_place_id with included
+        house number.
+
+        The inclusion is needed for efficient lookup of housenumbers in
+        full address searches.
+    """
+    if conn.server_version_tuple() >= (11, 0, 0):
+        with conn.cursor() as cur:
+            cur.execute(""" CREATE INDEX IF NOT EXISTS
+                                idx_location_property_tiger_housenumber_migrated
+                            ON location_property_tiger
+                            USING btree(parent_place_id)
+                            INCLUDE (startnumber, endnumber) """)

--- a/nominatim/version.py
+++ b/nominatim/version.py
@@ -9,8 +9,16 @@ Version information for Nominatim.
 # The database patch level tracks important changes between releases
 # and must always be increased when there is a change to the database or code
 # that requires a migration.
+#
+# When adding a migration on the development branch, raise the patch level
+# to 99 to make sure that the migration is applied when updating from a
+# patch release to the next minor version. Patch releases usually shouldn't
+# have migrations in them. When they are needed, then make sure that the
+# migration can reapplied and set the migration version to the appropriate
+# patch level when cherry-picking the commit with the migration.
+#
 # Released versions always have a database patch level of 0.
-NOMINATIM_VERSION = (4, 0, 0, 0)
+NOMINATIM_VERSION = (4, 0, 99, 1)
 
 POSTGRESQL_REQUIRED_VERSION = (9, 5)
 POSTGIS_REQUIRED_VERSION = (2, 2)


### PR DESCRIPTION
Queries with a house number need to rank streets higher that have the requested house number attached. We already do that for
ordinary house number objects and for interpolations. This adds support for Tiger house numbers as well.

The lookup for the reranking is fairly expensive. So as for the other tables, add a special index with house numbers included, so that Postgresql eventually does an index-only lookup. A migration is provided to add the index to existing installations.

Fixes #2501.