### PR TITLE
Fix order when searching for addr:* components

### DIFF
--- a/lib-sql/functions/partition-functions.sql
+++ b/lib-sql/functions/partition-functions.sql
@@ -96,7 +96,7 @@ BEGIN
               AND rank_address between from_rank and to_rank
               AND token_matches_address(token_info, key, keywords)
         GROUP BY place_id, keywords, rank_address, rank_search, isguess, postcode, centroid
-        ORDER BY bool_or(ST_Intersects(geometry, feature)), distance LIMIT 1;
+        ORDER BY bool_or(ST_Intersects(geometry, feature)) DESC, distance LIMIT 1;
       RETURN r;
   END IF;
 {% endfor %}

--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -506,3 +506,23 @@ Feature: Address computation
         Then results contain
            | osm | display_name               |
            | N2  | Leftside, Wonderway, Left |
+
+
+    Scenario: addr:* tags always match the closer area
+        Given the grid
+            | 1 |   |   |   |  2 |   | 5 |
+            |   |   |   |   |    |   |   |
+            |   | 10| 11|   |    |   |   |
+            | 4 |   |   |   |  3 |   | 6 |
+        And the places
+            | osm | class    | type           | admin | name  | geometry    |
+            | R1  | boundary | administrative | 8     | Left  | (1,2,3,4,1) |
+            | R2  | boundary | administrative | 8     | Left  | (2,3,6,5,2) |
+        And the places
+            | osm | class   | type    | name      | addr+city | geometry |
+            | W1  | highway | primary | Wonderway | Left      | 10,11    |
+        When importing
+        Then place_addressline doesn't contain
+            | object | address |
+            | W1     | R2      |
+


### PR DESCRIPTION
When matching addr:* components the preference was given to matches that do not intersect with the place instead of the other way around.

See also #2711.