### PR TITLE
Change default rank for highway objects to 30

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -82,7 +82,7 @@
           "" : [20, 0]
       },
       "highway" : {
-          "" : 26,
+          "" : 30,
           "service" : 27,
           "cycleway" : 27,
           "path" : 27,
@@ -93,7 +93,19 @@
           "primary_link" : 27,
           "trunk_link" : 27,
           "secondary_link" : 27,
-          "tertiary_link" : 27
+          "tertiary_link" : 27,
+          "residential" : 26,
+          "track" : 26,
+          "unclassified" : 26,
+          "tertiary" : 26,
+          "secondary" : 26,
+          "primary" : 26,
+          "living_street" : 26,
+          "trunk" : 26,
+          "motorway" : 26,
+          "pedestrian" : 26,
+          "road" : 26,
+          "construction" : 26
       },
       "mountain_pass" : {
           "" : [20, 0]

--- a/test/bdd/db/import/placex.feature
+++ b/test/bdd/db/import/placex.feature
@@ -176,7 +176,7 @@ Feature: Import into placex
           | W3     | 26          | 26 |
           | W4     | 26          | 26 |
           | W5     | 26          | 26 |
-          | W6     | 26          | 26 |
+          | W6     | 30          | 30 |
 
     Scenario: rank and inclusion of landuses
         Given the named places


### PR DESCRIPTION
The highway key is being used more and more for non-ways these days (stop signs, bus platforms, lamp posts, ...) . This clashes with Nominatim's assumption that essentially everything that has a highway tag can be used as the street part of the address.

Change the default rank of highway objects to 30 to avoid this. Only the known values for streets keep the rank 26 and are now
listed explicitly.