### PR TITLE
Added additional languages for Pakistan in country settings

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1247,7 +1247,7 @@ ph:
 # Pakistan (پاکستان)
 pk:
     partition: 14
-    languages: en, ur
+    languages: en, ur, pnb, sd, ps, bal
     names: !include country-names/pk.yaml
 
 


### PR DESCRIPTION
Pakistan is a multi-lingual country and its official languages are lingua franca used in education + formal settings but which are not common native languages. Urdu for examples is spoken natively by about 8% of people, whereas Punjabi is spoken by about 40%.

When I am adding features in Pakistan on OSM, I usually use the `name:pnb` tag for place names in Punjab, since especially for rural areas that tends to be the original language of the place name. (See https://taginfo.openstreetmap.org/keys/name%3Apnb). I only just realized Nominatim does not have this in the list of languages for Pakistan, so this pull request adds the most commonly spoken languages besides English and Urdu: Punjabi (pnb, different from pa which is used in India because of a difference in script), Sindhi, Pashto, and Balochi.

I am in the process of compiling an abbreviation list for Pakistan to submit later, and hopefully eventually, a Normalization rule set usable with libICU.