### PR TITLE
PHPUnit 9 changed configuration schema slightly

### DIFF
--- a/test/php/phpunit.xml
+++ b/test/php/phpunit.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    bootstrap="./bootstrap.php"
-    beStrictAboutTestsThatDoNotTestAnything="true"
-    >
-    <php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  bootstrap="./bootstrap.php"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>../../lib-php/</directory>
+    </include>
+  </coverage>
+  <php>
     </php>
-    <testsuites>
-        <testsuite name="Nominatim PHP Test Suite">
-            <directory>./Nominatim</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>../../lib-php/</directory>
-        </whitelist>
-    </filter>
-
+  <testsuites>
+    <testsuite name="Nominatim PHP Test Suite">
+      <directory>./Nominatim</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
For Ubuntu-18 we don't run the PHP Unit tests. For Ubuntu-20 (and soon Ubuntu-22) we do. Both use PHPunit 9.5 and it printed

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
``` 