### PR TITLE
Add experimental configuration switch for enabling forward dependencies

### DIFF
--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -148,6 +148,29 @@ Setting this option to 'yes' means that Nominatim skips reindexing of contained
 objects when the area becomes too large.
 
 
+#### NOMINATIM_UPDATE_FORWARD_DEPENDENCIES
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Forward geometry changes to dependet objects |
+| **Format:**        | bool |
+| **Default:**       | no |
+| **Comment:**       | EXPERT ONLY. Must not be enabled after import. |
+
+The geometry of OSM ways and relations may change when a node that is part
+of the object is moved around. These changes are not propagated per default.
+The geometry of ways/relations is only updated the next time that the object
+itself is touched. When enabling this option, then dependent objects will
+be marked for update when one of its member objects changes.
+
+Enabling this option may slow down updates significantly.
+
+!!! warning
+    If you want to enable this option, it must be set already on import.
+    Do not enable this option on an existing database that was imported with
+    NOMINATIM_UPDATE_FORWARD_DEPENDENCIES=no.
+    Updates will become unusably slow.
+
 #### NOMINATIM_LANGUAGES
 
 | Summary            |                                                     |

--- a/nominatim/clicmd/args.py
+++ b/nominatim/clicmd/args.py
@@ -187,6 +187,7 @@ class NominatimArgs:
                     osm2pgsql_style_path=self.config.config_dir,
                     threads=self.threads or default_threads,
                     dsn=self.config.get_libpq_dsn(),
+                    forward_dependencies=self.config.get_bool('UPDATE_FORWARD_DEPENDENCIES'),
                     flatnode_file=str(self.config.get_path('FLATNODE_FILE') or ''),
                     tablespaces=dict(slim_data=self.config.TABLESPACE_OSM_DATA,
                                      slim_index=self.config.TABLESPACE_OSM_INDEX,

--- a/nominatim/tools/exec_utils.py
+++ b/nominatim/tools/exec_utils.py
@@ -117,7 +117,6 @@ def run_osm2pgsql(options: Mapping[str, Any]) -> None:
     env = get_pg_env(options['dsn'])
     cmd = [str(options['osm2pgsql']),
            '--hstore', '--latlon', '--slim',
-           '--with-forward-dependencies', 'false',
            '--log-progress', 'true',
            '--number-processes', str(options['threads']),
            '--cache', str(options['osm2pgsql_cache']),
@@ -131,13 +130,13 @@ def run_osm2pgsql(options: Mapping[str, Any]) -> None:
     else:
         cmd.extend(('--output', 'gazetteer'))
 
-    if options['append']:
-        cmd.append('--append')
-    else:
-        cmd.append('--create')
+    cmd.append('--append' if options['append'] else '--create')
 
     if options['flatnode_file']:
         cmd.extend(('--flat-nodes', options['flatnode_file']))
+
+    if not options.get('forward_dependencies', False):
+        cmd.extend(('--with-forward-dependencies', 'false'))
 
     for key, param in (('slim_data', '--tablespace-slim-data'),
                        ('slim_index', '--tablespace-slim-index'),

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -33,6 +33,15 @@ NOMINATIM_MAX_WORD_FREQUENCY=50000
 # If true, admin level changes on places with many contained children are blocked.
 NOMINATIM_LIMIT_REINDEXING=yes
 
+# When set to 'yes' changes to OSM objects will be propagated to dependent
+# objects. This means that geometries of way/relations are updated when a
+# node on a way or a way in a relation changes.
+# EXPERT ONLY: Use with care. Enabling this option might lead to significantly
+#              more load when updates are applied.
+#              Do not enable this option on an existing database.
+# The default is to not propagate these changes.
+NOMINATIM_UPDATE_FORWARD_DEPENDENCIES=no
+
 # Restrict search languages.
 # Normally Nominatim will include all language variants of name:XX
 # in the search index. Set this to a comma separated list of language


### PR DESCRIPTION
When forward dependencies are enabled in osm2pgsql then nodes and ways are not only updated themselves when they change but also ways and relations that contain them. The most important effect is that Nominatim will update its data  on geometry changes due to a moved node.

The switch allows to experiment with forward dependencies and measure the performance. It is not yet there for production use and may disappear again before the next release.