### PR TITLE
Simplify apache rewrite rules

### DIFF
--- a/docs/admin/Setup-Nominatim-UI.md
+++ b/docs/admin/Setup-Nominatim-UI.md
@@ -163,22 +163,14 @@ directory like this:
 
   # If format-html is explicity requested, forward to the UI.
   RewriteCond %{QUERY_STRING} "format=html"
-  RewriteRule ^([^/]+).php ui/$1.html [R,END]
-  # Same but .php suffix is missing.
-  RewriteCond %{QUERY_STRING} "format=html"
-  RewriteRule ^([^/]+) ui/$1.html [R,END]
+  RewriteRule ^([^/]+)(?:.php)? ui/$1.html [R,END]
 
   # If no format parameter is there then forward anything
   # but /reverse and /lookup to the UI.
   RewriteCond %{QUERY_STRING} "!format="
   RewriteCond %{REQUEST_URI}  "!/lookup"
   RewriteCond %{REQUEST_URI}  "!/reverse"
-  RewriteRule ^([^/]+).php ui/$1.html [R,END]
-  # Same but .php suffix is missing.
-  RewriteCond %{QUERY_STRING} "!format="
-  RewriteCond %{REQUEST_URI}  "!/lookup"
-  RewriteCond %{REQUEST_URI}  "!/reverse"
-  RewriteRule ^([^/]+) ui/$1.html [R,END]
+  RewriteRule ^([^/]+)(?:.php)? ui/$1.html [R,END]
 </Directory>
 ```
 

--- a/docs/admin/Setup-Nominatim-UI.md
+++ b/docs/admin/Setup-Nominatim-UI.md
@@ -163,14 +163,14 @@ directory like this:
 
   # If format-html is explicity requested, forward to the UI.
   RewriteCond %{QUERY_STRING} "format=html"
-  RewriteRule ^([^/]+)(?:.php)? ui/$1.html [R,END]
+  RewriteRule ^([^/]+)(.php)? ui/$1.html [R,END]
 
   # If no format parameter is there then forward anything
   # but /reverse and /lookup to the UI.
   RewriteCond %{QUERY_STRING} "!format="
   RewriteCond %{REQUEST_URI}  "!/lookup"
   RewriteCond %{REQUEST_URI}  "!/reverse"
-  RewriteRule ^([^/]+)(?:.php)? ui/$1.html [R,END]
+  RewriteRule ^([^/]+)(.php)? ui/$1.html [R,END]
 </Directory>
 ```
 


### PR DESCRIPTION
Gets rid of the additional rule blocks by handling the `.php` suffix in a single regex.

`(?: )` defines a non-capturing group to match `.php` which is marked as optional with the subsequent `?`