### PR TITLE
Be more strict with country assignments

### DIFF
--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -170,15 +170,6 @@ BEGIN
 
 -- RAISE WARNING 'near osm fallback: %', ST_AsText(place_centre);
 
-  -- 
-  FOR nearcountry IN
-    SELECT country_code from country_osm_grid
-    WHERE st_dwithin(geometry, place_centre, 0.5)
-    ORDER BY st_distance(geometry, place_centre) asc, area asc limit 1
-  LOOP
-    RETURN nearcountry.country_code;
-  END LOOP;
-
   RETURN NULL;
 END;
 $$


### PR DESCRIPTION
If a OSM object can't be assigned a country from the OSM country boundaries or the OSM grid fallback, Nominatim would try until now again within a 0.5 degree margin. This PR removes this fallback.

The fallback country boundaries already contain a sufficiently large part of the water area, so there is no need to extend the country assignment even more. Features outside countries should not show a country in their address. It's just confusing and a potential source for conflict.

Fixes #2698.