### PR TITLE
Remove NOMINATIM_NOMINATIM_TOOL variable

### DIFF
--- a/cmake/tool-installed.tmpl
+++ b/cmake/tool-installed.tmpl
@@ -4,8 +4,6 @@ import os
 
 sys.path.insert(1, '@NOMINATIM_LIBDIR@/lib-python')
 
-os.environ['NOMINATIM_NOMINATIM_TOOL'] = os.path.abspath(__file__)
-
 from nominatim import cli
 from nominatim import version
 

--- a/cmake/tool.tmpl
+++ b/cmake/tool.tmpl
@@ -4,8 +4,6 @@ import os
 
 sys.path.insert(1, '@CMAKE_SOURCE_DIR@')
 
-os.environ['NOMINATIM_NOMINATIM_TOOL'] = os.path.abspath(__file__)
-
 from nominatim import cli
 from nominatim import version
 

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -105,7 +105,6 @@ class NominatimEnvironment:
         self.test_env['NOMINATIM_CONFIGDIR'] = str((self.src_dir / 'settings').resolve())
         self.test_env['NOMINATIM_DATABASE_MODULE_SRC_PATH'] = str((self.build_dir / 'module').resolve())
         self.test_env['NOMINATIM_OSM2PGSQL_BINARY'] = str((self.build_dir / 'osm2pgsql' / 'osm2pgsql').resolve())
-        self.test_env['NOMINATIM_NOMINATIM_TOOL'] = str((self.build_dir / 'nominatim').resolve())
         if self.tokenizer is not None:
             self.test_env['NOMINATIM_TOKENIZER'] = self.tokenizer
         if self.import_style is not None:


### PR DESCRIPTION
This was used by the old PHP scripts to call the Python tool. With the scripts now gone, the variable can be removed.