### PR TITLE
No longer use operator tag as a name

### DIFF
--- a/settings/import-extratags.style
+++ b/settings/import-extratags.style
@@ -131,13 +131,6 @@
     }
 },
 {
-    "keys" : ["amenity"],
-    "values" : {
-        "restaurant" : "main,operator",
-        "fuel" : "main,operator"
-    }
-},
-{
     "keys" : ["aeroway", "amenity", "club", "craft", "leisure",
               "office", "mountain_pass"],
     "values" : {
@@ -149,7 +142,7 @@
     "keys" : ["shop"],
     "values" : {
         "no" : "skip",
-        "" : "main,operator"
+        "" : "main"
     }
 },
 {
@@ -157,7 +150,7 @@
     "values" : {
         "yes" : "skip",
         "no" : "skip",
-        "" : "main,operator"
+        "" : "main"
     }
 },
 {

--- a/settings/import-full.style
+++ b/settings/import-full.style
@@ -131,13 +131,6 @@
     }
 },
 {
-    "keys" : ["amenity"],
-    "values" : {
-        "restaurant" : "main,operator",
-        "fuel" : "main,operator"
-    }
-},
-{
     "keys" : ["aeroway", "amenity", "club", "craft", "leisure",
               "office", "mountain_pass"],
     "values" : {
@@ -149,7 +142,7 @@
     "keys" : ["shop"],
     "values" : {
         "no" : "skip",
-        "" : "main,operator"
+        "" : "main"
     }
 },
 {
@@ -157,7 +150,7 @@
     "values" : {
         "yes" : "skip",
         "no" : "skip",
-        "" : "main,operator"
+        "" : "main"
     }
 },
 {


### PR DESCRIPTION
`operator` used to contain the name of the franchise, especially for restaurants and fuel stations. The tagging has changed in the last years and `brand` is now the tag of choice. In the meantime, the OSM data has been sufficiently cleaned up by now that the operator no longer needs to be considered a name tag. Use 'brand' as the searchable alternative.