### PR TITLE
Fix rank inheritance from linked places

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -1036,7 +1036,9 @@ BEGIN
                      || coalesce(NEW.extratags, ''::hstore);
 
     -- mark the linked place (excludes from search results)
-    UPDATE placex set linked_place_id = NEW.place_id
+    -- Force reindexing to remove any traces from the search indexes and
+    -- reset the address rank if necessary.
+    UPDATE placex set linked_place_id = NEW.place_id, indexed_status = 2
       WHERE place_id = location.place_id;
     -- ensure that those places are not found anymore
     {% if 'search_name' in db.tables %}

--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -238,3 +238,29 @@ Feature: Updates of linked places
         Then placex contains
             | object | extratags |
             | R1     | 'linked_place' : 'town' |
+
+
+    Scenario: Keep linking and ranks when place type changes
+        Given the grid
+            | 1 |   |   | 2 |
+            |   |   | 9 |   |
+            | 4 |   |   | 3 |
+        And the places
+            | osm | class    | type           | name | admin | geometry    |
+            | R1  | boundary | administrative | foo  | 8     | (1,2,3,4,1) |
+        And the places
+            | osm | class | type | name | geometry |
+            | N1  | place | city | foo  | 9        |
+        When importing
+        Then placex contains
+            | object | linked_place_id | rank_address |
+            | N1     | R1              | 16           |
+            | R1     | -               | 16           |
+
+        When updating places
+            | osm | class | type | name | geometry |
+            | N1  | place | town | foo  | 9        |
+        Then placex contains
+            | object | linked_place_id | rank_address |
+            | N1     | R1              | 16           |
+            | R1     | -               | 16           |


### PR DESCRIPTION
When taking over the address rank from a linked place, it needs to be the originally computed rank, not the one that might have been adjusted in the meantime. The adjustment was made under the assumption that the node is not linked.

Also place nodes need reindexing when they are linked to correct address rank shifts and remove them from all search indexes.

Fixes #2551.