### PR TITLE
documentation: clarify osm2pgsql isnt in project directory by default

### DIFF
--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -74,8 +74,6 @@ NOMINATIM_HTTP_PROXY_PASSWORD=
 # HTTPS_PROXY="http://user:pass@10.10.1.10:1080"
 
 # Location of the osm2pgsql binary.
-# When empty, osm2pgsql is expected to reside in the osm2pgsql directory in
-# the project directory.
 # EXPERT ONLY. You should usually use the supplied osm2pgsql.
 NOMINATIM_OSM2PGSQL_BINARY=
 


### PR DESCRIPTION
to match https://nominatim.org/release-docs/develop/customize/Settings/#nominatim_osm2pgsql_binary