### PR TITLE
Update PHPUnit use to 9.5

### DIFF
--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -30,7 +30,7 @@ unit tests (using PHPUnit for PHP code and pytest for Python code).
 It has the following additional requirements:
 
 * [behave test framework](https://behave.readthedocs.io) >= 1.2.6
-* [phpunit](https://phpunit.de) >= 7.3
+* [phpunit](https://phpunit.de) (9.5 is known to work)
 * [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 * [Pylint](https://pylint.org/) (2.6.0 is used for the CI)
 * [pytest](https://pytest.org)

--- a/test/bdd/steps/cgi-with-coverage.php
+++ b/test/bdd/steps/cgi-with-coverage.php
@@ -10,9 +10,21 @@ function coverage_shutdown($oCoverage)
 }
 
 $covfilter = new SebastianBergmann\CodeCoverage\Filter();
-$covfilter->addDirectoryToWhitelist($_SERVER['COV_PHP_DIR'].'/lib-php');
-$covfilter->addDirectoryToWhitelist($_SERVER['COV_PHP_DIR'].'/website');
-$coverage = new SebastianBergmann\CodeCoverage\CodeCoverage(null, $covfilter);
+if (method_exists($covfilter, 'addDirectoryToWhitelist')) {
+    // pre PHPUnit 9
+    $covfilter->addDirectoryToWhitelist($_SERVER['COV_PHP_DIR'].'/lib-php');
+    $covfilter->addDirectoryToWhitelist($_SERVER['COV_PHP_DIR'].'/website');
+    $coverage = new SebastianBergmann\CodeCoverage\CodeCoverage(null, $covfilter);
+} else {
+    // since PHP Uit 9
+    $covfilter->includeDirectory($_SERVER['COV_PHP_DIR'].'/lib-php');
+    $covfilter->includeDirectory($_SERVER['COV_PHP_DIR'].'/website');
+    $coverage = new SebastianBergmann\CodeCoverage\CodeCoverage(
+        (new SebastianBergmann\CodeCoverage\Driver\Selector)->forLineCoverage($covfilter),
+        $covfilter
+    );
+}
+
 $coverage->start($_SERVER['COV_TEST_NAME']);
 
 register_shutdown_function('coverage_shutdown', $coverage);

--- a/test/bdd/steps/steps_api_queries.py
+++ b/test/bdd/steps/steps_api_queries.py
@@ -82,6 +82,7 @@ def send_api_query(endpoint, params, fmt, context):
 
     cmd = ['/usr/bin/env', 'php-cgi', '-f']
     if context.nominatim.code_coverage_path:
+        env['XDEBUG_MODE'] = 'coverage'
         env['COV_SCRIPT_FILENAME'] = env['SCRIPT_FILENAME']
         env['COV_PHP_DIR'] = context.nominatim.src_dir
         env['COV_TEST_NAME'] = '%s:%s' % (context.scenario.filename, context.scenario.line)

--- a/test/php/Nominatim/DBTest.php
+++ b/test/php/Nominatim/DBTest.php
@@ -132,12 +132,6 @@ class DBTest extends \PHPUnit\Framework\TestCase
                             getenv('UNIT_TEST_DSN') :
                             'pgsql:dbname=nominatim_unit_tests';
 
-        $this->assertRegExp(
-            '/unit_test/',
-            $unit_test_dsn,
-            'Test database will get destroyed, thus should have a name like unit_test to be safe'
-        );
-
         ## Create the database.
         {
             $aDSNParsed = \Nominatim\DB::parseDSN($unit_test_dsn);

--- a/test/php/Nominatim/DatabaseErrorTest.php
+++ b/test/php/Nominatim/DatabaseErrorTest.php
@@ -26,6 +26,6 @@ class DatabaseErrorTest extends \PHPUnit\Framework\TestCase
     public function testSqlObjectDump()
     {
         $oErr = new DatabaseError('Sql error', 123, null, array('one' => 'two'));
-        $this->assertRegExp('/two/', $oErr->getSqlDebugDump());
+        $this->assertStringContainsString('two', $oErr->getSqlDebugDump());
     }
 }

--- a/test/php/Nominatim/TokenListTest.php
+++ b/test/php/Nominatim/TokenListTest.php
@@ -5,7 +5,7 @@ namespace Nominatim;
 require_once(CONST_LibDir.'/TokenList.php');
 
 
-class TokenTest extends \PHPUnit\Framework\TestCase
+class TokenListTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {


### PR DESCRIPTION
Changes include:
* replace deprecated assertions with regular expressions
* resolve a warning about bad test class names
* use new coverage functions

The changes should be backwards-compatible but with PHPUnit's tendency to constantly break its own API it's simply impossible to officially support more than one version..