### PR TITLE
Tiger install doc: add -refresh website- step

### DIFF
--- a/docs/customize/Tiger.md
+++ b/docs/customize/Tiger.md
@@ -14,13 +14,13 @@ entire US adds about 10GB to your database.
 
         nominatim add-data --tiger-data tiger-nominatim-preprocessed-latest.csv.tar.gz
 
-  3. Enable use of the Tiger data in your `.env` by adding:
+  3. Enable use of the Tiger data in your existing `.env` file by adding:
 
         echo NOMINATIM_USE_US_TIGER_DATA=yes >> .env
 
   4. Apply the new settings:
 
-        nominatim refresh --functions
+        nominatim refresh --functions --website
 
 
 See the [TIGER-data project](https://github.com/osm-search/TIGER-data) for more


### PR DESCRIPTION
Related to https://github.com/osm-search/Nominatim/discussions/2868#discussioncomment-4078615

Unclear how to make sure an admin doesn't write to a wrong `.env` file.