### PR TITLE
contract duplicate spaces in transliteration string

### DIFF
--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -24,6 +24,7 @@ transliteration:
     - ":: lower ()"
     - "[^a-z0-9[:Space:]] >"
     - ":: NFC ()"
+    - "[:Space:]+ > ' '"
 sanitizers:
     - step: clean-housenumbers
       filter-kind:


### PR DESCRIPTION
There are some pathological cases where an isolated letter may be deleted because it is in itself meaningless. If this happens in the middle of a sentence, then the transliteration contains two consecutive spaces. Add a final rule to fix this.

See also #2909.

This change requires a reimport to become effective. If you feel bold, you can also apply it to an existing instance by following these steps:

* update the tokenizer string in the database: `UPDATE nominatim_properties SET value = value || '; [:Space:]+ > '' ''' WHERE property = 'tokenizer_import_transliteration`
* remove the `tokenizer` directory from your project directory
* run `./nominatim refresh --website`

Note that by doing so, you are working outside the specification and you are on your own if it breaks things.