### PR TITLE
Fix extra tag handling in some flex scripts

### DIFF
--- a/settings/flex-base.lua
+++ b/settings/flex-base.lua
@@ -231,7 +231,6 @@ function Place:write_row(k, v, save_extra_mains)
         end
     end
 
-    print(k, v)
     place_table:insert{
         class = k,
         type = v,

--- a/settings/import-full.lua
+++ b/settings/import-full.lua
@@ -50,7 +50,11 @@ flex.set_prefilters{delete_keys = {'note', 'note:*', 'source', '*source', 'attri
                                    'nhd:*', 'gnis:*', 'geobase:*', 'KSJ2:*', 'yh:*',
                                    'osak:*', 'naptan:*', 'CLC:*', 'import', 'it:fvg:*',
                                    'type', 'lacounty:*', 'ref:ruian:*', 'building:ruian:type',
-                                   'ref:linz:*', 'is_in:postcode'},
+                                   'ref:linz:*', 'is_in:postcode',
+                                   '*:prefix', '*:suffix', 'name:prefix:*', 'name:suffix:*',
+                                   'name:etymology', 'name:signed', 'name:botanical',
+                                   '*:wikidata', '*:wikipedia', 'brand:wikipedia:*',
+                                   'addr:street:name', 'addr:street:type'},
                     delete_tags = {emergency = {'yes', 'no', 'fire_hydrant'},
                                    historic = {'yes', 'no'},
                                    military = {'yes', 'no'},
@@ -74,11 +78,7 @@ flex.set_prefilters{delete_keys = {'note', 'note:*', 'source', '*source', 'attri
                                    waterway = {'riverbank'},
                                    building = {'no'},
                                    boundary = {'place'}},
-                    extra_keys = {'*:prefix', '*:suffix', 'name:prefix:*', 'name:suffix:*',
-                               'name:etymology', 'name:signed', 'name:botanical',
-                               'wikidata', '*:wikidata',
-                               '*:wikipedia', 'brand:wikipedia:*',
-                               'addr:street:name', 'addr:street:type'}
+                    extra_keys = {'wikidata', 'wikipedia', 'wikipedia:*'}
                    }
 
 flex.set_name_tags{main = {'name', 'name:*',


### PR DESCRIPTION
`set_unused_handling(extra_...)` wasn't working properly when the extra tags list contained main tags (as is the case for the default 'full' style). Those tags should only be moved to extratags when they are not the main tag.

Also changes the 'full' style to remove more tags instead of saving them in extratags.