### PR TITLE
Assume CONST_MapIcon_URL has trailing slash to avoid double slash

### DIFF
--- a/lib-php/ClassTypes.php
+++ b/lib-php/ClassTypes.php
@@ -270,7 +270,7 @@ function getIconFile($aPlace)
         return null;
     }
 
-    return CONST_MapIcon_URL.'/'.$sIcon.'.p.20.png';
+    return CONST_MapIcon_URL.$sIcon.'.p.20.png';
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/osm-search/Nominatim/issues/2717

I don't think a new unit test is needed is needed.