### PR TITLE
PHP 8 behaves slightly different with in_array and usort

### DIFF
--- a/lib-php/ParameterParser.php
+++ b/lib-php/ParameterParser.php
@@ -70,7 +70,7 @@ class ParameterParser
             return $sDefault;
         }
 
-        if (!in_array($this->aParams[$sName], $aValues)) {
+        if (!in_array($this->aParams[$sName], $aValues, true)) {
             userError("Parameter '$sName' must be one of: ".join(', ', $aValues));
         }
 

--- a/lib-php/SimpleWordList.php
+++ b/lib-php/SimpleWordList.php
@@ -120,13 +120,18 @@ class SimpleWordList
         return array_slice($aWordSets, 0, SimpleWordList::MAX_WORDSETS);
     }
 
+    /**
+     * Custom search routine which takes two arrays. The array with the fewest
+     * items wins. If same number of items then the one with the longest first
+     * element wins.
+     */
     public static function cmpByArraylen($aA, $aB)
     {
         $iALen = count($aA);
         $iBLen = count($aB);
 
         if ($iALen == $iBLen) {
-            return 0;
+            return strlen($aB[0]) <=> strlen($aA[0]);
         }
 
         return ($iALen < $iBLen) ? -1 : 1;

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -137,6 +137,9 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSet()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Parameter 'val3' must be one of: foo, bar");
+
         $oParams = new ParameterParser(array(
                                         'val1' => 'foo',
                                         'val2' => '',
@@ -148,7 +151,7 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('foo', $oParams->getSet('val1', array('foo', 'bar')));
 
         $this->assertSame(false, $oParams->getSet('val2', array('foo', 'bar')));
-        $this->assertSame(0, $oParams->getSet('val3', array('foo', 'bar')));
+        $oParams->getSet('val3', array('foo', 'bar'));
     }
 
 

--- a/test/php/Nominatim/SimpleWordListTest.php
+++ b/test/php/Nominatim/SimpleWordListTest.php
@@ -77,7 +77,7 @@ class SimpleWordListTest extends \PHPUnit\Framework\TestCase
 
         $oList = new SimpleWordList('a b c');
         $this->assertEquals(
-            '(a b c),(a|b c),(a b|c),(a|b|c)',
+            '(a b c),(a b|c),(a|b c),(a|b|c)',
             $this->serializeSets($oList->getWordSets(new TokensFullSet()))
         );
 
@@ -88,6 +88,22 @@ class SimpleWordListTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testCmpByArraylen()
+    {
+        // Array elements are phrases, we want to sort so longest phrases are first
+        $aList1 = array('hackney', 'bridge', 'london', 'england');
+        $aList2 = array('hackney', 'london', 'bridge');
+        $aList3 = array('bridge', 'hackney', 'london', 'england');
+
+        $this->assertEquals(0, \Nominatim\SimpleWordList::cmpByArraylen($aList1, $aList1));
+
+        // list2 "wins". Less array elements
+        $this->assertEquals(1, \Nominatim\SimpleWordList::cmpByArraylen($aList1, $aList2));
+        $this->assertEquals(-1, \Nominatim\SimpleWordList::cmpByArraylen($aList2, $aList3));
+
+        // list1 "wins". Same number of array elements but longer first element
+        $this->assertEquals(-1, \Nominatim\SimpleWordList::cmpByArraylen($aList1, $aList3));
+    }
 
     public function testMaxWordSets()
     {


### PR DESCRIPTION
PHP 8.1 (default on Ubuntu-22) shows test suite failures we don't see with PHP 7.4

1. `php -r 'var_dump(in_array(0, array("option1","option2")));'`. PHP 7 returns `true`, PHP 8 returns `false`. PHP 8 is probably better here. Using strict mode https://www.php.net/manual/en/function.in-array.php both return `false`.

2. In `SimpleWordList.php` we use `usort` which can often have no winner. Thus nondeterministic sort outcome neither PHP 7 or PHP 8 can be said to be more correct than the other. I added a second clause to favor longer phrases. It's hopefully a relative cheap computation compared to hashing or full string comparison because the `usort` is called in a loop with potentially 100s of 1000s elements.