### PR TITLE
Minor adjustments to reverse zoom translation

### DIFF
--- a/docs/api/Reverse.md
+++ b/docs/api/Reverse.md
@@ -92,7 +92,10 @@ In terms of address details the zoom levels are as follows:
   5   | state
   8   | county
   10  | city
-  14  | suburb
+  12  | town / borough
+  13  | village / suburb
+  14  | neighbourhood
+  15  | locality
   16  | major streets
   17  | major and minor streets
   18  | building

--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -40,10 +40,10 @@ class ReverseGeocode
                       9 => 12,
                       10 => 17, // City
                       11 => 17,
-                      12 => 18, // Town / Village
-                      13 => 18,
-                      14 => 22, // Suburb
-                      15 => 22,
+                      12 => 18, // Town
+                      13 => 19, // Village
+                      14 => 22, // Neighbourhood
+                      15 => 25, // Locality
                       16 => 26, // major street
                       17 => 27, // minor street
                       18 => 30, // or >, Building


### PR DESCRIPTION
Add a 'village' zoom level at 13 between town and neighborhood and a all locality-like objects for zoom 15. These zoom levels had the same behavior as the lower level so far. However, the distinction for village and locality may be useful at times.

Fixes #3009.