### PR TITLE
Fix 'type' field in the geocodejson response

### DIFF
--- a/docs/admin/Migration.md
+++ b/docs/admin/Migration.md
@@ -15,6 +15,15 @@ breaking changes. **Please read them before running the migration.**
     If you are migrating from a version <3.6, then you still have to follow
     the manual migration steps up to 3.6.
 
+## 4.0.0 -> master
+
+### geocodejson output changed
+
+The `type` field of the geocodejson output has changed. It now contains
+the address class of the object instead of the value of the OSM tag. If
+your client has used the `type` field, switch them to read `osm_value`
+instead.
+
 ## 3.7.0 -> 4.0.0
 
 ### NOMINATIM_PHRASE_CONFIG removed

--- a/docs/api/Output.md
+++ b/docs/api/Output.md
@@ -98,7 +98,10 @@ The GeocodeJSON format follows the
 The following feature attributes are implemented:
 
  * `osm_type`, `osm_id` - reference to the OSM object (unofficial extension, [see notes](#osm-reference))
- * `type` - value of the main tag of the object (e.g. residential, restaurant, ...)
+ * `type` - the 'address level' of the object ('house', 'street', `district`, `city`,
+            `county`, `state`, `country`, `locality`)
+ * `osm_key`- key of the main tag of the OSM object (e.g. boundary, highway, amenity)
+ * `osm_value` - value of the main tag of the OSM object (e.g. residential, restaurant)
  * `label` - full comma-separated address
  * `name` - localised name of the place
  * `housenumber`, `street`, `locality`, `district`, `postcode`, `city`,

--- a/lib-php/lib.php
+++ b/lib-php/lib.php
@@ -206,6 +206,36 @@ function parseLatLon($sQuery)
     return array($sFound, $fQueryLat, $fQueryLon);
 }
 
+function addressRankToGeocodeJsonType($iAddressRank)
+{
+    if ($iAddressRank >= 29 && $iAddressRank <= 30) {
+        return 'house';
+    }
+    if ($iAddressRank >= 26 && $iAddressRank < 28) {
+        return 'street';
+    }
+    if ($iAddressRank >= 22 && $iAddressRank < 26) {
+        return 'locality';
+    }
+    if ($iAddressRank >= 17 && $iAddressRank < 22) {
+        return 'district';
+    }
+    if ($iAddressRank >= 13 && $iAddressRank < 17) {
+        return 'city';
+    }
+    if ($iAddressRank >= 10 && $iAddressRank < 13) {
+        return 'county';
+    }
+    if ($iAddressRank >= 5 && $iAddressRank < 10) {
+        return 'state';
+    }
+    if ($iAddressRank >= 4 && $iAddressRank < 5) {
+        return 'country';
+    }
+
+    return 'locality';
+}
+
 if (!function_exists('array_key_last')) {
     function array_key_last(array $array)
     {

--- a/lib-php/template/search-geocodejson.php
+++ b/lib-php/template/search-geocodejson.php
@@ -26,7 +26,7 @@ foreach ($aSearchResults as $iResNum => $aPointDetails) {
         $aPlace['properties']['geocoding']['osm_id'] = $aPointDetails['osm_id'];
     }
 
-    $aPlace['properties']['geocoding']['type'] = $aPointDetails['type'];
+    $aPlace['properties']['geocoding']['type'] = addressRankToGeocodeJsonType($aPointDetails['rank_address']);
 
     $aPlace['properties']['geocoding']['label'] = $aPointDetails['langaddress'];
 

--- a/lib-php/template/search-geocodejson.php
+++ b/lib-php/template/search-geocodejson.php
@@ -25,6 +25,8 @@ foreach ($aSearchResults as $iResNum => $aPointDetails) {
         $aPlace['properties']['geocoding']['osm_type'] = $sOSMType;
         $aPlace['properties']['geocoding']['osm_id'] = $aPointDetails['osm_id'];
     }
+    $aPlace['properties']['geocoding']['osm_key'] = $aPointDetails['class'];
+    $aPlace['properties']['geocoding']['osm_value'] = $aPointDetails['type'];
 
     $aPlace['properties']['geocoding']['type'] = addressRankToGeocodeJsonType($aPointDetails['rank_address']);
 


### PR DESCRIPTION
According to the [geocodejson spec](https://github.com/geocoders/geocodejson-spec/tree/master/draft) the 'type' field should contain a group that roughly corresponds to the address classes. Nominatim instead returns the value of the OSM main tag. This is bad for two reasons:
* many of the values are not exactly helpful. Many housenumbers have, for example, "yes" (from building=yes). All boundaries have "administrative" no matter what admin level they are.
* The value of the main tag is unrestricted. It is impossible to make a list of valid values.

This PR changes the `type` field to emit the address class of the object in the same way that [photon does](https://github.com/komoot/photon/blob/f85dc2c80b11bd990507f2aa356a193f0ef84df7/src/main/java/de/komoot/photon/nominatim/model/AddressType.java#L9). To preserve the more detailed object type information, especially on POI level, the response gets two new fields 'osm_key', 'osm_value' corresponding to key and value of the OSM main tag.

***This is an API-breaking change. If you have been using the 'type' field of the geocodejson response, you must switch to reading the 'osm_value' field instead or adapt your code to the new values.***