### PR TITLE
Introduce optional token analysis for housenumbers

### DIFF
--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -206,15 +206,16 @@ by a sanitizer (see for example the
 The token-analysis section contains the list of configured analyzers. Each
 analyzer must have an `id` parameter that uniquely identifies the analyzer.
 The only exception is the default analyzer that is used when no special
-analyzer was selected.
+analyzer was selected. There is one special id '@housenumber'. If an analyzer
+with that name is present, it is used for normalization of house numbers.
 
 Different analyzer implementations may exist. To select the implementation,
-the `analyzer` parameter must be set. Currently there is only one implementation
-`generic` which is described in the following.
+the `analyzer` parameter must be set. The different implementations are
+described in the following.
 
 ##### Generic token analyzer
 
-The generic analyzer is able to create variants from a list of given
+The generic analyzer `generic` is able to create variants from a list of given
 abbreviation and decomposition replacements and introduce spelling variations.
 
 ###### Variants
@@ -330,6 +331,14 @@ the mode by adding:
 ```
 
 to the analyser configuration.
+
+##### Housenumber token analyzer
+
+The analyzer `housenumbers` is purpose-made to analyze house numbers. It
+creates variants with optional spaces between numbers and letters. Thus,
+house numbers of the form '3 a', '3A', '3-A' etc. are all considered equivalent.
+
+The analyzer cannot be customized.
 
 ### Reconfiguration
 

--- a/lib-php/tokenizer/icu_tokenizer.php
+++ b/lib-php/tokenizer/icu_tokenizer.php
@@ -157,7 +157,8 @@ class Tokenizer
         $sSQL = 'SELECT word_id, word_token, type, word,';
         $sSQL .= "      info->>'op' as operator,";
         $sSQL .= "      info->>'class' as class, info->>'type' as ctype,";
-        $sSQL .= "      info->>'count' as count";
+        $sSQL .= "      info->>'count' as count,";
+        $sSQL .= "      info->>'lookup' as lookup";
         $sSQL .= ' FROM word WHERE word_token in (';
         $sSQL .= join(',', $this->oDB->getDBQuotedList($aTokens)).')';
 
@@ -179,7 +180,8 @@ class Tokenizer
                     }
                     break;
                 case 'H':  // house number tokens
-                    $oValidTokens->addToken($sTok, new Token\HouseNumber($iId, $aWord['word_token']));
+                    $sLookup = $aWord['lookup'] ?? $aWord['word_token'];
+                    $oValidTokens->addToken($sTok, new Token\HouseNumber($iId, $sLookup));
                     break;
                 case 'P':  // postcode tokens
                     // Postcodes are not normalized, so they may have content

--- a/lib-sql/tokenizer/icu_tokenizer.sql
+++ b/lib-sql/tokenizer/icu_tokenizer.sql
@@ -200,3 +200,26 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION create_analyzed_hnr_id(norm_term TEXT, lookup_terms TEXT[])
+  RETURNS INTEGER
+  AS $$
+DECLARE
+  return_id INTEGER;
+BEGIN
+  SELECT min(word_id) INTO return_id
+    FROM word WHERE word = norm_term and type = 'H';
+
+  IF return_id IS NULL THEN
+    return_id := nextval('seq_word');
+    INSERT INTO word (word_id, word_token, type, word, info)
+      SELECT return_id, lookup_term, 'H', norm_term,
+             json_build_object('lookup', lookup_terms[1])
+        FROM unnest(lookup_terms) as lookup_term;
+  END IF;
+
+  RETURN return_id;
+END;
+$$
+LANGUAGE plpgsql;

--- a/lib-sql/tokenizer/icu_tokenizer_tables.sql
+++ b/lib-sql/tokenizer/icu_tokenizer_tables.sql
@@ -28,6 +28,10 @@ CREATE INDEX idx_word_postcodes ON word
 CREATE INDEX idx_word_full_word ON word
     USING btree(word) {{db.tablespace.address_index}}
     WHERE type = 'W';
+-- Used when inserting analyzed housenumbers (exclude old-style entries).
+CREATE INDEX idx_word_housenumbers ON word
+    USING btree(word) {{db.tablespace.address_index}}
+    WHERE type = 'H' and word is not null;
 
 GRANT SELECT ON word TO "{{config.DATABASE_WEBUSER}}";
 

--- a/nominatim/indexer/runners.py
+++ b/nominatim/indexer/runners.py
@@ -45,8 +45,9 @@ class AbstractPlacexRunner:
 
     @staticmethod
     def get_place_details(worker, ids):
-        worker.perform("""SELECT place_id, (placex_indexing_prepare(placex)).*
-                          FROM placex WHERE place_id IN %s""",
+        worker.perform("""SELECT place_id, extra.*
+                          FROM placex, LATERAL placex_indexing_prepare(placex) as extra
+                          WHERE place_id IN %s""",
                        (tuple((p[0] for p in ids)), ))
 
 

--- a/nominatim/tokenizer/icu_token_analysis.py
+++ b/nominatim/tokenizer/icu_token_analysis.py
@@ -25,5 +25,5 @@ class ICUTokenAnalysis:
         self.search = Transliterator.createFromRules("icu_search",
                                                      norm_rules + trans_rules)
 
-        self.analysis = {name: arules.create(self.to_ascii, arules.config)
+        self.analysis = {name: arules.create(self.normalizer, self.to_ascii, arules.config)
                          for name, arules in analysis_rules.items()}

--- a/nominatim/tokenizer/icu_token_analysis.py
+++ b/nominatim/tokenizer/icu_token_analysis.py
@@ -27,3 +27,10 @@ class ICUTokenAnalysis:
 
         self.analysis = {name: arules.create(self.normalizer, self.to_ascii, arules.config)
                          for name, arules in analysis_rules.items()}
+
+
+    def get_analyzer(self, name):
+        """ Return the given named analyzer. If no analyzer with that
+            name exists, return the default analyzer.
+        """
+        return self.analysis.get(name) or self.analysis[None]

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -119,7 +119,8 @@ class LegacyICUTokenizer(AbstractTokenizer):
             if not conn.table_exists('search_name'):
                 return
             with conn.cursor(name="hnr_counter") as cur:
-                cur.execute("""SELECT DISTINCT word_id, coalesce(info->>'lookup', word_token) FROM word
+                cur.execute("""SELECT DISTINCT word_id, coalesce(info->>'lookup', word_token)
+                               FROM word
                                WHERE type = 'H'
                                  AND NOT EXISTS(SELECT * FROM search_name
                                                 WHERE ARRAY[word.word_id] && name_vector)

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -590,7 +590,7 @@ class LegacyICUNameAnalyzer(AbstractAnalyzer):
                     continue
 
                 with self.conn.cursor() as cur:
-                    cur.execute("SELECT (getorcreate_full_word(%s, %s)).*",
+                    cur.execute("SELECT * FROM getorcreate_full_word(%s, %s)",
                                 (token_id, variants))
                     full, part = cur.fetchone()
 

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -561,7 +561,8 @@ class LegacyICUNameAnalyzer(AbstractAnalyzer):
 
         for name in names:
             analyzer_id = name.get_attr('analyzer')
-            norm_name = self._normalized(name.name)
+            analyzer = self.token_analysis.analysis[analyzer_id]
+            norm_name = analyzer.normalize(name.name)
             if analyzer_id is None:
                 token_id = norm_name
             else:
@@ -569,7 +570,7 @@ class LegacyICUNameAnalyzer(AbstractAnalyzer):
 
             full, part = self._cache.names.get(token_id, (None, None))
             if full is None:
-                variants = self.token_analysis.analysis[analyzer_id].get_variants_ascii(norm_name)
+                variants = analyzer.get_variants_ascii(norm_name)
                 if not variants:
                     continue
 

--- a/nominatim/tokenizer/icu_tokenizer.py
+++ b/nominatim/tokenizer/icu_tokenizer.py
@@ -561,7 +561,7 @@ class LegacyICUNameAnalyzer(AbstractAnalyzer):
 
         for name in names:
             analyzer_id = name.get_attr('analyzer')
-            analyzer = self.token_analysis.analysis[analyzer_id]
+            analyzer = self.token_analysis.get_analyzer(analyzer_id)
             norm_name = analyzer.normalize(name.name)
             if analyzer_id is None:
                 token_id = norm_name

--- a/nominatim/tokenizer/legacy_tokenizer.py
+++ b/nominatim/tokenizer/legacy_tokenizer.py
@@ -515,7 +515,7 @@ class _TokenInfo:
             simple_list = list(set(simple_list))
 
         with conn.cursor() as cur:
-            cur.execute("SELECT (create_housenumbers(%s)).* ", (simple_list, ))
+            cur.execute("SELECT * FROM create_housenumbers(%s)", (simple_list, ))
             self.data['hnr_tokens'], self.data['hnr'] = cur.fetchone()
 
 

--- a/nominatim/tokenizer/token_analysis/generic.py
+++ b/nominatim/tokenizer/token_analysis/generic.py
@@ -47,10 +47,10 @@ def configure(rules, normalization_rules):
 
 ### Analysis section
 
-def create(transliterator, config):
+def create(normalizer, transliterator, config):
     """ Create a new token analysis instance for this module.
     """
-    return GenericTokenAnalysis(transliterator, config)
+    return GenericTokenAnalysis(normalizer, transliterator, config)
 
 
 class GenericTokenAnalysis:
@@ -58,7 +58,8 @@ class GenericTokenAnalysis:
         and provides the functions to apply the transformations.
     """
 
-    def __init__(self, to_ascii, config):
+    def __init__(self, norm, to_ascii, config):
+        self.norm = norm
         self.to_ascii = to_ascii
         self.variant_only = config['variant_only']
 
@@ -72,6 +73,13 @@ class GenericTokenAnalysis:
 
         # set up mutation rules
         self.mutations = [MutationVariantGenerator(*cfg) for cfg in config['mutations']]
+
+
+    def normalize(self, name):
+        """ Return the normalized form of the name. This is the standard form
+            from which possible variants for the name can be derived.
+        """
+        return self.norm.transliterate(name).strip()
 
 
     def get_variants_ascii(self, norm_name):

--- a/nominatim/tokenizer/token_analysis/housenumbers.py
+++ b/nominatim/tokenizer/token_analysis/housenumbers.py
@@ -15,17 +15,18 @@ from nominatim.tokenizer.token_analysis.generic_mutation import MutationVariantG
 RE_NON_DIGIT = re.compile('[^0-9]')
 RE_DIGIT_ALPHA = re.compile(r'(\d)\s*([^\d\s␣])')
 RE_ALPHA_DIGIT = re.compile(r'([^\s\d␣])\s*(\d)')
+RE_NAMED_PART = re.compile(r'[a-z]{4}')
 
 ### Configuration section
 
-def configure(rules, normalization_rules):
+def configure(rules, normalization_rules): # pylint: disable=W0613
     """ All behaviour is currently hard-coded.
     """
     return None
 
 ### Analysis section
 
-def create(normalizer, transliterator, config):
+def create(normalizer, transliterator, config): # pylint: disable=W0613
     """ Create a new token analysis instance for this module.
     """
     return HousenumberTokenAnalysis(normalizer, transliterator)
@@ -48,8 +49,14 @@ class HousenumberTokenAnalysis:
             return name
 
         norm = self.trans.transliterate(self.norm.transliterate(name))
-        norm = RE_DIGIT_ALPHA.sub(r'\1␣\2', norm)
-        norm = RE_ALPHA_DIGIT.sub(r'\1␣\2', norm)
+        # If there is a significant non-numeric part, use as is.
+        if RE_NAMED_PART.search(norm) is None:
+            # Otherwise add optional spaces between digits and letters.
+            (norm_opt, cnt1) = RE_DIGIT_ALPHA.subn(r'\1␣\2', norm)
+            (norm_opt, cnt2) = RE_ALPHA_DIGIT.subn(r'\1␣\2', norm_opt)
+            # Avoid creating too many variants per number.
+            if cnt1 + cnt2 <= 4:
+                return norm_opt
 
         return norm
 

--- a/nominatim/tokenizer/token_analysis/housenumbers.py
+++ b/nominatim/tokenizer/token_analysis/housenumbers.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2022 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Specialized processor for housenumbers. Analyses common housenumber patterns
+and creates variants for them.
+"""
+import re
+
+from nominatim.tokenizer.token_analysis.generic_mutation import MutationVariantGenerator
+
+RE_NON_DIGIT = re.compile('[^0-9]')
+RE_DIGIT_ALPHA = re.compile(r'(\d)\s*([^\d\s␣])')
+RE_ALPHA_DIGIT = re.compile(r'([^\s\d␣])\s*(\d)')
+
+### Configuration section
+
+def configure(rules, normalization_rules):
+    """ All behaviour is currently hard-coded.
+    """
+    return None
+
+### Analysis section
+
+def create(normalizer, transliterator, config):
+    """ Create a new token analysis instance for this module.
+    """
+    return HousenumberTokenAnalysis(normalizer, transliterator)
+
+
+class HousenumberTokenAnalysis:
+    """ Detects common housenumber patterns and normalizes them.
+    """
+    def __init__(self, norm, trans):
+        self.norm = norm
+        self.trans = trans
+
+        self.mutator = MutationVariantGenerator('␣', (' ', ''))
+
+    def normalize(self, name):
+        """ Return the normalized form of the housenumber.
+        """
+        # shortcut for number-only numbers, which make up 90% of the data.
+        if RE_NON_DIGIT.search(name) is None:
+            return name
+
+        norm = self.trans.transliterate(self.norm.transliterate(name))
+        norm = RE_DIGIT_ALPHA.sub(r'\1␣\2', norm)
+        norm = RE_ALPHA_DIGIT.sub(r'\1␣\2', norm)
+
+        return norm
+
+    def get_variants_ascii(self, norm_name):
+        """ Compute the spelling variants for the given normalized housenumber.
+
+            Generates variants for optional spaces (marked with '␣').
+        """
+        return list(self.mutator.generate([norm_name]))

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -41,6 +41,8 @@ sanitizers:
       mode: append
 token-analysis:
     - analyzer: generic
+    - id: "@housenumber"
+      analyzer: housenumbers
     - id: bg
       analyzer: generic
       mode: variant-only

--- a/test/bdd/db/query/housenumbers.feature
+++ b/test/bdd/db/query/housenumbers.feature
@@ -27,6 +27,7 @@ Feature: Searching of house numbers
          | N1  |
 
 
+    @fail-legacy
     Scenario Outline: Numeral housenumbers in any script are found
         Given the places
          | osm | class    | type | housenr  | geometry |
@@ -83,6 +84,7 @@ Feature: Searching of house numbers
         | 2, 4, 12 |
 
 
+    @fail-legacy
     Scenario Outline: Housenumber - letter combinations are found
         Given the places
          | osm | class    | type | housenr | geometry |
@@ -148,6 +150,7 @@ Feature: Searching of house numbers
         | 34/10 |
 
 
+    @fail-legacy
     Scenario Outline: a bis housenumber is found
         Given the places
          | osm | class    | type | housenr | geometry |
@@ -180,6 +183,8 @@ Feature: Searching of house numbers
         | 45 BIS |
         | 45 bis |
 
+
+    @fail-legacy
     Scenario Outline: a ter housenumber is found
         Given the places
          | osm | class    | type | housenr | geometry |
@@ -213,6 +218,7 @@ Feature: Searching of house numbers
         | 45 TER |
 
 
+    @fail-legacy
     Scenario Outline: a number - letter - number combination housenumber is found
         Given the places
          | osm | class    | type | housenr | geometry |
@@ -246,6 +252,7 @@ Feature: Searching of house numbers
         | 501h1 |
 
 
+    @fail-legacy
     Scenario Outline: Russian housenumbers are found
         Given the places
          | osm | class    | type | housenr | geometry |

--- a/test/bdd/db/query/housenumbers.feature
+++ b/test/bdd/db/query/housenumbers.feature
@@ -9,10 +9,10 @@ Feature: Searching of house numbers
          |   |   |   |   | 4 |
 
 
-    Scenario: A simple numeral housenumber is found
+    Scenario: A simple ascii digit housenumber is found
         Given the places
-         | osm | class    | type | housenr | geometry |
-         | N1  | building | yes  | 45      | 9        |
+         | osm | class    | type | housenr  | geometry |
+         | N1  | building | yes  | 45       | 9        |
         And the places
          | osm | class   | type | name       | geometry |
          | W10 | highway | path | North Road | 1,2,3    |
@@ -25,6 +25,34 @@ Feature: Searching of house numbers
         Then results contain
          | osm |
          | N1  |
+
+
+    Scenario Outline: Numeral housenumbers in any script are found
+        Given the places
+         | osm | class    | type | housenr  | geometry |
+         | N1  | building | yes  | <number> | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | North Road | 1,2,3    |
+        When importing
+        And sending search query "45, North Road"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "North Road ④⑤"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "North Road 𑁪𑁫"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | number |
+        | 45     |
+        | ④⑤     |
+        | 𑁪𑁫     |
 
 
     Scenario Outline: Each housenumber in a list is found
@@ -53,6 +81,196 @@ Feature: Searching of house numbers
         | 2;4;12 |
         | 2,4,12 |
         | 2, 4, 12 |
+
+
+    Scenario Outline: Housenumber - letter combinations are found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name     | geometry |
+         | W10 | highway | path | Multistr | 1,2,3    |
+        When importing
+        When sending search query "2A Multistr"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "2 a Multistr"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "2-A Multistr"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Multistr 2 A"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | hnr |
+        | 2a  |
+        | 2 A |
+        | 2-a |
+        | 2/A |
+
+
+    Scenario Outline: Number - Number combinations as a housenumber are found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | Chester St | 1,2,3    |
+        When importing
+        When sending search query "34-10 Chester St"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "34/10 Chester St"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "34 10 Chester St"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "3410 Chester St"
+        Then results contain
+         | osm |
+         | W10 |
+
+    Examples:
+        | hnr   |
+        | 34-10 |
+        | 34 10 |
+        | 34/10 |
+
+
+    Scenario Outline: a bis housenumber is found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | Rue Paris | 1,2,3    |
+        When importing
+        When sending search query "Rue Paris 45bis"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue Paris 45 BIS"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue Paris 45BIS"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue Paris 45 bis"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | hnr   |
+        | 45bis |
+        | 45BIS |
+        | 45 BIS |
+        | 45 bis |
+
+    Scenario Outline: a ter housenumber is found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | Rue du Berger | 1,2,3    |
+        When importing
+        When sending search query "Rue du Berger 45ter"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue du Berger 45 TER"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue du Berger 45TER"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Rue du Berger 45 ter"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | hnr   |
+        | 45ter |
+        | 45TER |
+        | 45 ter |
+        | 45 TER |
+
+
+    Scenario Outline: a number - letter - number combination housenumber is found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | Herengracht | 1,2,3    |
+        When importing
+        When sending search query "501-H 1 Herengracht"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "501H-1 Herengracht"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "501H1 Herengracht"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "501-H1 Herengracht"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | hnr |
+        | 501 H1 |
+        | 501H 1 |
+        | 501/H/1 |
+        | 501h1 |
+
+
+    Scenario Outline: Russian housenumbers are found
+        Given the places
+         | osm | class    | type | housenr | geometry |
+         | N1  | building | yes  | <hnr>   | 9        |
+        And the places
+         | osm | class   | type | name       | geometry |
+         | W10 | highway | path | Голубинская улица | 1,2,3    |
+        When importing
+        When sending search query "Голубинская улица 55к3"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Голубинская улица 55 k3"
+        Then results contain
+         | osm |
+         | N1  |
+        When sending search query "Голубинская улица 55 к-3"
+        Then results contain
+         | osm |
+         | N1  |
+
+    Examples:
+        | hnr |
+        | 55к3 |
+        | 55 к3 |
 
 
     Scenario: A name mapped as a housenumber is found

--- a/test/python/mock_icu_word_table.py
+++ b/test/python/mock_icu_word_table.py
@@ -58,11 +58,21 @@ class MockIcuWordTable:
         self.conn.commit()
 
 
-    def add_housenumber(self, word_id, word_token):
+    def add_housenumber(self, word_id, word_tokens, word=None):
         with self.conn.cursor() as cur:
-            cur.execute("""INSERT INTO word (word_id, word_token, type)
-                              VALUES (%s, %s, 'H')
-                        """, (word_id, word_token))
+            if isinstance(word_tokens, str):
+                # old style without analyser
+                cur.execute("""INSERT INTO word (word_id, word_token, type)
+                                  VALUES (%s, %s, 'H')
+                            """, (word_id, word_tokens))
+            else:
+                if word is None:
+                    word = word_tokens[0]
+                for token in word_tokens:
+                    cur.execute("""INSERT INTO word (word_id, word_token, type, word, info)
+                                      VALUES (%s, %s, 'H', %s, jsonb_build_object('lookup', %s))
+                                """, (word_id, token, word, word_tokens[0]))
+
         self.conn.commit()
 
 

--- a/test/python/tokenizer/token_analysis/test_generic.py
+++ b/test/python/tokenizer/token_analysis/test_generic.py
@@ -32,8 +32,9 @@ def make_analyser(*variants, variant_only=False):
         rules['mode'] = 'variant-only'
     config = module.configure(rules, DEFAULT_NORMALIZATION)
     trans = Transliterator.createFromRules("test_trans", DEFAULT_TRANSLITERATION)
+    norm = Transliterator.createFromRules("test_norm", DEFAULT_NORMALIZATION)
 
-    return module.create(trans, config)
+    return module.create(norm, trans, config)
 
 
 def get_normalized_variants(proc, name):
@@ -45,8 +46,9 @@ def test_no_variants():
     rules = { 'analyzer': 'generic' }
     config = module.configure(rules, DEFAULT_NORMALIZATION)
     trans = Transliterator.createFromRules("test_trans", DEFAULT_TRANSLITERATION)
+    norm = Transliterator.createFromRules("test_norm", DEFAULT_NORMALIZATION)
 
-    proc = module.create(trans, config)
+    proc = module.create(norm, trans, config)
 
     assert get_normalized_variants(proc, '大德!') == ['dà dé']
 

--- a/test/python/tokenizer/token_analysis/test_generic_mutation.py
+++ b/test/python/tokenizer/token_analysis/test_generic_mutation.py
@@ -33,8 +33,9 @@ class TestMutationNoVariants:
                 }
         config = module.configure(rules, DEFAULT_NORMALIZATION)
         trans = Transliterator.createFromRules("test_trans", DEFAULT_TRANSLITERATION)
+        norm = Transliterator.createFromRules("test_norm", DEFAULT_NORMALIZATION)
 
-        self.analysis = module.create(trans, config)
+        self.analysis = module.create(norm, trans, config)
 
 
     def variants(self, name):


### PR DESCRIPTION
With this change it is now possible to configure an analyzer for housenumbers. This means that housenumbers like standard word tokens can now produce variants. This is used to introduce optional spaces, in particular for '3a' vs. '3 a'.

There is only support for one global analyzer for all housenumbers. If there is an analyser with the special ID `@housenumber`, it will be used. Otherwise housenumbers are handled as before and are just normalized.

Changing the housenumber analyser currently requires a reimport. So it will be a while before this change becomes visible on nominatim.osm.org.