### PR TITLE
ICU: better letter identification in normalization

### DIFF
--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -8,8 +8,8 @@ normalization:
     - "ª > a"
     - "º > o"
     - "[[:Punctuation:][:Symbol:]\u02bc]  > ' '"
-    - "ß > 'ss'" # German szet is unimbigiously equal to double ss
-    - "[^[:Letter:] [:Number:] [:Space:]] >"
+    - "ß > 'ss'" # German szet is unambiguously equal to double ss
+    - "[^[:alnum:] [:Canonical_Combining_Class=Virama:] [:Space:]] >"
     - "[:Lm:] >"
     - ":: [[:Number:]] Latin ()"
     - ":: [[:Number:]] Ascii ();"


### PR DESCRIPTION
The Letter class does not include non-spacing marks that can also have a consonant or vowel meaning, especially in Indian languages. Use the alnum property instead which includes them all. Also include the vowel-canceling Virama, which is not a letter by itself but changes the transliteration.

This change should avoid some surprising results like getting [Chengdu when searching for Canada](https://nominatim.openstreetmap.org/ui/search.html?q=canada).

Only has an effect after the next reimport of the database.