### PR TITLE
Keep address parts inherited from surrounding buildings after indexing

### DIFF
--- a/test/bdd/db/import/parenting.feature
+++ b/test/bdd/db/import/parenting.feature
@@ -376,6 +376,10 @@ Feature: Parenting of objects
          | N1     | W3              | 3 |
          | N2     | W3              | 3 |
          | N3     | W3              | 3 |
+        When sending geocodejson search query "3, foo" with address
+        Then results contain
+         | housenumber |
+         | 3           |
 
     Scenario: POIs don't inherit from streets
         Given the scene building-on-street-corner


### PR DESCRIPTION
The inherited house number is needed for display output. We can't take the one from the housenumber field because it is already
normalized. Remove the inherited address only when reindexing, so that we start with a clean state.

Fixes #2683.