### PR TITLE
Invalidations when boundaries and places change their rank

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -916,7 +916,8 @@ BEGIN
              LATERAL compute_place_rank(country_code, 'A', class, type,
                                         admin_level, False, null) prank
         WHERE osm_type = 'R'
-              and prank.address_rank = NEW.rank_address
+              and ((class = 'place' and prank.address_rank = NEW.rank_address)
+                   or (class = 'boundary' and rank_address = NEW.rank_address))
               and geometry && NEW.centroid and _ST_Covers(geometry, NEW.centroid)
         LIMIT 1
     LOOP
@@ -1100,6 +1101,15 @@ BEGIN
       END IF;
     END IF;
   END IF;
+
+  {% if not disable_diff_updates %}
+  IF OLD.rank_address != NEW.rank_address THEN
+    -- After a rank shift all addresses containing us must be updated.
+    UPDATE placex p SET indexed_status = 2 FROM place_addressline pa
+      WHERE pa.address_place_id = NEW.place_id and p.place_id = pa.place_id
+            and p.indexed_status = 0 and p.rank_address between 4 and 25;
+  END IF;
+  {% endif %}
 
   IF NEW.admin_level = 2
      AND NEW.class = 'boundary' AND NEW.type = 'administrative'

--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -307,3 +307,35 @@ Feature: Updates of linked places
             | object | linked_place_id | rank_address |
             | N1     | R1              | 16           |
             | R1     | -               | 16           |
+
+
+    Scenario: Invalidate surrounding place nodes when place type changes
+        Given the grid
+            | 1 |   |   | 2 |
+            |   | 8 | 9 |   |
+            | 4 |   |   | 3 |
+        And the places
+            | osm | class    | type           | name | admin | geometry    |
+            | R1  | boundary | administrative | foo  | 8     | (1,2,3,4,1) |
+        And the places
+            | osm | class | type | name | geometry |
+            | N1  | place | town | foo  | 9        |
+            | N2  | place | city | bar  | 8        |
+        And the relations
+         | id | members  |
+         | 1  | N1:label |
+        When importing
+        Then placex contains
+            | object | linked_place_id | rank_address |
+            | N1     | R1              | 16           |
+            | R1     | -               | 16           |
+            | N2     | -               | 18           |
+
+        When updating places
+            | osm | class | type   | name | geometry |
+            | N1  | place | suburb | foo  | 9        |
+        Then placex contains
+            | object | linked_place_id | rank_address |
+            | N1     | R1              | 20           |
+            | R1     | -               | 20           |
+            | N2     | -               | 16           |


### PR DESCRIPTION
When a boundary or place changes its address rank, all places where it participates as address need to be potentially reindexed.

Also use the computed rank when testing place nodes against boundaries. This was changed to make sure that import and update behave the same but rank changes to boundaries are done before place nodes are computed. So using the modified rank is correct.

Fixes #2794.