### PR TITLE
Disable JIT and parallel workers on search frontend

### DIFF
--- a/lib-php/DB.php
+++ b/lib-php/DB.php
@@ -38,6 +38,9 @@ class DB
 
         $conn->exec("SET DateStyle TO 'sql,european'");
         $conn->exec("SET client_encoding TO 'utf-8'");
+        // Disable JIT and parallel workers. They interfere badly with search SQL.
+        $conn->exec("UPDATE pg_settings SET setting = -1 WHERE name = 'jit_above_cost'");
+        $conn->exec("UPDATE pg_settings SET setting = 0 WHERE name = 'max_parallel_workers_per_gather'");
         $iMaxExecution = ini_get('max_execution_time');
         if ($iMaxExecution > 0) {
             $conn->setAttribute(\PDO::ATTR_TIMEOUT, $iMaxExecution); // seconds


### PR DESCRIPTION
Query planning has always been wrong for indexes on array and geometry columns in terms of expected number of results and consequently about the cost of the query. That regularly leads to JIT and/or parallel workers being activated on the smallest of queries. The import part already disables JIT and parallel workers for all its connections to Postgres. It looks like the frontend part is increasingly effected as well. So switch the stuff off for those connections, too.