### PR TITLE
Remove shortcut disabling forward dependencies

### DIFF
--- a/nominatim/clicmd/args.py
+++ b/nominatim/clicmd/args.py
@@ -181,7 +181,6 @@ class NominatimArgs:
                     osm2pgsql_style_path=self.config.config_dir,
                     threads=self.threads or default_threads,
                     dsn=self.config.get_libpq_dsn(),
-                    forward_dependencies=self.config.get_bool('UPDATE_FORWARD_DEPENDENCIES'),
                     flatnode_file=str(self.config.get_path('FLATNODE_FILE') or ''),
                     tablespaces=dict(slim_data=self.config.TABLESPACE_OSM_DATA,
                                      slim_index=self.config.TABLESPACE_OSM_INDEX,

--- a/nominatim/tools/exec_utils.py
+++ b/nominatim/tools/exec_utils.py
@@ -136,9 +136,6 @@ def run_osm2pgsql(options: Mapping[str, Any]) -> None:
     if options['flatnode_file']:
         cmd.extend(('--flat-nodes', options['flatnode_file']))
 
-    if not options.get('forward_dependencies', False):
-        cmd.extend(('--with-forward-dependencies', 'false'))
-
     for key, param in (('slim_data', '--tablespace-slim-data'),
                        ('slim_index', '--tablespace-slim-index'),
                        ('main_data', '--tablespace-main-data'),

--- a/nominatim/version.py
+++ b/nominatim/version.py
@@ -25,7 +25,7 @@ from typing import Optional, Tuple
 # patch level when cherry-picking the commit with the migration.
 #
 # Released versions always have a database patch level of 0.
-NOMINATIM_VERSION = (4, 2, 0, 0)
+NOMINATIM_VERSION = (4, 2, 99, 0)
 
 POSTGRESQL_REQUIRED_VERSION = (9, 6)
 POSTGIS_REQUIRED_VERSION = (2, 2)

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -33,15 +33,6 @@ NOMINATIM_MAX_WORD_FREQUENCY=50000
 # If true, admin level changes on places with many contained children are blocked.
 NOMINATIM_LIMIT_REINDEXING=yes
 
-# When set to 'yes' changes to OSM objects will be propagated to dependent
-# objects. This means that geometries of way/relations are updated when a
-# node on a way or a way in a relation changes.
-# EXPERT ONLY: Use with care. Enabling this option might lead to significantly
-#              more load when updates are applied.
-#              Do not enable this option on an existing database.
-# The default is to not propagate these changes.
-NOMINATIM_UPDATE_FORWARD_DEPENDENCIES=no
-
 # Restrict search languages.
 # Normally Nominatim will include all language variants of name:XX
 # in the search index. Set this to a comma separated list of language


### PR DESCRIPTION
The gazetteer output of osm2pgsql has always had an optimization, where it would not forward changes from OSM object to those containing the object. In concrete terms: geometries of a way or area would not be updated in the Nominatim database when just a node was moved. This was done to keep the processing load for updates manageable. In the meantime hardware and update codes have improved enough that this shortcut is no longer necessary. The OSMF servers have been running updates for a month now with processing forward dependencies enabled and that had no effect whatsoever on the efficiency of updates.

This PR simply removes the code that disables forward dependencies including the experimental flag used to test the function. The migration for this change needs to create the appropriate index on the osm2pgsql middle tables. This takes a couple of hours on a machine under load.

Fixes #2563.