### PR TITLE
Admin command for forced indexing

### DIFF
--- a/docs/admin/Maintenance.md
+++ b/docs/admin/Maintenance.md
@@ -34,6 +34,30 @@ to rerun the statistics computation when adding larger amounts of new data,
 for example, when adding an additional country via `nominatim add-data`.
 
 
+## Forcing recomputation of places and areas
+
+Command: `nominatim refresh --data-object [NWR]<id> --data-area [NWR]<id>`
+
+When running replication updates, Nominatim tries to recompute the search
+and address information for all places that are affected by a change. But it
+needs to restrict the total number of changes to make sure it can keep up
+with the minutely updates. Therefore it will refrain from propagating changes
+that affect a lot of objects.
+
+The administrator may force an update of places in the database.
+`nominatim refresh --data-object` invalidates a single OSM object.
+`nominatim refresh --data-area` invalidates an OSM object and all dependent
+objects. That are usually the places that inside its area or around the
+center of the object. Both commands expect the OSM object as an argument
+of the form OSM type + OSM id. The type must be `N` (node), `W` (way) or
+`R` (relation).
+
+After invalidating the object, indexing must be run again. If continuous
+update are running in the background, the objects will be recomputed together
+with the next round of updates. Otherwise you need to run `nominatim index`
+to finish the recomputation.
+
+
 ## Removing large deleted objects
 
 Nominatim refuses to delete very large areas because often these deletions are

--- a/nominatim/cli.py
+++ b/nominatim/cli.py
@@ -70,7 +70,10 @@ class CommandlineParser:
             appropriate subcommand.
         """
         args = NominatimArgs()
-        self.parser.parse_args(args=kwargs.get('cli_args'), namespace=args)
+        try:
+            self.parser.parse_args(args=kwargs.get('cli_args'), namespace=args)
+        except SystemExit:
+            return 1
 
         if args.subcommand is None:
             self.parser.print_help()

--- a/nominatim/clicmd/refresh.py
+++ b/nominatim/clicmd/refresh.py
@@ -7,6 +7,7 @@
 """
 Implementation of 'refresh' subcommand.
 """
+from argparse import ArgumentTypeError
 import logging
 from pathlib import Path
 
@@ -24,7 +25,7 @@ def _parse_osm_object(obj):
         Raises an ArgumentError if the format is not recognized.
     """
     if len(obj) < 2 or obj[0].lower() not in 'nrw' or not obj[1:].isdigit():
-        raise ArgumentError("Expect OSM object id of form [N|W|R]<id>.")
+        raise ArgumentTypeError("Cannot parse OSM ID. Expect format: [N|W|R]<id>.")
 
     return (obj[0].upper(), int(obj[1:]))
 
@@ -79,7 +80,7 @@ class UpdateRefresh:
                            help='Enable debug warning statements in functions')
 
 
-    def run(self, args):
+    def run(self, args): #pylint: disable=too-many-branches
         from ..tools import refresh, postcodes
         from ..indexer.indexer import Indexer
 

--- a/test/python/cli/test_cmd_api.py
+++ b/test/python/cli/test_cmd_api.py
@@ -14,15 +14,14 @@ import nominatim.clicmd.api
 
 @pytest.mark.parametrize("endpoint", (('search', 'reverse', 'lookup', 'details', 'status')))
 def test_no_api_without_phpcgi(src_dir, endpoint):
-    with pytest.raises(SystemExit):
-        nominatim.cli.nominatim(module_dir='MODULE NOT AVAILABLE',
-                                osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                phplib_dir=str(src_dir / 'lib-php'),
-                                data_dir=str(src_dir / 'data'),
-                                phpcgi_path=None,
-                                sqllib_dir=str(src_dir / 'lib-sql'),
-                                config_dir=str(src_dir / 'settings'),
-                                cli_args=[endpoint])
+    assert nominatim.cli.nominatim(module_dir='MODULE NOT AVAILABLE',
+                                   osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
+                                   phplib_dir=str(src_dir / 'lib-php'),
+                                   data_dir=str(src_dir / 'data'),
+                                   phpcgi_path=None,
+                                   sqllib_dir=str(src_dir / 'lib-sql'),
+                                   config_dir=str(src_dir / 'settings'),
+                                   cli_args=[endpoint]) == 1
 
 
 @pytest.mark.parametrize("params", [('search', '--query', 'new'),

--- a/test/python/cli/test_cmd_refresh.py
+++ b/test/python/cli/test_cmd_refresh.py
@@ -82,3 +82,24 @@ class TestRefresh:
         assert self.call_nominatim('refresh', '--importance', '--wiki-data') == 0
 
         assert calls == ['import', 'update']
+
+    @pytest.mark.parametrize('params', [('--data-object', 'w234'),
+                                        ('--data-object', 'N23', '--data-object', 'N24'),
+                                        ('--data-area', 'R7723'),
+                                        ('--data-area', 'r7723', '--data-area', 'r2'),
+                                        ('--data-area', 'R9284425', '--data-object', 'n1234567894567')])
+    def test_refresh_objects(self, params, mock_func_factory):
+        func_mock = mock_func_factory(nominatim.tools.refresh, 'invalidate_osm_object')
+
+        assert self.call_nominatim('refresh', *params) == 0
+
+        assert func_mock.called == len(params)/2
+
+
+    @pytest.mark.parametrize('func', ('--data-object', '--data-area'))
+    @pytest.mark.parametrize('param', ('234', 'a55', 'R 453', 'Rel'))
+    def test_refresh_objects_bad_param(self, func, param, mock_func_factory):
+        func_mock = mock_func_factory(nominatim.tools.refresh, 'invalidate_osm_object')
+
+        self.call_nominatim('refresh', func, param) == 1
+        assert func_mock.called == 0


### PR DESCRIPTION
This adds two new commands `refresh --data-object` and `refresh --data-area` to the CLI tool. The allow to mark rows in placex for indexing in a bit more comfortable way. See included documentation for details.