### PR TITLE
Ignore irrelevant extra tags on address interpolations

### DIFF
--- a/lib-sql/functions/interpolation.sql
+++ b/lib-sql/functions/interpolation.sql
@@ -15,7 +15,7 @@ DECLARE
   location RECORD;
   waynodes BIGINT[];
 BEGIN
-  IF akeys(in_address) != ARRAY['interpolation'] THEN
+  IF in_address ? 'street' or in_address ? 'place' THEN
     RETURN in_address;
   END IF;
 

--- a/test/bdd/db/import/interpolation.feature
+++ b/test/bdd/db/import/interpolation.feature
@@ -403,3 +403,33 @@ Feature: Import of address interpolations
         Then results contain
           | ID | osm_type | osm_id | type  | display_name |
           | 0  | node     | 1      | house | 0 |
+
+    Scenario: Parenting of interpolation with additional tags
+        Given the grid
+          | 1 |   |   |   |   |   |
+          |   |   |   |   |   |   |
+          |   | 8 |   |   | 9 |   |
+          |   |   |   |   |   |   |
+          | 2 |   |   |   |   | 3 |
+        Given the places
+          | osm | class | type  | housenr | addr+street |
+          | N8  | place | house | 10      | Horiz St    |
+          | N9  | place | house | 16      | Horiz St    |
+        And the places
+          | osm | class   | type        | name     | geometry |
+          | W1  | highway | residential | Vert St  | 1,2      |
+          | W2  | highway | residential | Horiz St | 2,3      |
+        And the places
+          | osm | class | type   | addr+interpolation | addr+inclusion | geometry |
+          | W10 | place | houses | even               | actual         | 8,9      |
+        And the ways
+          | id | nodes |
+          | 10 | 8,9   |
+        When importing
+        Then placex contains
+          | object | parent_place_id |
+          | N8     | W2              |
+          | N9     | W2              |
+        And W10 expands to interpolation
+          | start | end | parent_place_id |
+          | 12    | 14  | W2              |

--- a/test/bdd/steps/steps_db_ops.py
+++ b/test/bdd/steps/steps_db_ops.py
@@ -370,6 +370,6 @@ def check_location_property_osmline(context, oid, neg):
 
             DBRow(oid, res, context).assert_row(row, ('start', 'end'))
 
-        assert not todo
+        assert not todo, f"Unmatched lines in table: {list(context.table[i] for i in todo)}"
 
 


### PR DESCRIPTION
When deciding if an address interpolation has address information, only look for addr:street and addr:place. If they are not there go looking for the address on the address nodes. Ignores irrelevant tags like addr:inclusion.

Fixes #2797.