### PR TITLE
Change indexing order for interpolations and non-addressable objects

### DIFF
--- a/nominatim/indexer/indexer.py
+++ b/nominatim/indexer/indexer.py
@@ -160,15 +160,12 @@ class Indexer:
                     minrank, maxrank, self.num_threads)
 
         with self.tokenizer.name_analyzer() as analyzer:
-            for rank in range(max(1, minrank), maxrank):
-                self._index(runners.RankRunner(rank, analyzer))
+            for rank in range(max(1, minrank), maxrank + 1):
+                self._index(runners.RankRunner(rank, analyzer), 20 if rank == 30 else 1)
 
             if maxrank == 30:
                 self._index(runners.RankRunner(0, analyzer))
                 self._index(runners.InterpolationRunner(analyzer), 20)
-                self._index(runners.RankRunner(30, analyzer), 20)
-            else:
-                self._index(runners.RankRunner(maxrank, analyzer))
 
 
     def index_postcodes(self):

--- a/test/python/indexer/test_indexing.py
+++ b/test/python/indexer/test_indexing.py
@@ -177,25 +177,16 @@ def test_index_all_by_rank(test_db, threads, test_tokenizer):
         SELECT count(*) FROM placex p WHERE rank_address > 0
           AND indexed_date >= (SELECT min(indexed_date) FROM placex o
                                WHERE p.rank_address < o.rank_address)""") == 0
-    # placex rank < 30 objects come before interpolations
+    # placex address ranked objects come before interpolations
     assert test_db.scalar(
-        """SELECT count(*) FROM placex WHERE rank_address < 30
+        """SELECT count(*) FROM placex WHERE rank_address > 0
              AND indexed_date >
                    (SELECT min(indexed_date) FROM location_property_osmline)""") == 0
-    # placex rank = 30 objects come after interpolations
+    # rank 0 comes after all other placex objects
     assert test_db.scalar(
-        """SELECT count(*) FROM placex WHERE rank_address = 30
-             AND indexed_date <
-                   (SELECT max(indexed_date) FROM location_property_osmline)""") == 0
-    # rank 0 comes after rank 29 and before rank 30
-    assert test_db.scalar(
-        """SELECT count(*) FROM placex WHERE rank_address < 30
+        """SELECT count(*) FROM placex WHERE rank_address > 0
              AND indexed_date >
                    (SELECT min(indexed_date) FROM placex WHERE rank_address = 0)""") == 0
-    assert test_db.scalar(
-        """SELECT count(*) FROM placex WHERE rank_address = 30
-             AND indexed_date <
-                   (SELECT max(indexed_date) FROM placex WHERE rank_address = 0)""") == 0
 
 
 @pytest.mark.parametrize("threads", [1, 15])


### PR DESCRIPTION
Housenumber nodes used to take parent information from their interpolation way, when on e existed. For that reason, the interpolation needed to be indexed before rank 30 objects. This has changed with the reworking of interpolations in #2597. This opens up the possibility to change the indexing order, so that interpolation can use precomputed information from their nodes in turn. This will be important for an upcoming PR for the handling of postcodes.