### PR TITLE
Accept any OSM type in street member of associatedStreet

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -120,7 +120,8 @@ BEGIN
       IF location.members[i+1] = 'street' THEN
         FOR parent IN
           SELECT place_id from placex
-           WHERE osm_type = 'W' and osm_id = substring(location.members[i],2)::bigint
+           WHERE osm_type = upper(substring(location.members[i], 1, 1))
+                 and osm_id = substring(location.members[i], 2)::bigint
                  and name is not null
                  and rank_search between 26 and 27
         LOOP

--- a/test/bdd/db/import/parenting.feature
+++ b/test/bdd/db/import/parenting.feature
@@ -355,6 +355,29 @@ Feature: Parenting of objects
          | object | parent_place_id |
          | N1     | W3 |
 
+
+    Scenario: street member in associatedStreet relation can be a relation
+        Given the grid
+          | 1 |   |   | 2 |
+          | 3 |   |   | 4 |
+          |   |   |   |   |
+          |   | 9 |   |   |
+          | 5 |   |   | 6 |
+        And the places
+          | osm | class | type  | housenr | geometry |
+          | N9  | place | house | 34      | 9        |
+        And the named places
+          | osm | class   | type       | name      | geometry    |
+          | R14 | highway | pedestrian | Right St  | (1,2,4,3,1) |
+          | W14 | highway | pedestrian | Left St   | 5,6         |
+        And the relations
+          | id | members             | tags+type |
+          | 1  | N9:house,R14:street | associatedStreet |
+        When importing
+        Then placex contains
+          | object | parent_place_id |
+          | N9     | R14             |
+
     Scenario: POIs in building inherit address
         Given the scene building-on-street-corner
         And the named places


### PR DESCRIPTION
The French community has started putting pedestrian areas into associatedStreet relations which are mapped as multipolygons and consequently as relations. Nominatim has so far assumed that the object is a way as per Wiki documentation. That leads to a couple of interesting bugs with the assignment of the parent street. This change makes sure that the type is properly checked. Given that it doesn't make much of a difference, it allows that the 'street' member may now be of any type. The subsequent lookup in placex guarantees that the referenced OSM object is indeed a street.

Fixes #2669.