### PR TITLE
Ignore URL parameters in array notation

### DIFF
--- a/lib-php/ParameterParser.php
+++ b/lib-php/ParameterParser.php
@@ -22,7 +22,10 @@ class ParameterParser
 
     public function getBool($sName, $bDefault = false)
     {
-        if (!isset($this->aParams[$sName]) || strlen($this->aParams[$sName]) == 0) {
+        if (!isset($this->aParams[$sName])
+            || !is_string($this->aParams[$sName])
+            || strlen($this->aParams[$sName]) == 0
+        ) {
             return $bDefault;
         }
 
@@ -31,7 +34,7 @@ class ParameterParser
 
     public function getInt($sName, $bDefault = false)
     {
-        if (!isset($this->aParams[$sName])) {
+        if (!isset($this->aParams[$sName]) || is_array($this->aParams[$sName])) {
             return $bDefault;
         }
 
@@ -44,7 +47,7 @@ class ParameterParser
 
     public function getFloat($sName, $bDefault = false)
     {
-        if (!isset($this->aParams[$sName])) {
+        if (!isset($this->aParams[$sName]) || is_array($this->aParams[$sName])) {
             return $bDefault;
         }
 
@@ -57,7 +60,10 @@ class ParameterParser
 
     public function getString($sName, $bDefault = false)
     {
-        if (!isset($this->aParams[$sName]) || strlen($this->aParams[$sName]) == 0) {
+        if (!isset($this->aParams[$sName])
+            || !is_string($this->aParams[$sName])
+            || strlen($this->aParams[$sName]) == 0
+        ) {
             return $bDefault;
         }
 
@@ -66,7 +72,10 @@ class ParameterParser
 
     public function getSet($sName, $aValues, $sDefault = false)
     {
-        if (!isset($this->aParams[$sName]) || strlen($this->aParams[$sName]) == 0) {
+        if (!isset($this->aParams[$sName])
+            || !is_string($this->aParams[$sName])
+            || strlen($this->aParams[$sName]) == 0
+        ) {
             return $sDefault;
         }
 

--- a/test/bdd/api/search/params.feature
+++ b/test/bdd/api/search/params.feature
@@ -368,3 +368,10 @@ Feature: Search queries
           | Triesenberg |
 
 
+    Scenario: Array parameters are ignored
+        When sending json search query "Vaduz" with address
+          | countrycodes[] | polygon_svg[] | limit[] | polygon_threshold[] |
+          | IT             | 1             | 3       | 3.4                 |
+        Then result addresses contain
+          | ID | country_code |
+          | 0  | li           |

--- a/test/php/Nominatim/ParameterParserTest.php
+++ b/test/php/Nominatim/ParameterParserTest.php
@@ -137,9 +137,6 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSet()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Parameter 'val3' must be one of: foo, bar");
-
         $oParams = new ParameterParser(array(
                                         'val1' => 'foo',
                                         'val2' => '',
@@ -151,7 +148,7 @@ class ParameterParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('foo', $oParams->getSet('val1', array('foo', 'bar')));
 
         $this->assertSame(false, $oParams->getSet('val2', array('foo', 'bar')));
-        $oParams->getSet('val3', array('foo', 'bar'));
+        $this->assertSame(false, $oParams->getSet('val3', array('foo', 'bar')));
     }
 
 


### PR DESCRIPTION
PHP automatically parses parameters in an array notation(foo[]) into array types. Ignore these parameters as 'unknown'.

Fixes #2763.