### PR TITLE
Improve hierarchy computation for place areas

### DIFF
--- a/test/bdd/db/import/addressing.feature
+++ b/test/bdd/db/import/addressing.feature
@@ -74,20 +74,22 @@ Feature: Address computation
 
     Scenario: boundary areas are preferred over place nodes in the address
         Given the grid
-            | 1 |   |   |   |   |   | 3 |
-            |   | 5 |   |   |   |   |   |
-            |   | 6 |   |   |   |   |   |
-            | 2 |   |   |   |   |   | 4 |
+            | 1 |   |   |   | 10 |   | 3 |
+            |   | 5 |   |   |    |   |   |
+            |   | 6 |   |   |    |   |   |
+            | 2 |   |   |   | 11 |   | 4 |
         And the named places
-            | osm | class    | type    | admin | geometry |
-            | N1  | place    | square  | 15    | 5 |
-            | N2  | place    | city    | 15    | 6 |
-            | R1  | place    | city    | 8     | (1,2,4,3,1) |
+            | osm | class    | type           | admin | geometry |
+            | N1  | place    | square         | 15    | 5 |
+            | N2  | place    | city           | 15    | 6 |
+            | R1  | place    | city           | 8     | (1,2,4,3,1) |
+            | R2  | boundary | administrative | 9     | (1,10,11,2,1) |
         When importing
         Then place_addressline contains
             | object | address | isaddress | cached_rank_address |
             | N1     | R1      | True      | 16                  |
-            | N1     | N2      | False     | 16                  |
+            | N1     | R2      | True      | 18                  |
+            | N1     | N2      | False     | 18                  |
 
     Scenario: place nodes outside a smaller ranked area are ignored
         Given the grid

--- a/test/bdd/db/import/rank_computation.feature
+++ b/test/bdd/db/import/rank_computation.feature
@@ -197,3 +197,61 @@ Feature: Rank assignment
             | N20    | R22     | 16                  |
             | N20    | R21     | 18                  |
 
+    Scenario: Mixes of admin boundaries and place areas I
+        Given the grid
+          | 1 |   | 10 |  |  | 2 |
+          |   | 9 |    |  |  |   |
+          | 20|   | 21 |  |  |   |
+          | 4 |   | 11 |  |  | 3 |
+        And the places
+          | osm | class    | type           | admin | name           | geometry      |
+          | R1  | boundary | administrative | 5     | Greater London | (1,2,3,4,1)   |
+          | R2  | boundary | administrative | 8     | Kensington     | (1,10,11,4,1) |
+        And the places
+          | osm | class    | type           | name           | geometry    |
+          | R10 | place    | city           | London         | (1,2,3,4,1) |
+          | N9  | place    | town           | Fulham         | 9           |
+          | W1  | highway  | residential    | Lots Grove     | 20,21       |
+        When importing
+        Then placex contains
+         | object | rank_search | rank_address |
+         | R1     | 10          | 10           |
+         | R10    | 16          | 16           |
+         | R2     | 16          | 18           |
+         | N9     | 18          | 18           |
+        And place_addressline contains
+         | object | address | isaddress | cached_rank_address |
+         | W1     | R1      | True      | 10                  |
+         | W1     | R10     | True      | 16                  |
+         | W1     | R2      | True      | 18                  |
+         | W1     | N9      | False     | 18                  |
+
+
+    Scenario: Mixes of admin boundaries and place areas II
+        Given the grid
+          | 1 |   | 10 |  | 5 | 2 |
+          |   | 9 |    |  |   |   |
+          | 20|   | 21 |  |   |   |
+          | 4 |   | 11 |  | 6 | 3 |
+        And the places
+          | osm | class    | type           | admin | name           | geometry    |
+          | R1  | boundary | administrative | 5     | Greater London | (1,2,3,4,1) |
+          | R2  | boundary | administrative | 8     | London         | (1,5,6,4,1) |
+        And the places
+          | osm | class    | type           | name           | geometry      |
+          | R10 | place    | city           | Westminster    | (1,10,11,4,1) |
+          | N9  | place    | town           | Fulham         | 9             |
+          | W1  | highway  | residential    | Lots Grove     | 20,21         |
+        When importing
+        Then placex contains
+         | object | rank_search | rank_address |
+         | R1     | 10          | 10           |
+         | R2     | 16          | 16           |
+         | R10    | 16          | 18           |
+         | N9     | 18          | 18           |
+        And place_addressline contains
+         | object | address | isaddress | cached_rank_address |
+         | W1     | R1      | True      | 10                  |
+         | W1     | R10     | True      | 18                  |
+         | W1     | R2      | True      | 16                  |
+         | W1     | N9      | False     | 18                  |


### PR DESCRIPTION
Improve address rank shifting when place areas are intermixed with administrative boundaries. This basically ensures that the place areas are put into the correct place in the admin_level hierarchy according to the containment relation, i.e if an area contains another area completely, it must be further to the top of the address hierarchy.

Hopefully improves the handling of the tagging situation around London, which is evolving further and further away from established international standards.