### PR TITLE
Allow search for partials consisting of 3 or more words

### DIFF
--- a/lib-php/SearchDescription.php
+++ b/lib-php/SearchDescription.php
@@ -264,6 +264,8 @@ class SearchDescription
     {
         if (empty($this->aName)) {
             $this->bNameNeedsAddress = $bNeedsAddress;
+        } elseif ($bSearchable && count($this->aName) >= 2) {
+            $this->bNameNeedsAddress = false;
         } else {
             $this->bNameNeedsAddress &= $bNeedsAddress;
         }


### PR DESCRIPTION
The search query builder currently rejects searches for partial
names only, when the partial terms are all very frequent to avoid
queries that return too many results.

This change slightly relaxes the condition to allow the search when
there are 3 or more partial terms. With so many terms the number
of matches should be managable.

Fixes #2727.