### PR TITLE
Swap order of query interpretation

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -617,16 +617,15 @@ class Geocode
                     }
                     $aReverseGroupedSearches = $this->getGroupedSearches($aSearches, $aPhrases, $oValidTokens);
 
-                    foreach ($aGroupedSearches as $aSearches) {
+                    foreach ($aReverseGroupedSearches as $aSearches) {
                         foreach ($aSearches as $aSearch) {
-                            if (!isset($aReverseGroupedSearches[$aSearch->getRank()])) {
-                                $aReverseGroupedSearches[$aSearch->getRank()] = array();
+                            if (!isset($aGroupedSearches[$aSearch->getRank()])) {
+                                $aGroupedSearches[$aSearch->getRank()] = array();
                             }
-                            $aReverseGroupedSearches[$aSearch->getRank()][] = $aSearch;
+                            $aGroupedSearches[$aSearch->getRank()][] = $aSearch;
                         }
                     }
 
-                    $aGroupedSearches = $aReverseGroupedSearches;
                     ksort($aGroupedSearches);
                 }
             } else {


### PR DESCRIPTION
Free-form queries are interpreted by Nominatim in two ways: a forward reading in the order 'street, city, country' and a backward reading in the order 'country, city, street'. The forward reading is used much more frequently by users. Therefore it makes sense to try that interpretation first. This PR swaps the order.