### PR TITLE
new "nominatim --version" global CLI argument

### DIFF
--- a/nominatim/cli.py
+++ b/nominatim/cli.py
@@ -18,6 +18,7 @@ from nominatim.config import Configuration
 from nominatim.tools.exec_utils import run_legacy_script, run_php_server
 from nominatim.errors import UsageError
 from nominatim import clicmd
+from nominatim import version
 from nominatim.clicmd.args import NominatimArgs
 
 LOG = logging.getLogger()
@@ -36,6 +37,11 @@ class CommandlineParser:
         self.subs = self.parser.add_subparsers(title='available commands',
                                                dest='subcommand')
 
+        # Global arguments that only work if no sub-command given
+        self.parser.add_argument('--version', action='version',
+                                 version=CommandlineParser.nominatim_version_text(),
+                                 help='Print Nominatim version and exit')
+
         # Arguments added to every sub-command
         self.default_args = argparse.ArgumentParser(add_help=False)
         group = self.default_args.add_argument_group('Default arguments')
@@ -51,6 +57,11 @@ class CommandlineParser:
         group.add_argument('-j', '--threads', metavar='NUM', type=int,
                            help='Number of parallel threads to use')
 
+    @staticmethod
+    def nominatim_version_text():
+        """ Program name and version number as string
+        """
+        return "Nominatim version %s.%s.%s.%s\n" % version.NOMINATIM_VERSION
 
     def add_subcommand(self, name, cmd):
         """ Add a subcommand to the parser. The subcommand must be a class

--- a/test/python/cli/test_cli.py
+++ b/test/python/cli/test_cli.py
@@ -26,6 +26,13 @@ def test_cli_help(cli_call, capsys):
     captured = capsys.readouterr()
     assert captured.out.startswith('usage:')
 
+def test_cli_version(cli_call, capsys):
+    """ Running nominatim tool --version prints a version string.
+    """
+    assert cli_call('--version') == 1
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith('Nominatim version')
 
 @pytest.mark.parametrize("name,oid", [('file', 'foo.osm'), ('diff', 'foo.osc')])
 def test_cli_add_data_file_command(cli_call, mock_func_factory, name, oid):


### PR DESCRIPTION
For https://github.com/osm-search/Nominatim/issues/2615

```
$ nominatim
usage: nominatim [-h] [--version] {import,freeze,replication,special-phrases,add-data,index,refresh,admin,export,serve,search,reverse,lookup,details,status} ...

    Command-line tools for importing, updating, administrating and querying the Nominatim database.

optional arguments:
  -h, --help            show this help message and exit
  --version             Print Nominatim version and exit

available commands:
  {import,freeze,replication,special-phrases,add-data,index,refresh,admin,export,serve,search,reverse,lookup,details,status}
    import              Create a new Nominatim database from an OSM file.
    freeze              Make database read-only.
...
```

```
$ nominatim --version
Nominatim version 4.0.99.6
```

```
$ nominatim status --version
usage: nominatim [-h] [--version] {import,freeze,replication,special-phrases,add-data,index,refresh,admin,export,serve,search,reverse,lookup,details,status} ...
nominatim: error: unrecognized arguments: --version
```
