### PR TITLE
Fix minimum number of results that are searched for

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -103,7 +103,7 @@ class Geocode
         }
 
         $this->iFinalLimit = $iLimit;
-        $this->iLimit = $iLimit + min($iLimit, 10);
+        $this->iLimit = $iLimit + max($iLimit, 10);
     }
 
     public function setFeatureType($sFeatureType)


### PR DESCRIPTION
The intent was to always search for at least 10 results.

Improves on #882.