### PR TITLE
Remove county nodes in Canada from addresses

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -115,6 +115,13 @@
       }
   }
 },
+{ "countries" : [ "ca" ],
+  "tags" : {
+      "place" : {
+          "county" : [12, 0]
+      }
+  }
+},
 { "countries" : [ "de" ],
   "tags" : {
       "place" : {


### PR DESCRIPTION
Canada has complete coverage for administrative boundaries on county level. Removing the county nodes from the addresses avoids error due to a wide-spread doubling of place nodes for city counties, e.g. https://www.openstreetmap.org/node/6182594243 and https://www.openstreetmap.org/node/9406695086.