### PR TITLE
Modify update_database.sh to update db date with python helper script

### DIFF
--- a/utils/parsedate.py
+++ b/utils/parsedate.py
@@ -1,0 +1,30 @@
+import sys
+import re
+from datetime import datetime
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise TypeError("Must pass file to parse as an argument")
+
+    file_to_parse = sys.argv[1]
+    max_timestamp = None
+
+    with open(file_to_parse, "r") as f:
+        for line in f:
+            # split line with whitespace, '=', and '>' deliminators
+            split_line = re.split("[\s=>]", line)
+            # timestamp will be at index next to 'timestamp' string
+            if "timestamp" in split_line:
+                timestamp_idx = split_line.index("timestamp") + 1
+                timestamp_str = split_line[timestamp_idx]
+                # create timestamp object from string
+                timestamp = datetime.strptime(timestamp_str, "\"%Y-%m-%dT%H:%M:%SZ\"")
+                if max_timestamp is None:
+                    max_timestamp = timestamp
+                elif timestamp > max_timestamp:
+                    max_timestamp = timestamp
+
+        if max_timestamp is None:
+            raise ValueError("A timestamp was not found in the inputted lines")
+        
+    print(max_timestamp)

--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -22,7 +22,8 @@
 
 # REPLACE WITH LIST OF YOUR "COUNTRIES":
 #
-COUNTRIES="europe/monaco europe/andorra"
+#COUNTRIES="europe/monaco europe/andorra"
+COUNTRIES="europe/germany/sachsen"
 
 UPDATEBASEURL="https://download.geofabrik.de"
 UPDATECOUNTRYPOSTFIX="-updates"
@@ -39,6 +40,7 @@ FOLLOWUP="nominatim index"
 
 # ******************************************************************************
 UPDATEDIR="update"
+DATEUPDATE="state.txt"
 
 for COUNTRY in $COUNTRIES;
 do
@@ -56,6 +58,12 @@ do
 
     echo "Attempting to import diffs"
     nominatim add-data --diff ${DIR}/${FILENAME}.osc.gz
+
+    echo "Attempting to update date of db"
+    zgrep timestamp ${DIR}/${FILENAME}.osc.gz | tee newtimestamps.txt
+    NEWTIME = $(python3 parsedate.py newtimestamps.txt)
+    psql -U postgres -d nominatim -c "UPDATE import_status SET lastimportdate = $NEWTIME"
+    rm newtimestamps.txt
 done
 
 echo "===================================================================="


### PR DESCRIPTION
This PR addresses #2622 and adds lines to the `update_database.sh` script to: (1) parse the timestamps from the `.gz` update files, (2) load the timestamps into a temporary file, (3) call a python helper script to determine the maximum timestamp, (4) update the timestamp in the database, and (5) remove the temporary timestamp file.