### PR TITLE
Use grapheme_stripos instead of stripos in PHP code

### DIFF
--- a/lib-php/Geocode.php
+++ b/lib-php/Geocode.php
@@ -874,7 +874,7 @@ class Geocode
                 $iCountWords = 0;
                 $sAddress = $aResult['langaddress'];
                 foreach ($aRecheckWords as $i => $sWord) {
-                    if (stripos($sAddress, $sWord)!==false) {
+                    if (grapheme_stripos($sAddress, $sWord)!==false) {
                         $iCountWords++;
                         if (preg_match('/(^|,)\s*'.preg_quote($sWord, '/').'\s*(,|$)/', $sAddress)) {
                             $iCountWords += 0.1;


### PR DESCRIPTION
The stripos() does not handle non-ASCII correctly.

Fixes #2904.