### PR TITLE
add git commit hash to 'nominatim --version' output

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -256,6 +256,10 @@ jobs:
               working-directory: /home/nominatim
               if: matrix.flavour == 'centos'
 
+            - name: Print version
+              run: nominatim --version
+              working-directory: /home/nominatim/nominatim-project
+
             - name: Import
               run: nominatim import --osm-file ../test.pbf
               working-directory: /home/nominatim/nominatim-project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,17 @@ set(NOMINATIM_VERSION "${NOMINATIM_VERSION_MAJOR}.${NOMINATIM_VERSION_MINOR}.${N
 
 add_definitions(-DNOMINATIM_VERSION="${NOMINATIM_VERSION}")
 
+# Setting GIT_HASH
+find_package(Git)
+if (GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+endif()
 
 #-----------------------------------------------------------------------------
 #  Configuration

--- a/cmake/tool-installed.tmpl
+++ b/cmake/tool-installed.tmpl
@@ -7,6 +7,9 @@ sys.path.insert(1, '@NOMINATIM_LIBDIR@/lib-python')
 os.environ['NOMINATIM_NOMINATIM_TOOL'] = os.path.abspath(__file__)
 
 from nominatim import cli
+from nominatim import version
+
+version.GIT_COMMIT_HASH = '@GIT_HASH@'
 
 exit(cli.nominatim(module_dir='@NOMINATIM_LIBDIR@/module',
                    osm2pgsql_path='@NOMINATIM_LIBDIR@/osm2pgsql',

--- a/cmake/tool.tmpl
+++ b/cmake/tool.tmpl
@@ -7,6 +7,9 @@ sys.path.insert(1, '@CMAKE_SOURCE_DIR@')
 os.environ['NOMINATIM_NOMINATIM_TOOL'] = os.path.abspath(__file__)
 
 from nominatim import cli
+from nominatim import version
+
+version.GIT_COMMIT_HASH = '@GIT_HASH@'
 
 exit(cli.nominatim(module_dir='@CMAKE_BINARY_DIR@/module',
                    osm2pgsql_path='@CMAKE_BINARY_DIR@/osm2pgsql/osm2pgsql',

--- a/nominatim/cli.py
+++ b/nominatim/cli.py
@@ -38,8 +38,7 @@ class CommandlineParser:
                                                dest='subcommand')
 
         # Global arguments that only work if no sub-command given
-        self.parser.add_argument('--version', action='version',
-                                 version=CommandlineParser.nominatim_version_text(),
+        self.parser.add_argument('--version', action='store_true',
                                  help='Print Nominatim version and exit')
 
         # Arguments added to every sub-command
@@ -61,7 +60,10 @@ class CommandlineParser:
     def nominatim_version_text():
         """ Program name and version number as string
         """
-        return "Nominatim version %s.%s.%s.%s\n" % version.NOMINATIM_VERSION
+        text = 'Nominatim version %s.%s.%s.%s' % version.NOMINATIM_VERSION
+        if version.GIT_COMMIT_HASH is not None:
+            text += ' (%s)' % version.GIT_COMMIT_HASH
+        return text
 
     def add_subcommand(self, name, cmd):
         """ Add a subcommand to the parser. The subcommand must be a class
@@ -85,6 +87,10 @@ class CommandlineParser:
             self.parser.parse_args(args=kwargs.get('cli_args'), namespace=args)
         except SystemExit:
             return 1
+
+        if args.version:
+            print(CommandlineParser.nominatim_version_text())
+            return 0
 
         if args.subcommand is None:
             self.parser.print_help()

--- a/nominatim/version.py
+++ b/nominatim/version.py
@@ -28,3 +28,9 @@ NOMINATIM_VERSION = (4, 0, 99, 6)
 
 POSTGRESQL_REQUIRED_VERSION = (9, 5)
 POSTGIS_REQUIRED_VERSION = (2, 2)
+
+# Cmake sets a variabe @GIT_HASH@ by executing 'git --log'. It is not run
+# on every execution of 'make'.
+# cmake/tool-installed.tmpl is used to build the binary 'nominatim'. Inside
+# there is a call to set the variable value below.
+GIT_COMMIT_HASH = None

--- a/test/python/cli/test_cli.py
+++ b/test/python/cli/test_cli.py
@@ -29,7 +29,7 @@ def test_cli_help(cli_call, capsys):
 def test_cli_version(cli_call, capsys):
     """ Running nominatim tool --version prints a version string.
     """
-    assert cli_call('--version') == 1
+    assert cli_call('--version') == 0
 
     captured = capsys.readouterr()
     assert captured.out.startswith('Nominatim version')


### PR DESCRIPTION
for https://github.com/osm-search/Nominatim/issues/2615

```bash
$ nominatim --version
Nominaim version 4.0.99.6 (8c073993)
```

Cmake run fails should git not be installed. A work-around could be to execute multiple commands in `execute_process`, the last being 'true' and setting `COMMAND_ERROR_IS_FATAL LAST`.

During development I got an error
```
fatal: unsafe repository ('/home/vagrant/Nominatim' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /home/vagrant/Nominatim
```
That's related to the recent https://github.blog/2022-04-12-git-security-vulnerability-announced/ Probably only affects my virtual machine setup and other users won't see this.