### PR TITLE
Undefined offset in error log

### DIFF
--- a/lib-php/log.php
+++ b/lib-php/log.php
@@ -78,7 +78,7 @@ function logEnd(&$oDB, $hLog, $iNumResults)
 
     if (CONST_Log_DB) {
         $aEndTime = explode('.', $fEndTime);
-        if (!$aEndTime[1]) {
+        if (!isset($aEndTime[1])) {
             $aEndTime[1] = '0';
         }
         $sEndTime = date('Y-m-d H:i:s', $aEndTime[0]).'.'.$aEndTime[1];


### PR DESCRIPTION
Like #125, just in Apache error log and refers to end time:
`[Fri May 06 23:07:04.999970 2022] [php7:notice] [pid 1848445] [client X.X.X.X:54568] PHP Notice:  Undefined offset: 1 in /usr/local/lib/nominatim/lib-php/log.php on line 73`