### PR TITLE
Fix bug with keeping linking on updates

### DIFF
--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -2,6 +2,25 @@
 Feature: Updates of linked places
     Tests that linked places are correctly added and deleted.
 
+    Scenario: Linking is kept when boundary is updated
+        Given the places
+            | osm | class | type | name | geometry |
+            | N1  | place | city | foo  | 0 0 |
+        And the places
+            | osm | class    | type           | name | admin | geometry |
+            | R1  | boundary | administrative | foo  | 8     | poly-area:0.1 |
+        When importing
+        Then placex contains
+         | object | linked_place_id |
+         | N1     | R1 |
+        When updating places
+         | osm | class    | type           | name | name+name:de | admin | geometry |
+         | R1  | boundary | administrative | foo  | Dingens      | 8     | poly-area:0.1 |
+        Then placex contains
+         | object | linked_place_id |
+         | N1     | R1 |
+
+
     Scenario: Add linked place when linking relation is renamed
         Given the places
             | osm | class | type | name | geometry |


### PR DESCRIPTION
This fixes an issue where boundaries would loose their linked place node when they were updated.

Background: 

When moving the finding of linked places to the precomputation stage, it was also moved before the statement where the linked_place_id was removed from the linkee. The result was that the current linkee was excluded when looking for a linked place on updates because it was still linked to the boundary to be updated.

Fixed by allowing to either keep the linkage or change to an unlinked place.