### PR TITLE
Actions: use Ubuntu 20 image for testing old versions of dependent software

### DIFF
--- a/.github/actions/build-nominatim/action.yml
+++ b/.github/actions/build-nominatim/action.yml
@@ -1,10 +1,10 @@
 name: 'Build Nominatim'
 
 inputs:
-    ubuntu:
+    flavour:
         description: 'Version of Ubuntu to install on'
         required: false
-        default: '20'
+        default: 'ubuntu-20'
     cmake-args:
         description: 'Additional options to hand to cmake'
         required: false
@@ -23,10 +23,10 @@ runs:
             sudo rm -rf /opt/hostedtoolcache/go /opt/hostedtoolcache/CodeQL /usr/lib/jvm /usr/local/share/chromium /usr/local/lib/android
             df -h
           shell: bash
-        - name: Install prerequisites
+        - name: Install${{ matrix.flavour }} prerequisites
           run: |
             sudo apt-get install -y -qq libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libpq-dev libproj-dev libicu-dev liblua${LUA_VERSION}-dev lua${LUA_VERSION}
-            if [ "x$UBUNTUVER" == "x18" ]; then
+            if [ "$FLAVOUR" == "oldstuff" ]; then
                 pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==1.4 datrie asyncpg
             else
                 sudo apt-get install -y -qq python3-icu python3-datrie python3-pyosmium python3-jinja2 python3-psutil python3-psycopg2 python3-dotenv python3-yaml python3-asyncpg
@@ -34,7 +34,7 @@ runs:
             fi
           shell: bash
           env:
-            UBUNTUVER: ${{ inputs.ubuntu }}
+            FLAVOUR: ${{ inputs.flavour }}
             CMAKE_ARGS: ${{ inputs.cmake-args }}
             LUA_VERSION: ${{ inputs.lua }}
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,20 +37,26 @@ jobs:
         needs: create-archive
         strategy:
             matrix:
-                ubuntu: [18, 20, 22]
+                flavour: [oldstuff, "ubuntu-20", "ubuntu-22"]
                 include:
-                    - ubuntu: 18
-                      postgresql: 9.6
-                      postgis: 2.5
-                      php: 7.2
-                    - ubuntu: 20
+                    - flavour: oldstuff
+                      ubuntu: 20
+                      postgresql: '9.6'
+                      postgis: '2.5'
+                      php: '7.3'
+                      lua: '5.1'
+                    - flavour: ubuntu-20
+                      ubuntu: 20
                       postgresql: 13
                       postgis: 3
-                      php: 7.4
-                    - ubuntu: 22
+                      php: '7.4'
+                      lua: '5.3'
+                    - flavour: ubuntu-22
+                      ubuntu: 22
                       postgresql: 15
                       postgis: 3
-                      php: 8.1
+                      php: '8.1'
+                      lua: '5.3'
 
         runs-on: ubuntu-${{ matrix.ubuntu }}.04
 
@@ -72,7 +78,7 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                 python-version: 3.7
-              if: matrix.ubuntu == 18
+              if: matrix.flavour == 'oldstuff'
 
             - uses: ./Nominatim/.github/actions/setup-postgresql
               with:
@@ -81,23 +87,24 @@ jobs:
 
             - uses: ./Nominatim/.github/actions/build-nominatim
               with:
-                  ubuntu: ${{ matrix.ubuntu }}
+                  flavour: ${{ matrix.flavour }}
+                  lua: ${{ matrix.lua }}
 
             - name: Install test prerequsites (behave from apt)
               run: sudo apt-get install -y -qq python3-behave
-              if: matrix.ubuntu == 20
+              if: matrix.flavour == 'ubuntu-20'
 
             - name: Install test prerequsites (behave from pip)
               run: pip3 install behave==1.2.6
-              if: ${{ (matrix.ubuntu == 18) || (matrix.ubuntu == 22) }}
+              if: (matrix.flavour == 'oldstuff') || (matrix.flavour == 'ubuntu-22')
 
             - name: Install test prerequsites (from apt for Ununtu 2x)
               run: sudo apt-get install -y -qq python3-pytest uvicorn
-              if: matrix.ubuntu >= 20
+              if: matrix.flavour != 'oldstuff'
 
             - name: Install test prerequsites (from pip for Ubuntu 18)
               run: pip3 install pytest uvicorn
-              if: matrix.ubuntu == 18
+              if: matrix.flavour == 'oldstuff'
 
             - name: Install Python webservers
               run: pip3 install falcon sanic sanic-testing starlette
@@ -129,12 +136,12 @@ jobs:
 
             - name: Install newer Python packages (for typechecking info)
               run: pip3 install -U osmium uvicorn
-              if: matrix.ubuntu >= 20
+              if: matrix.flavour != 'oldstuff'
 
             - name: Python static typechecking
               run: python3 -m mypy --strict nominatim
               working-directory: Nominatim
-              if: matrix.ubuntu >= 20
+              if: matrix.flavour != 'oldstuff'
 
     legacy-test:
         needs: create-archive
@@ -151,7 +158,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: '7.4'
 
             - uses: ./Nominatim/.github/actions/setup-postgresql
               with:
@@ -163,7 +170,6 @@ jobs:
 
             - uses: ./Nominatim/.github/actions/build-nominatim
               with:
-                  ubuntu: 20
                   cmake-args: -DBUILD_MODULE=on
 
             - name: Install test prerequsites

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -53,7 +53,7 @@ For running Nominatim:
   * [PyICU](https://pypi.org/project/PyICU/)
   * [PyYaml](https://pyyaml.org/) (5.1+)
   * [datrie](https://github.com/pytries/datrie)
-  * [PHP](https://php.net) (7.0 or later)
+  * [PHP](https://php.net) (7.3+)
   * PHP-pgsql
   * PHP-intl (bundled with PHP)
   * PHP-cgi (for running queries from the command line)


### PR DESCRIPTION
The Ubuntu18 image will be removed for Github Actions in the near future,  so switch to the Ubuntu 20 image for testing old versions of dependent libraries.

This also increases the minimum requirement for PHP to 7.3 as this is the oldest version that works on Github Actions.