### PR TITLE
Assorted performance improvements for BDD tests

### DIFF
--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -95,6 +95,7 @@ class NominatimEnvironment:
 
         self.test_env = dict(self.default_config)
         self.test_env['NOMINATIM_DATABASE_DSN'] = dsn
+        self.test_env['NOMINATIM_LANGUAGES'] = 'en,de,fr,ja'
         self.test_env['NOMINATIM_FLATNODE_FILE'] = ''
         self.test_env['NOMINATIM_IMPORT_STYLE'] = 'full'
         self.test_env['NOMINATIM_USE_US_TIGER_DATA'] = 'yes'

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -172,23 +172,23 @@ class NominatimEnvironment:
 
         self.template_db_done = True
 
-        if self._reuse_or_drop_db(self.template_db):
-            return
-
         self.write_nominatim_config(self.template_db)
 
-        try:
-            # execute nominatim import on an empty file to get the right tables
-            with tempfile.NamedTemporaryFile(dir='/tmp', suffix='.xml') as fd:
-                fd.write(b'<osm version="0.6"></osm>')
-                fd.flush()
-                self.run_nominatim('import', '--osm-file', fd.name,
-                                             '--osm2pgsql-cache', '1',
-                                             '--ignore-errors',
-                                             '--offline', '--index-noanalyse')
-        except:
-            self.db_drop_database(self.template_db)
-            raise
+        if not self._reuse_or_drop_db(self.template_db):
+            try:
+                # execute nominatim import on an empty file to get the right tables
+                with tempfile.NamedTemporaryFile(dir='/tmp', suffix='.xml') as fd:
+                    fd.write(b'<osm version="0.6"></osm>')
+                    fd.flush()
+                    self.run_nominatim('import', '--osm-file', fd.name,
+                                                 '--osm2pgsql-cache', '1',
+                                                 '--ignore-errors',
+                                                 '--offline', '--index-noanalyse')
+            except:
+                self.db_drop_database(self.template_db)
+                raise
+
+        self.run_nominatim('refresh', '--functions')
 
 
     def setup_api_db(self):

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -184,7 +184,8 @@ class NominatimEnvironment:
                 fd.flush()
                 self.run_nominatim('import', '--osm-file', fd.name,
                                              '--osm2pgsql-cache', '1',
-                                             '--ignore-errors')
+                                             '--ignore-errors',
+                                             '--offline', '--index-noanalyse')
         except:
             self.db_drop_database(self.template_db)
             raise

--- a/test/bdd/steps/steps_db_ops.py
+++ b/test/bdd/steps/steps_db_ops.py
@@ -93,7 +93,6 @@ def add_data_to_planet_ways(context):
 def import_and_index_data_from_place_table(context):
     """ Import data previously set up in the place table.
     """
-    context.nominatim.run_nominatim('refresh', '--functions')
     context.nominatim.run_nominatim('import', '--continue', 'load-data',
                                               '--index-noanalyse', '-q',
                                               '--offline')

--- a/test/bdd/steps/steps_db_ops.py
+++ b/test/bdd/steps/steps_db_ops.py
@@ -95,7 +95,8 @@ def import_and_index_data_from_place_table(context):
     """
     context.nominatim.run_nominatim('refresh', '--functions')
     context.nominatim.run_nominatim('import', '--continue', 'load-data',
-                                              '--index-noanalyse', '-q')
+                                              '--index-noanalyse', '-q',
+                                              '--offline')
 
     check_database_integrity(context)
 


### PR DESCRIPTION
To make the BDD tests run a little bit faster, this PR:
* adds an 'offline' mode that makes sure the import doesn't contact the OSM API to get the change date for the database content (which is artificial data and not the OSM data)
* calls 'refresh --functions` only once at the beginning on the template instead of repeating it for every scenario
* restricts languages to four test languages. The import of country names is quite time consuming otherwise and has to be done for every scenario.