### PR TITLE
Documentation: remove year from TIGER filename, new 2022 data

### DIFF
--- a/docs/customize/Tiger.md
+++ b/docs/customize/Tiger.md
@@ -5,14 +5,14 @@ address set to complement the OSM house number data in the US. You can add
 TIGER data to your own Nominatim instance by following these steps. The
 entire US adds about 10GB to your database.
 
-  1. Get preprocessed TIGER 2021 data:
+  1. Get preprocessed TIGER data:
 
         cd $PROJECT_DIR
-        wget https://nominatim.org/data/tiger2021-nominatim-preprocessed.csv.tar.gz
+        wget https://nominatim.org/data/tiger-nominatim-preprocessed-latest.csv.tar.gz
 
   2. Import the data into your Nominatim database:
 
-        nominatim add-data --tiger-data tiger2021-nominatim-preprocessed.csv.tar.gz
+        nominatim add-data --tiger-data tiger-nominatim-preprocessed-latest.csv.tar.gz
 
   3. Enable use of the Tiger data in your `.env` by adding:
 


### PR DESCRIPTION
https://nominatim.org/downloads/ uses 'latest' in the filename to I removed it from the `docs/customize/Tiger.md`, too.

I preprossed the 2022 TIGER data. You can find it at
https://downloads.opencagedata.com/public/tiger2022-nominatim-preprocessed.csv.tar.gz
https://downloads.opencagedata.com/public/us_postcodes_from_tiger2022.csv.gz

2021: 34,329,441 lines in CSV files
2022: 33,900,561 (-1%)

2021: 3234 files
2022: 3245 files

Notable difference is new files for Conneticut. Counties got replaced by Councils.
"In 2019 the state recommended to the United States Census Bureau that the nine Councils of Governments replace counties for statistical purposes, and the Census intends to implement it in 2023" https://en.wikipedia.org/wiki/List_of_counties_in_Connecticut
Looks like it happened in 2022.

```
2021 (8 files)
< 09001.csv
< 09003.csv
< 09005.csv
< 09007.csv
< 09009.csv
< 09011.csv
< 09013.csv
< 09015.csv
2022 (9 files)
> 09110.csv
> 09120.csv
> 09130.csv
> 09140.csv
> 09150.csv
> 09160.csv
> 09170.csv
> 09180.csv
> 09190.csv
```

Files with more than 10% changes (number of lines). I did spot checks and can't see anything unusual.

```
file          | 2021  | 2022
02013.csv	88	104
02050.csv	478	574
02060.csv	63	80
02070.csv	283	319
02158.csv	96	166
02164.csv	82	128
02188.csv	204	273
02290.csv	296	356
36061.csv	11857	10005
40007.csv	596	690
36081.csv	3212	3716
46102.csv	191	387
40105.csv	1351	1587
66010.csv	1	7296
78010.csv	1	725
78020.csv	1	119
78030.csv	1	385
```
