### PR TITLE
Consider "modifier letter apostrophe" to be punctuation

### DIFF
--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -7,7 +7,7 @@ normalization:
     - "'nº' > 'no'"
     - "ª > a"
     - "º > o"
-    - "[[:Punctuation:][:Symbol:]]  > ' '"
+    - "[[:Punctuation:][:Symbol:]\u02bc]  > ' '"
     - "ß > 'ss'" # German szet is unimbigiously equal to double ss
     - "[^[:Letter:] [:Number:] [:Space:]] >"
     - "[:Lm:] >"


### PR DESCRIPTION
While technically being a letter, the apostrophe is often replaced with a normal apostrophe in writing which is a punctuation mark.
This makes sure that the modifier letter apostrophe yields the same normalization results and thus is really interchangable.

Only has an effect after the next reimport.

Fixes #2569.