### PR TITLE
Reorganize how Nominatim finds its extra data and libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,14 @@ if (BUILD_IMPORTER)
     install(DIRECTORY nominatim
             DESTINATION ${NOMINATIM_LIBDIR}/lib-python
             FILES_MATCHING PATTERN "*.py"
+            PATTERN "paths.py" EXCLUDE
             PATTERN __pycache__ EXCLUDE)
+
+    configure_file(${PROJECT_SOURCE_DIR}/cmake/paths-py.tmpl paths-py.installed)
+    install(FILES ${PROJECT_BINARY_DIR}/paths-py.installed
+            DESTINATION ${NOMINATIM_LIBDIR}/lib-python/nominatim
+            RENAME paths.py)
+
     install(DIRECTORY lib-sql DESTINATION ${NOMINATIM_LIBDIR})
 
     install(FILES ${COUNTRY_GRID_FILE}

--- a/cmake/paths-py.tmpl
+++ b/cmake/paths-py.tmpl
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2022 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Path settings for extra data used by Nominatim (installed version).
+"""
+from pathlib import Path
+
+PHPLIB_DIR = (Path('@NOMINATIM_LIBDIR@') / 'lib-php').resolve()
+SQLLIB_DIR = (Path('@NOMINATIM_LIBDIR@') / 'lib-sql').resolve()
+DATA_DIR = Path('@NOMINATIM_DATADIR@').resolve()
+CONFIG_DIR = Path('@NOMINATIM_CONFIGDIR@').resolve()

--- a/cmake/tool-installed.tmpl
+++ b/cmake/tool-installed.tmpl
@@ -11,8 +11,4 @@ version.GIT_COMMIT_HASH = '@GIT_HASH@'
 
 exit(cli.nominatim(module_dir='@NOMINATIM_LIBDIR@/module',
                    osm2pgsql_path='@NOMINATIM_LIBDIR@/osm2pgsql',
-                   phplib_dir='@NOMINATIM_LIBDIR@/lib-php',
-                   sqllib_dir='@NOMINATIM_LIBDIR@/lib-sql',
-                   data_dir='@NOMINATIM_DATADIR@',
-                   config_dir='@NOMINATIM_CONFIGDIR@',
                    phpcgi_path='@PHPCGI_BIN@'))

--- a/cmake/tool.tmpl
+++ b/cmake/tool.tmpl
@@ -11,8 +11,4 @@ version.GIT_COMMIT_HASH = '@GIT_HASH@'
 
 exit(cli.nominatim(module_dir='@CMAKE_BINARY_DIR@/module',
                    osm2pgsql_path='@CMAKE_BINARY_DIR@/osm2pgsql/osm2pgsql',
-                   phplib_dir='@CMAKE_SOURCE_DIR@/lib-php',
-                   sqllib_dir='@CMAKE_SOURCE_DIR@/lib-sql',
-                   data_dir='@CMAKE_SOURCE_DIR@/data',
-                   config_dir='@CMAKE_SOURCE_DIR@/settings',
                    phpcgi_path='@PHPCGI_BIN@'))

--- a/nominatim/cli.py
+++ b/nominatim/cli.py
@@ -100,9 +100,7 @@ class CommandlineParser:
             self.parser.print_help()
             return 1
 
-        for arg in ('module_dir', 'osm2pgsql_path', 'phplib_dir', 'sqllib_dir',
-                    'data_dir', 'config_dir', 'phpcgi_path'):
-            setattr(args, arg, Path(kwargs[arg]))
+        args.phpcgi_path = Path(kwargs['phpcgi_path'])
         args.project_dir = Path(args.project_dir).resolve()
 
         if 'cli_args' not in kwargs:
@@ -111,13 +109,10 @@ class CommandlineParser:
                                 datefmt='%Y-%m-%d %H:%M:%S',
                                 level=max(4 - args.verbose, 1) * 10)
 
-        args.config = Configuration(args.project_dir, args.config_dir,
+        args.config = Configuration(args.project_dir,
                                     environ=kwargs.get('environ', os.environ))
-        args.config.set_libdirs(module=args.module_dir,
-                                osm2pgsql=args.osm2pgsql_path,
-                                php=args.phplib_dir,
-                                sql=args.sqllib_dir,
-                                data=args.data_dir)
+        args.config.set_libdirs(module=kwargs['module_dir'],
+                                osm2pgsql=kwargs['osm2pgsql_path'])
 
         log = logging.getLogger()
         log.warning('Using project directory: %s', str(args.project_dir))
@@ -195,7 +190,7 @@ class QueryExport:
         if args.restrict_to_osm_relation:
             params.extend(('--restrict-to-osm-relation', args.restrict_to_osm_relation))
 
-        return run_legacy_script('export.php', *params, nominatim_env=args)
+        return run_legacy_script('export.php', *params, config=args.config)
 
 
 class AdminServe:

--- a/nominatim/clicmd/admin.py
+++ b/nominatim/clicmd/admin.py
@@ -88,4 +88,4 @@ class AdminFuncs:
             params.append('--reverse-only')
         if args.target == 'search':
             params.append('--search-only')
-        return run_legacy_script(*params, nominatim_env=args)
+        return run_legacy_script(*params, config=args.config)

--- a/nominatim/clicmd/args.py
+++ b/nominatim/clicmd/args.py
@@ -42,12 +42,6 @@ class NominatimArgs:
     # Basic environment set by root program.
     config: Configuration
     project_dir: Path
-    module_dir: Path
-    osm2pgsql_path: Path
-    phplib_dir: Path
-    sqllib_dir: Path
-    data_dir: Path
-    config_dir: Path
     phpcgi_path: Path
 
     # Global switches
@@ -181,7 +175,7 @@ class NominatimArgs:
             from the command line arguments. The resulting dict can be
             further customized and then used in `run_osm2pgsql()`.
         """
-        return dict(osm2pgsql=self.config.OSM2PGSQL_BINARY or self.osm2pgsql_path,
+        return dict(osm2pgsql=self.config.OSM2PGSQL_BINARY or self.config.lib_dir.osm2pgsql,
                     osm2pgsql_cache=self.osm2pgsql_cache or default_cache,
                     osm2pgsql_style=self.config.get_import_style_file(),
                     osm2pgsql_style_path=self.config.config_dir,

--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -87,7 +87,7 @@ class SetupAll:
 
             LOG.warning('Setting up country tables')
             country_info.setup_country_tables(args.config.get_libpq_dsn(),
-                                              args.data_dir,
+                                              args.config.lib_dir.data,
                                               args.no_partitions)
 
             LOG.warning('Importing OSM data file')

--- a/nominatim/paths.py
+++ b/nominatim/paths.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2022 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Path settings for extra data used by Nominatim.
+"""
+from pathlib import Path
+
+PHPLIB_DIR = (Path(__file__) / '..' / '..' / 'lib-php').resolve()
+SQLLIB_DIR = (Path(__file__) / '..' / '..' / 'lib-sql').resolve()
+DATA_DIR = (Path(__file__) / '..' / '..' / 'data').resolve()
+CONFIG_DIR = (Path(__file__) / '..' / '..' / 'settings').resolve()

--- a/nominatim/tokenizer/factory.py
+++ b/nominatim/tokenizer/factory.py
@@ -55,6 +55,7 @@ def create_tokenizer(config: Configuration, init_db: bool = True,
         module_name = config.TOKENIZER
 
     # Create the directory for the tokenizer data
+    assert config.project_dir is not None
     basedir = config.project_dir / 'tokenizer'
     if not basedir.exists():
         basedir.mkdir()
@@ -80,6 +81,7 @@ def get_tokenizer_for_db(config: Configuration) -> AbstractTokenizer:
         The function looks up the appropriate tokenizer in the database
         and initialises it.
     """
+    assert config.project_dir is not None
     basedir = config.project_dir / 'tokenizer'
     if not basedir.is_dir():
         # Directory will be repopulated by tokenizer below.

--- a/nominatim/tokenizer/legacy_tokenizer.py
+++ b/nominatim/tokenizer/legacy_tokenizer.py
@@ -106,6 +106,7 @@ class LegacyTokenizer(AbstractTokenizer):
             This copies all necessary data in the project directory to make
             sure the tokenizer remains stable even over updates.
         """
+        assert config.project_dir is not None
         module_dir = _install_module(config.DATABASE_MODULE_PATH,
                                      config.lib_dir.module,
                                      config.project_dir / 'module')
@@ -127,6 +128,8 @@ class LegacyTokenizer(AbstractTokenizer):
     def init_from_project(self, config: Configuration) -> None:
         """ Initialise the tokenizer from the project directory.
         """
+        assert config.project_dir is not None
+
         with connect(self.dsn) as conn:
             self.normalization = properties.get_property(conn, DBCFG_NORMALIZATION)
 
@@ -149,6 +152,8 @@ class LegacyTokenizer(AbstractTokenizer):
     def update_sql_functions(self, config: Configuration) -> None:
         """ Reimport the SQL functions for this tokenizer.
         """
+        assert config.project_dir is not None
+
         with connect(self.dsn) as conn:
             max_word_freq = properties.get_property(conn, DBCFG_MAXWORDFREQ)
             modulepath = config.DATABASE_MODULE_PATH or \
@@ -193,6 +198,8 @@ class LegacyTokenizer(AbstractTokenizer):
             This is a special migration function for updating existing databases
             to new software versions.
         """
+        assert config.project_dir is not None
+
         self.normalization = config.TERM_NORMALIZATION
         module_dir = _install_module(config.DATABASE_MODULE_PATH,
                                      config.lib_dir.module,

--- a/nominatim/tools/refresh.py
+++ b/nominatim/tools/refresh.py
@@ -216,6 +216,7 @@ def setup_website(basedir: Path, config: Configuration, conn: Connection) -> Non
         LOG.info('Creating website directory.')
         basedir.mkdir()
 
+    assert config.project_dir is not None
     template = dedent(f"""\
                       <?php
 

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -43,7 +43,7 @@ class NominatimEnvironment:
         self.code_coverage_path = config['PHPCOV']
         self.code_coverage_id = 1
 
-        self.default_config = Configuration(None, self.src_dir / 'settings').get_os_env()
+        self.default_config = Configuration(None).get_os_env()
         self.test_env = None
         self.template_db_done = False
         self.api_db_done = False
@@ -130,13 +130,9 @@ class NominatimEnvironment:
 
 
     def get_test_config(self):
-        cfg = Configuration(Path(self.website_dir.name), self.src_dir / 'settings',
-                            environ=self.test_env)
+        cfg = Configuration(Path(self.website_dir.name), environ=self.test_env)
         cfg.set_libdirs(module=self.build_dir / 'module',
-                        osm2pgsql=self.build_dir / 'osm2pgsql' / 'osm2pgsql',
-                        php=self.src_dir / 'lib-php',
-                        sql=self.src_dir / 'lib-sql',
-                        data=self.src_dir / 'data')
+                        osm2pgsql=self.build_dir / 'osm2pgsql' / 'osm2pgsql')
         return cfg
 
     def get_libpq_dsn(self):

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -302,10 +302,6 @@ class NominatimEnvironment:
 
         cli.nominatim(module_dir='',
                       osm2pgsql_path=str(self.build_dir / 'osm2pgsql' / 'osm2pgsql'),
-                      phplib_dir=str(self.src_dir / 'lib-php'),
-                      sqllib_dir=str(self.src_dir / 'lib-sql'),
-                      data_dir=str(self.src_dir / 'data'),
-                      config_dir=str(self.src_dir / 'settings'),
                       cli_args=cmdline,
                       phpcgi_path='',
                       environ=self.test_env)

--- a/test/python/cli/conftest.py
+++ b/test/python/cli/conftest.py
@@ -53,11 +53,7 @@ def cli_call(src_dir):
     def _call_nominatim(*args):
         return nominatim.cli.nominatim(module_dir='MODULE NOT AVAILABLE',
                                        osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                       phplib_dir=str(src_dir / 'lib-php'),
-                                       data_dir=str(src_dir / 'data'),
                                        phpcgi_path='/usr/bin/php-cgi',
-                                       sqllib_dir=str(src_dir / 'lib-sql'),
-                                       config_dir=str(src_dir / 'settings'),
                                        cli_args=args)
 
     return _call_nominatim

--- a/test/python/cli/test_cli.py
+++ b/test/python/cli/test_cli.py
@@ -82,19 +82,17 @@ def test_cli_export_command(cli_call, mock_run_legacy):
                                          ('restrict-to-osm-way', '727'),
                                          ('restrict-to-osm-relation', '197532')
                                         ])
-def test_export_parameters(src_dir, tmp_path, param, value):
+def test_export_parameters(src_dir, tmp_path, param, value, monkeypatch):
     (tmp_path / 'admin').mkdir()
     (tmp_path / 'admin' / 'export.php').write_text(f"""<?php
         exit(strpos(implode(' ', $_SERVER['argv']), '--{param} {value}') >= 0 ? 0 : 10);
         """)
 
+    monkeypatch.setattr(nominatim.paths, 'PHPLIB_DIR', tmp_path)
+
     assert nominatim.cli.nominatim(module_dir='MODULE NOT AVAILABLE',
                                    osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                   phplib_dir=str(tmp_path),
-                                   data_dir=str(src_dir / 'data'),
                                    phpcgi_path='/usr/bin/php-cgi',
-                                   sqllib_dir=str(src_dir / 'lib-sql'),
-                                   config_dir=str(src_dir / 'settings'),
                                    cli_args=['export', '--' + param, value]) == 0
 
 

--- a/test/python/cli/test_cmd_replication.py
+++ b/test/python/cli/test_cmd_replication.py
@@ -15,6 +15,7 @@ import pytest
 import nominatim.cli
 import nominatim.indexer.indexer
 import nominatim.tools.replication
+import nominatim.tools.refresh
 from nominatim.db import status
 
 @pytest.fixture
@@ -107,7 +108,7 @@ class TestCliReplication:
     def test_replication_update_once_no_index(self, update_mock):
         assert self.call_nominatim('--once', '--no-index') == 0
 
-        assert str(update_mock.last_args[1]['osm2pgsql']) == 'OSM2PGSQL NOT AVAILABLE'
+        assert str(update_mock.last_args[1]['osm2pgsql']).endswith('OSM2PGSQL NOT AVAILABLE')
 
 
     def test_replication_update_custom_osm2pgsql(self, monkeypatch, update_mock):

--- a/test/python/config/test_config.py
+++ b/test/python/config/test_config.py
@@ -14,23 +14,23 @@ from nominatim.config import Configuration, flatten_config_list
 from nominatim.errors import UsageError
 
 @pytest.fixture
-def make_config(src_dir):
+def make_config():
     """ Create a configuration object from the given project directory.
     """
     def _mk_config(project_dir=None):
-        return Configuration(project_dir, src_dir / 'settings')
+        return Configuration(project_dir)
 
     return _mk_config
 
 @pytest.fixture
-def make_config_path(src_dir, tmp_path):
+def make_config_path(tmp_path):
     """ Create a configuration object with project and config directories
         in a temporary directory.
     """
     def _mk_config():
         (tmp_path / 'project').mkdir()
         (tmp_path / 'config').mkdir()
-        conf = Configuration(tmp_path / 'project', src_dir / 'settings')
+        conf = Configuration(tmp_path / 'project')
         conf.config_dir = tmp_path / 'config'
         return conf
 

--- a/test/python/config/test_config_load_module.py
+++ b/test/python/config/test_config_load_module.py
@@ -21,7 +21,7 @@ def test_config(src_dir, tmp_path):
     """
     (tmp_path / 'project').mkdir()
     (tmp_path / 'config').mkdir()
-    conf = Configuration(tmp_path / 'project', src_dir / 'settings')
+    conf = Configuration(tmp_path / 'project')
     conf.config_dir = tmp_path / 'config'
     return conf
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -107,24 +107,18 @@ def table_factory(temp_db_cursor):
 
 
 @pytest.fixture
-def def_config(src_dir):
-    cfg = Configuration(None, src_dir / 'settings')
-    cfg.set_libdirs(module='.', osm2pgsql='.',
-                    php=src_dir / 'lib-php',
-                    sql=src_dir / 'lib-sql',
-                    data=src_dir / 'data')
+def def_config():
+    cfg = Configuration(None)
+    cfg.set_libdirs(module='.', osm2pgsql='.')
     return cfg
 
 
 @pytest.fixture
-def project_env(src_dir, tmp_path):
+def project_env(tmp_path):
     projdir = tmp_path / 'project'
     projdir.mkdir()
-    cfg = Configuration(projdir, src_dir / 'settings')
-    cfg.set_libdirs(module='.', osm2pgsql='.',
-                    php=src_dir / 'lib-php',
-                    sql=src_dir / 'lib-sql',
-                    data=src_dir / 'data')
+    cfg = Configuration(projdir)
+    cfg.set_libdirs(module='.', osm2pgsql='.')
     return cfg
 
 
@@ -214,9 +208,8 @@ def osmline_table(temp_db_with_extensions, table_factory):
 @pytest.fixture
 def sql_preprocessor_cfg(tmp_path, table_factory, temp_db_with_extensions):
     table_factory('country_name', 'partition INT', ((0, ), (1, ), (2, )))
-    cfg = Configuration(None, SRC_DIR.resolve() / 'settings')
-    cfg.set_libdirs(module='.', osm2pgsql='.', php=SRC_DIR / 'lib-php',
-                    sql=tmp_path, data=SRC_DIR / 'data')
+    cfg = Configuration(None)
+    cfg.set_libdirs(module='.', osm2pgsql='.', sql=tmp_path)
     return cfg
 
 


### PR DESCRIPTION
Nominatim has quite a bit of extra data it needs to access from the Python code: configuration, SQL and PHP code, extra data files etc. So far the paths to the data was hard-coded in the nominatim executable which was rewritten on installation to provide the paths to whereever data was installed. This does not help when the Nominatim code is executed from somewhere else.

This PR introduces a new module `nominatim.paths` which contains the data paths. There is a version in the source which points to the data relative to its position, so that the data can be found inside the source directory when the Python code is not installed but executed in place. During installation the module is replaced by a version that points to the installation paths.

The code now consistently uses paths from config.lib_dir which is prefilled from the paths from `nominatim.paths`. This means that it is still possible to overwrite the defaults after instantiating a Configuration. This comes in handy occasionally for the unit tests.