### PR TITLE
Add migration for new country name handling in ICU tokenizer

### DIFF
--- a/nominatim/db/connection.py
+++ b/nominatim/db/connection.py
@@ -90,6 +90,17 @@ class _Connection(psycopg2.extensions.connection):
             return num == 1
 
 
+    def table_has_column(self, table, column):
+        """ Check if the table 'table' exists and has a column with name 'column'.
+        """
+        with self.cursor() as cur:
+            has_column = cur.scalar("""SELECT count(*) FROM information_schema.columns
+                                       WHERE table_name = %s
+                                             and column_name = %s""",
+                                    (table, column))
+            return has_column > 0
+
+
     def index_exists(self, index, table=None):
         """ Check that an index with the given name exists in the database.
             If table is not None then the index must relate to the given

--- a/nominatim/version.py
+++ b/nominatim/version.py
@@ -24,7 +24,7 @@ Version information for Nominatim.
 # patch level when cherry-picking the commit with the migration.
 #
 # Released versions always have a database patch level of 0.
-NOMINATIM_VERSION = (4, 0, 99, 5)
+NOMINATIM_VERSION = (4, 0, 99, 6)
 
 POSTGRESQL_REQUIRED_VERSION = (9, 5)
 POSTGIS_REQUIRED_VERSION = (2, 2)

--- a/test/bdd/db/update/country.feature
+++ b/test/bdd/db/update/country.feature
@@ -56,10 +56,20 @@ Feature: Country handling
         Then results contain
             | osm |
             | N1  |
+        When sending search query "Wenig, de"
+        Then results contain
+            | osm |
+            | N1  |
         When updating places
             | osm  | class    | type           | admin | name+name:en | country | geometry |
             | R1   | boundary | administrative | 2     | Lilly        | de      | (9 52, 9 53, 10 52, 9 52) |
         When sending search query "Wenig, Germany"
+            | accept-language |
+            | en,de |
+        Then results contain
+            | osm | display_name |
+            | N1  | Wenig, Lilly |
+        When sending search query "Wenig, de"
             | accept-language |
             | en,de |
         Then results contain

--- a/test/python/db/test_connection.py
+++ b/test/python/db/test_connection.py
@@ -26,6 +26,16 @@ def test_connection_table_exists(db, table_factory):
     assert db.table_exists('foobar')
 
 
+def test_has_column_no_table(db):
+    assert not db.table_has_column('sometable', 'somecolumn')
+
+
+@pytest.mark.parametrize('name,result', [('tram', True), ('car', False)])
+def test_has_column(db, table_factory, name, result):
+    table_factory('stuff', 'tram TEXT')
+
+    assert db.table_has_column('stuff', name) == result
+
 def test_connection_index_exists(db, table_factory, temp_db_cursor):
     assert not db.index_exists('some_index')
 


### PR DESCRIPTION
Addendum to #2629. It is important to mark the names from country_name as internal or they will be removed, when a country is updated. Most importantly, this alos affects country codes which are internal names as well.

This adds a migration which simply reimports the default country names, so that existing databases have the right flag in the word table.

Fixes #2653.