### PR TITLE
Python implementation of Lookup API

### DIFF
--- a/nominatim/api/__init__.py
+++ b/nominatim/api/__init__.py
@@ -32,5 +32,7 @@ from .results import (SourceTable as SourceTable,
                       WordInfos as WordInfos,
                       DetailedResult as DetailedResult,
                       ReverseResult as ReverseResult,
-                      ReverseResults as ReverseResults)
+                      ReverseResults as ReverseResults,
+                      SearchResult as SearchResult,
+                      SearchResults as SearchResults)
 from .localization import (Locales as Locales)

--- a/nominatim/api/core.py
+++ b/nominatim/api/core.py
@@ -20,7 +20,7 @@ from nominatim.db.sqlalchemy_schema import SearchTables
 from nominatim.config import Configuration
 from nominatim.api.connection import SearchConnection
 from nominatim.api.status import get_status, StatusResult
-from nominatim.api.lookup import get_place_by_id
+from nominatim.api.lookup import get_detailed_place
 from nominatim.api.reverse import ReverseGeocoder
 from nominatim.api.types import PlaceRef, LookupDetails, AnyPoint, DataLayer
 from nominatim.api.results import DetailedResult, ReverseResult
@@ -137,7 +137,7 @@ class NominatimAPIAsync:
             Returns None if there is no entry under the given ID.
         """
         async with self.begin() as conn:
-            return await get_place_by_id(conn, place, details or LookupDetails())
+            return await get_detailed_place(conn, place, details or LookupDetails())
 
 
     async def reverse(self, coord: AnyPoint, max_rank: Optional[int] = None,

--- a/nominatim/api/lookup.py
+++ b/nominatim/api/lookup.py
@@ -12,7 +12,7 @@ import datetime as dt
 
 import sqlalchemy as sa
 
-from nominatim.typing import SaColumn, SaLabel, SaRow
+from nominatim.typing import SaColumn, SaRow, SaSelect
 from nominatim.api.connection import SearchConnection
 import nominatim.api.types as ntyp
 import nominatim.api.results as nres
@@ -20,23 +20,12 @@ from nominatim.api.logging import log
 
 RowFunc = Callable[[Optional[SaRow], Type[nres.BaseResultT]], Optional[nres.BaseResultT]]
 
-def _select_column_geometry(column: SaColumn,
-                            geometry_output: ntyp.GeometryFormat) -> SaLabel:
-    """ Create the appropriate column expression for selecting a
-        geometry for the details response.
-    """
-    if geometry_output & ntyp.GeometryFormat.GEOJSON:
-        return sa.literal_column(f"""
-                  ST_AsGeoJSON(CASE WHEN ST_NPoints({column.name}) > 5000
-                               THEN ST_SimplifyPreserveTopology({column.name}, 0.0001)
-                               ELSE {column.name} END)
-                  """).label('geometry_geojson')
+GeomFunc = Callable[[SaSelect, SaColumn], SaSelect]
 
-    return sa.func.ST_GeometryType(column).label('geometry_type')
 
 
 async def find_in_placex(conn: SearchConnection, place: ntyp.PlaceRef,
-                         details: ntyp.LookupDetails) -> Optional[SaRow]:
+                         add_geometries: GeomFunc) -> Optional[SaRow]:
     """ Search for the given place in the placex table and return the
         base information.
     """
@@ -49,8 +38,7 @@ async def find_in_placex(conn: SearchConnection, place: ntyp.PlaceRef,
                     t.c.importance, t.c.wikipedia, t.c.indexed_date,
                     t.c.parent_place_id, t.c.rank_address, t.c.rank_search,
                     t.c.linked_place_id,
-                    t.c.centroid,
-                    _select_column_geometry(t.c.geometry, details.geometry_output))
+                    t.c.centroid)
 
     if isinstance(place, ntyp.PlaceID):
         sql = sql.where(t.c.place_id == place.place_id)
@@ -65,11 +53,11 @@ async def find_in_placex(conn: SearchConnection, place: ntyp.PlaceRef,
     else:
         return None
 
-    return (await conn.execute(sql)).one_or_none()
+    return (await conn.execute(add_geometries(sql, t.c.geometry))).one_or_none()
 
 
 async def find_in_osmline(conn: SearchConnection, place: ntyp.PlaceRef,
-                          details: ntyp.LookupDetails) -> Optional[SaRow]:
+                          add_geometries: GeomFunc) -> Optional[SaRow]:
     """ Search for the given place in the osmline table and return the
         base information.
     """
@@ -78,8 +66,7 @@ async def find_in_osmline(conn: SearchConnection, place: ntyp.PlaceRef,
     sql = sa.select(t.c.place_id, t.c.osm_id, t.c.parent_place_id,
                     t.c.indexed_date, t.c.startnumber, t.c.endnumber,
                     t.c.step, t.c.address, t.c.postcode, t.c.country_code,
-                    t.c.linegeo.ST_Centroid().label('centroid'),
-                    _select_column_geometry(t.c.linegeo, details.geometry_output))
+                    t.c.linegeo.ST_Centroid().label('centroid'))
 
     if isinstance(place, ntyp.PlaceID):
         sql = sql.where(t.c.place_id == place.place_id)
@@ -94,14 +81,17 @@ async def find_in_osmline(conn: SearchConnection, place: ntyp.PlaceRef,
     else:
         return None
 
-    return (await conn.execute(sql)).one_or_none()
+    return (await conn.execute(add_geometries(sql, t.c.linegeo))).one_or_none()
 
 
 async def find_in_tiger(conn: SearchConnection, place: ntyp.PlaceRef,
-                        details: ntyp.LookupDetails) -> Optional[SaRow]:
+                        add_geometries: GeomFunc) -> Optional[SaRow]:
     """ Search for the given place in the table of Tiger addresses and return
         the base information. Only lookup by place ID is supported.
     """
+    if not isinstance(place, ntyp.PlaceID):
+        return None
+
     log().section("Find in TIGER table")
     t = conn.t.tiger
     parent = conn.t.placex
@@ -109,61 +99,54 @@ async def find_in_tiger(conn: SearchConnection, place: ntyp.PlaceRef,
                     parent.c.osm_type, parent.c.osm_id,
                     t.c.startnumber, t.c.endnumber, t.c.step,
                     t.c.postcode,
-                    t.c.linegeo.ST_Centroid().label('centroid'),
-                    _select_column_geometry(t.c.linegeo, details.geometry_output))
+                    t.c.linegeo.ST_Centroid().label('centroid'))\
+            .where(t.c.place_id == place.place_id)\
+            .join(parent, t.c.parent_place_id == parent.c.place_id, isouter=True)
 
-    if isinstance(place, ntyp.PlaceID):
-        sql = sql.where(t.c.place_id == place.place_id)\
-                 .join(parent, t.c.parent_place_id == parent.c.place_id, isouter=True)
-    else:
-        return None
-
-    return (await conn.execute(sql)).one_or_none()
+    return (await conn.execute(add_geometries(sql, t.c.linegeo))).one_or_none()
 
 
 async def find_in_postcode(conn: SearchConnection, place: ntyp.PlaceRef,
-                           details: ntyp.LookupDetails) -> Optional[SaRow]:
+                           add_geometries: GeomFunc) -> Optional[SaRow]:
     """ Search for the given place in the postcode table and return the
         base information. Only lookup by place ID is supported.
     """
+    if not isinstance(place, ntyp.PlaceID):
+        return None
+
     log().section("Find in postcode table")
     t = conn.t.postcode
     sql = sa.select(t.c.place_id, t.c.parent_place_id,
                     t.c.rank_search, t.c.rank_address,
                     t.c.indexed_date, t.c.postcode, t.c.country_code,
-                    t.c.geometry.label('centroid'),
-                    _select_column_geometry(t.c.geometry, details.geometry_output))
+                    t.c.geometry.label('centroid')) \
+            .where(t.c.place_id == place.place_id)
 
-    if isinstance(place, ntyp.PlaceID):
-        sql = sql.where(t.c.place_id == place.place_id)
-    else:
-        return None
-
-    return (await conn.execute(sql)).one_or_none()
+    return (await conn.execute(add_geometries(sql, t.c.geometry))).one_or_none()
 
 
 async def find_in_all_tables(conn: SearchConnection, place: ntyp.PlaceRef,
-                             details: ntyp.LookupDetails
+                             add_geometries: GeomFunc
                             ) -> Tuple[Optional[SaRow], RowFunc[nres.BaseResultT]]:
     """ Search for the given place in all data tables
         and return the base information.
     """
-    row = await find_in_placex(conn, place, details)
+    row = await find_in_placex(conn, place, add_geometries)
     log().var_dump('Result (placex)', row)
     if row is not None:
         return row, nres.create_from_placex_row
 
-    row = await find_in_osmline(conn, place, details)
+    row = await find_in_osmline(conn, place, add_geometries)
     log().var_dump('Result (osmline)', row)
     if row is not None:
         return row, nres.create_from_osmline_row
 
-    row = await find_in_postcode(conn, place, details)
+    row = await find_in_postcode(conn, place, add_geometries)
     log().var_dump('Result (postcode)', row)
     if row is not None:
         return row, nres.create_from_postcode_row
 
-    row = await find_in_tiger(conn, place, details)
+    row = await find_in_tiger(conn, place, add_geometries)
     log().var_dump('Result (tiger)', row)
     return row, nres.create_from_tiger_row
 
@@ -172,13 +155,24 @@ async def get_detailed_place(conn: SearchConnection, place: ntyp.PlaceRef,
                              details: ntyp.LookupDetails) -> Optional[nres.DetailedResult]:
     """ Retrieve a place with additional details from the database.
     """
-    log().function('get_place_by_id', place=place, details=details)
+    log().function('get_detailed_place', place=place, details=details)
 
     if details.geometry_output and details.geometry_output != ntyp.GeometryFormat.GEOJSON:
         raise ValueError("lookup only supports geojosn polygon output.")
 
+    if details.geometry_output & ntyp.GeometryFormat.GEOJSON:
+        def _add_geometry(sql: SaSelect, column: SaColumn) -> SaSelect:
+            return sql.add_columns(sa.literal_column(f"""
+                      ST_AsGeoJSON(CASE WHEN ST_NPoints({column.name}) > 5000
+                                   THEN ST_SimplifyPreserveTopology({column.name}, 0.0001)
+                                   ELSE {column.name} END)
+                       """).label('geometry_geojson'))
+    else:
+        def _add_geometry(sql: SaSelect, column: SaColumn) -> SaSelect:
+            return sql.add_columns(sa.func.ST_GeometryType(column).label('geometry_type'))
+
     row_func: RowFunc[nres.DetailedResult]
-    row, row_func = await find_in_all_tables(conn, place, details)
+    row, row_func = await find_in_all_tables(conn, place, _add_geometry)
 
     if row is None:
         return None
@@ -194,6 +188,51 @@ async def get_detailed_place(conn: SearchConnection, place: ntyp.PlaceRef,
     indexed_date = getattr(row, 'indexed_date', None)
     if indexed_date is not None:
         result.indexed_date = indexed_date.replace(tzinfo=dt.timezone.utc)
+
+    await nres.add_result_details(conn, result, details)
+
+    return result
+
+
+async def get_simple_place(conn: SearchConnection, place: ntyp.PlaceRef,
+                             details: ntyp.LookupDetails) -> Optional[nres.SearchResult]:
+    """ Retrieve a place as a simple search result from the database.
+    """
+    log().function('get_simple_place', place=place, details=details)
+
+    def _add_geometry(sql: SaSelect, col: SaColumn) -> SaSelect:
+        if not details.geometry_output:
+            return sql
+
+        out = []
+
+        if details.geometry_simplification > 0.0:
+            col = col.ST_SimplifyPreserveTopology(details.geometry_simplification)
+
+        if details.geometry_output & ntyp.GeometryFormat.GEOJSON:
+            out.append(col.ST_AsGeoJSON().label('geometry_geojson'))
+        if details.geometry_output & ntyp.GeometryFormat.TEXT:
+            out.append(col.ST_AsText().label('geometry_text'))
+        if details.geometry_output & ntyp.GeometryFormat.KML:
+            out.append(col.ST_AsKML().label('geometry_kml'))
+        if details.geometry_output & ntyp.GeometryFormat.SVG:
+            out.append(col.ST_AsSVG().label('geometry_svg'))
+
+        return sql.add_columns(*out)
+
+
+    row_func: RowFunc[nres.SearchResult]
+    row, row_func = await find_in_all_tables(conn, place, _add_geometry)
+
+    if row is None:
+        return None
+
+    result = row_func(row, nres.SearchResult)
+    assert result is not None
+
+    # add missing details
+    assert result is not None
+    result.bbox = getattr(row, 'bbox', None)
 
     await nres.add_result_details(conn, result, details)
 

--- a/nominatim/api/results.py
+++ b/nominatim/api/results.py
@@ -173,6 +173,19 @@ class ReverseResults(List[ReverseResult]):
     """
 
 
+@dataclasses.dataclass
+class SearchResult(BaseResult):
+    """ A search result for forward geocoding.
+    """
+    bbox: Optional[Bbox] = None
+
+
+class SearchResults(List[SearchResult]):
+    """ Sequence of forward lookup results ordered by relevance.
+        May be empty when no result was found.
+    """
+
+
 def _filter_geometries(row: SaRow) -> Dict[str, str]:
     return {k[9:]: v for k, v in row._mapping.items() # pylint: disable=W0212
             if k.startswith('geometry_')}

--- a/nominatim/api/v1/classtypes.py
+++ b/nominatim/api/v1/classtypes.py
@@ -10,7 +10,7 @@ Hard-coded information about tag catagories.
 These tables have been copied verbatim from the old PHP code. For future
 version a more flexible formatting is required.
 """
-from typing import Tuple, Optional, Mapping
+from typing import Tuple, Optional, Mapping, Union
 
 import nominatim.api as napi
 
@@ -41,7 +41,7 @@ def get_label_tag(category: Tuple[str, str], extratags: Optional[Mapping[str, st
     return label.lower().replace(' ', '_')
 
 
-def bbox_from_result(result: napi.ReverseResult) -> napi.Bbox:
+def bbox_from_result(result: Union[napi.ReverseResult, napi.SearchResult]) -> napi.Bbox:
     """ Compute a bounding box for the result. For ways and relations
         a given boundingbox is used. For all other object, a box is computed
         around the centroid according to dimensions dereived from the

--- a/nominatim/api/v1/format.py
+++ b/nominatim/api/v1/format.py
@@ -198,33 +198,33 @@ def _format_reverse_jsonv2(results: napi.ReverseResults,
 
 
 @dispatch.format_func(napi.SearchResults, 'xml')
-def _format_reverse_xml(results: napi.SearchResults, options: Mapping[str, Any]) -> str:
+def _format_search_xml(results: napi.SearchResults, options: Mapping[str, Any]) -> str:
     return format_xml.format_base_xml(results,
                                       options, False, 'searchresults',
                                       {'querystring': 'TODO'})
 
 
 @dispatch.format_func(napi.SearchResults, 'geojson')
-def _format_reverse_geojson(results: napi.SearchResults,
+def _format_search_geojson(results: napi.SearchResults,
                             options: Mapping[str, Any]) -> str:
     return format_json.format_base_geojson(results, options, False)
 
 
 @dispatch.format_func(napi.SearchResults, 'geocodejson')
-def _format_reverse_geocodejson(results: napi.SearchResults,
+def _format_search_geocodejson(results: napi.SearchResults,
                                 options: Mapping[str, Any]) -> str:
     return format_json.format_base_geocodejson(results, options, False)
 
 
 @dispatch.format_func(napi.SearchResults, 'json')
-def _format_reverse_json(results: napi.SearchResults,
+def _format_search_json(results: napi.SearchResults,
                          options: Mapping[str, Any]) -> str:
     return format_json.format_base_json(results, options, False,
                                         class_label='class')
 
 
 @dispatch.format_func(napi.SearchResults, 'jsonv2')
-def _format_reverse_jsonv2(results: napi.SearchResults,
+def _format_search_jsonv2(results: napi.SearchResults,
                            options: Mapping[str, Any]) -> str:
     return format_json.format_base_json(results, options, False,
                                         class_label='category')

--- a/nominatim/api/v1/format.py
+++ b/nominatim/api/v1/format.py
@@ -195,3 +195,36 @@ def _format_reverse_jsonv2(results: napi.ReverseResults,
                            options: Mapping[str, Any]) -> str:
     return format_json.format_base_json(results, options, True,
                                         class_label='category')
+
+
+@dispatch.format_func(napi.SearchResults, 'xml')
+def _format_reverse_xml(results: napi.SearchResults, options: Mapping[str, Any]) -> str:
+    return format_xml.format_base_xml(results,
+                                      options, False, 'searchresults',
+                                      {'querystring': 'TODO'})
+
+
+@dispatch.format_func(napi.SearchResults, 'geojson')
+def _format_reverse_geojson(results: napi.SearchResults,
+                            options: Mapping[str, Any]) -> str:
+    return format_json.format_base_geojson(results, options, False)
+
+
+@dispatch.format_func(napi.SearchResults, 'geocodejson')
+def _format_reverse_geocodejson(results: napi.SearchResults,
+                                options: Mapping[str, Any]) -> str:
+    return format_json.format_base_geocodejson(results, options, False)
+
+
+@dispatch.format_func(napi.SearchResults, 'json')
+def _format_reverse_json(results: napi.SearchResults,
+                         options: Mapping[str, Any]) -> str:
+    return format_json.format_base_json(results, options, False,
+                                        class_label='class')
+
+
+@dispatch.format_func(napi.SearchResults, 'jsonv2')
+def _format_reverse_jsonv2(results: napi.SearchResults,
+                           options: Mapping[str, Any]) -> str:
+    return format_json.format_base_json(results, options, False,
+                                        class_label='category')

--- a/nominatim/api/v1/format_json.py
+++ b/nominatim/api/v1/format_json.py
@@ -249,7 +249,7 @@ def format_base_geocodejson(results: napi.ReverseResults,
         out.keyval('osm_key', result.category[0])\
            .keyval('osm_value', result.category[1])\
            .keyval('type', GEOCODEJSON_RANKS[max(3, min(28, result.rank_address))])\
-           .keyval_not_none('accuracy', result.distance, transform=int)\
+           .keyval_not_none('accuracy', getattr(result, 'distance', None), transform=int)\
            .keyval('label', ', '.join(label_parts))\
            .keyval_not_none('name', result.names, transform=locales.display_name)\
 

--- a/nominatim/api/v1/format_json.py
+++ b/nominatim/api/v1/format_json.py
@@ -7,11 +7,13 @@
 """
 Helper functions for output of results in json formats.
 """
-from typing import Mapping, Any, Optional, Tuple
+from typing import Mapping, Any, Optional, Tuple, Union
 
 import nominatim.api as napi
 import nominatim.api.v1.classtypes as cl
 from nominatim.utils.json_writer import JsonWriter
+
+#pylint: disable=too-many-branches
 
 def _write_osm_id(out: JsonWriter, osm_object: Optional[Tuple[str, int]]) -> None:
     if osm_object is not None:
@@ -61,7 +63,7 @@ def _write_geocodejson_address(out: JsonWriter,
         out.keyval('country_code', country_code)
 
 
-def format_base_json(results: napi.ReverseResults, #pylint: disable=too-many-branches
+def format_base_json(results: Union[napi.ReverseResults, napi.SearchResults],
                      options: Mapping[str, Any], simple: bool,
                      class_label: str) -> str:
     """ Return the result list as a simple json string in custom Nominatim format.
@@ -141,7 +143,7 @@ def format_base_json(results: napi.ReverseResults, #pylint: disable=too-many-bra
     return out()
 
 
-def format_base_geojson(results: napi.ReverseResults,
+def format_base_geojson(results: Union[napi.ReverseResults, napi.SearchResults],
                         options: Mapping[str, Any],
                         simple: bool) -> str:
     """ Return the result list as a geojson string.
@@ -210,7 +212,7 @@ def format_base_geojson(results: napi.ReverseResults,
     return out()
 
 
-def format_base_geocodejson(results: napi.ReverseResults,
+def format_base_geocodejson(results: Union[napi.ReverseResults, napi.SearchResults],
                             options: Mapping[str, Any], simple: bool) -> str:
     """ Return the result list as a geocodejson string.
     """

--- a/nominatim/api/v1/format_xml.py
+++ b/nominatim/api/v1/format_xml.py
@@ -7,12 +7,14 @@
 """
 Helper functions for output of results in XML format.
 """
-from typing import Mapping, Any, Optional
+from typing import Mapping, Any, Optional, Union
 import datetime as dt
 import xml.etree.ElementTree as ET
 
 import nominatim.api as napi
 import nominatim.api.v1.classtypes as cl
+
+#pylint: disable=too-many-branches
 
 def _write_xml_address(root: ET.Element, address: napi.AddressLines,
                        country_code: Optional[str]) -> None:
@@ -34,7 +36,7 @@ def _write_xml_address(root: ET.Element, address: napi.AddressLines,
         ET.SubElement(root, 'country_code').text = country_code
 
 
-def _create_base_entry(result: napi.ReverseResult, #pylint: disable=too-many-branches
+def _create_base_entry(result: Union[napi.ReverseResult, napi.SearchResult],
                        root: ET.Element, simple: bool,
                        locales: napi.Locales) -> ET.Element:
     if result.address_rows:
@@ -86,7 +88,7 @@ def _create_base_entry(result: napi.ReverseResult, #pylint: disable=too-many-bra
     return place
 
 
-def format_base_xml(results: napi.ReverseResults,
+def format_base_xml(results: Union[napi.ReverseResults, napi.SearchResults],
                     options: Mapping[str, Any],
                     simple: bool, xml_root_tag: str,
                     xml_extra_info: Mapping[str, str]) -> str:

--- a/nominatim/api/v1/server_glue.py
+++ b/nominatim/api/v1/server_glue.py
@@ -268,7 +268,7 @@ async def details_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> 
 
     locales = napi.Locales.from_accept_languages(params.get_accepted_languages())
 
-    result = await api.lookup(place, details)
+    result = await api.details(place, details)
 
     if debug:
         return params.build_response(loglib.get_and_disable())

--- a/nominatim/api/v1/server_glue.py
+++ b/nominatim/api/v1/server_glue.py
@@ -227,8 +227,11 @@ class ASGIAdaptor(abc.ABC):
 
 
     def parse_geometry_details(self, fmt: str) -> napi.LookupDetails:
+        """ Create details strucutre from the supplied geometry parameters.
+        """
         details = napi.LookupDetails(address_details=True,
-                                     geometry_simplification=self.get_float('polygon_threshold', 0.0))
+                                     geometry_simplification=
+                                       self.get_float('polygon_threshold', 0.0))
         numgeoms = 0
         if self.get_bool('polygon_geojson', False):
             details.geometry_output |= napi.GeometryFormat.GEOJSON
@@ -348,7 +351,7 @@ async def lookup_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> A
     details = params.parse_geometry_details(fmt)
 
     places = []
-    for oid in params.get('osm_ids', '').split(','):
+    for oid in (params.get('osm_ids') or '').split(','):
         oid = oid.strip()
         if len(oid) > 1 and oid[0] in 'RNWrnw' and oid[1:].isdigit():
             places.append(napi.OsmID(oid[0], int(oid[1:])))

--- a/nominatim/api/v1/server_glue.py
+++ b/nominatim/api/v1/server_glue.py
@@ -226,6 +226,30 @@ class ASGIAdaptor(abc.ABC):
         return fmt
 
 
+    def parse_geometry_details(self, fmt: str) -> napi.LookupDetails:
+        details = napi.LookupDetails(address_details=True,
+                                     geometry_simplification=self.get_float('polygon_threshold', 0.0))
+        numgeoms = 0
+        if self.get_bool('polygon_geojson', False):
+            details.geometry_output |= napi.GeometryFormat.GEOJSON
+            numgeoms += 1
+        if fmt not in ('geojson', 'geocodejson'):
+            if self.get_bool('polygon_text', False):
+                details.geometry_output |= napi.GeometryFormat.TEXT
+                numgeoms += 1
+            if self.get_bool('polygon_kml', False):
+                details.geometry_output |= napi.GeometryFormat.KML
+                numgeoms += 1
+            if self.get_bool('polygon_svg', False):
+                details.geometry_output |= napi.GeometryFormat.SVG
+                numgeoms += 1
+
+        if numgeoms > self.config().get_int('POLYGON_OUTPUT_MAX_TYPES'):
+            self.raise_error('Too many polgyon output options selected.')
+
+        return details
+
+
 async def status_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> Any:
     """ Server glue for /status endpoint. See API docs for details.
     """
@@ -291,28 +315,10 @@ async def reverse_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> 
     debug = params.setup_debugging()
     coord = napi.Point(params.get_float('lon'), params.get_float('lat'))
     locales = napi.Locales.from_accept_languages(params.get_accepted_languages())
+    details = params.parse_geometry_details(fmt)
 
     zoom = max(0, min(18, params.get_int('zoom', 18)))
 
-    details = napi.LookupDetails(address_details=True,
-                                 geometry_simplification=params.get_float('polygon_threshold', 0.0))
-    numgeoms = 0
-    if params.get_bool('polygon_geojson', False):
-        details.geometry_output |= napi.GeometryFormat.GEOJSON
-        numgeoms += 1
-    if fmt not in ('geojson', 'geocodejson'):
-        if params.get_bool('polygon_text', False):
-            details.geometry_output |= napi.GeometryFormat.TEXT
-            numgeoms += 1
-        if params.get_bool('polygon_kml', False):
-            details.geometry_output |= napi.GeometryFormat.KML
-            numgeoms += 1
-        if params.get_bool('polygon_svg', False):
-            details.geometry_output |= napi.GeometryFormat.SVG
-            numgeoms += 1
-
-    if numgeoms > params.config().get_int('POLYGON_OUTPUT_MAX_TYPES'):
-        params.raise_error('Too many polgyon output options selected.')
 
     result = await api.reverse(coord, REVERSE_MAX_RANKS[zoom],
                                params.get_layers() or
@@ -326,15 +332,43 @@ async def reverse_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> 
                    'extratags': params.get_bool('extratags', False),
                    'namedetails': params.get_bool('namedetails', False),
                    'addressdetails': params.get_bool('addressdetails', True)}
-    if fmt == 'xml':
-        fmt_options['xml_roottag'] = 'reversegeocode'
-        fmt_options['xml_extra_info'] = {'querystring': 'TODO'}
 
     output = formatting.format_result(napi.ReverseResults([result] if result else []),
                                       fmt, fmt_options)
 
     return params.build_response(output)
 
+
+async def lookup_endpoint(api: napi.NominatimAPIAsync, params: ASGIAdaptor) -> Any:
+    """ Server glue for /lookup endpoint. See API docs for details.
+    """
+    fmt = params.parse_format(napi.SearchResults, 'xml')
+    debug = params.setup_debugging()
+    locales = napi.Locales.from_accept_languages(params.get_accepted_languages())
+    details = params.parse_geometry_details(fmt)
+
+    places = []
+    for oid in params.get('osm_ids', '').split(','):
+        oid = oid.strip()
+        if len(oid) > 1 and oid[0] in 'RNWrnw' and oid[1:].isdigit():
+            places.append(napi.OsmID(oid[0], int(oid[1:])))
+
+    if places:
+        results = await api.lookup(places, details)
+    else:
+        results = napi.SearchResults()
+
+    if debug:
+        return params.build_response(loglib.get_and_disable())
+
+    fmt_options = {'locales': locales,
+                   'extratags': params.get_bool('extratags', False),
+                   'namedetails': params.get_bool('namedetails', False),
+                   'addressdetails': params.get_bool('addressdetails', True)}
+
+    output = formatting.format_result(results, fmt, fmt_options)
+
+    return params.build_response(output)
 
 EndpointFunc = Callable[[napi.NominatimAPIAsync, ASGIAdaptor], Any]
 
@@ -357,5 +391,6 @@ REVERSE_MAX_RANKS = [2, 2, 2,   # 0-2   Continent/Sea
 ROUTES = [
     ('status', status_endpoint),
     ('details', details_endpoint),
-    ('reverse', reverse_endpoint)
+    ('reverse', reverse_endpoint),
+    ('lookup', lookup_endpoint)
 ]

--- a/nominatim/clicmd/api.py
+++ b/nominatim/clicmd/api.py
@@ -292,7 +292,7 @@ class APIDetails:
         if args.polygon_geojson:
             details.geometry_output = napi.GeometryFormat.GEOJSON
 
-        result = api.lookup(place, details)
+        result = api.details(place, details)
 
         if result:
             output = api_output.format_result(

--- a/nominatim/clicmd/api.py
+++ b/nominatim/clicmd/api.py
@@ -214,19 +214,31 @@ class APILookup:
 
 
     def run(self, args: NominatimArgs) -> int:
-        params: Dict[str, object] = dict(osm_ids=','.join(args.ids), format=args.format)
+        api = napi.NominatimAPI(args.project_dir)
 
-        for param, _ in EXTRADATA_PARAMS:
-            if getattr(args, param):
-                params[param] = '1'
-        if args.lang:
-            params['accept-language'] = args.lang
-        if args.polygon_output:
-            params['polygon_' + args.polygon_output] = '1'
-        if args.polygon_threshold:
-            params['polygon_threshold'] = args.polygon_threshold
+        details = napi.LookupDetails(address_details=True, # needed for display name
+                                     geometry_output=args.get_geometry_output(),
+                                     geometry_simplification=args.polygon_threshold or 0.0)
 
-        return _run_api('lookup', args, params)
+        places = [napi.OsmID(o[0], int(o[1:])) for o in args.ids]
+
+        results = api.lookup(places, details)
+
+        output = api_output.format_result(
+                    results,
+                    args.format,
+                    {'locales': args.get_locales(api.config.DEFAULT_LANGUAGE),
+                     'extratags': args.extratags,
+                     'namedetails': args.namedetails,
+                     'addressdetails': args.addressdetails})
+        if args.format != 'xml':
+            # reformat the result, so it is pretty-printed
+            json.dump(json.loads(output), sys.stdout, indent=4, ensure_ascii=False)
+        else:
+            sys.stdout.write(output)
+        sys.stdout.write('\n')
+
+        return 0
 
 
 class APIDetails:

--- a/test/python/api/test_api_details.py
+++ b/test/python/api/test_api_details.py
@@ -31,7 +31,7 @@ def test_lookup_in_placex(apiobj, idobj):
                      indexed_date=import_date,
                      geometry='LINESTRING(23 34, 23.1 34, 23.1 34.1, 23 34)')
 
-    result = apiobj.api.lookup(idobj, napi.LookupDetails())
+    result = apiobj.api.details(idobj, napi.LookupDetails())
 
     assert result is not None
 
@@ -79,7 +79,7 @@ def test_lookup_in_placex_minimal_info(apiobj):
                      indexed_date=import_date,
                      geometry='LINESTRING(23 34, 23.1 34, 23.1 34.1, 23 34)')
 
-    result = apiobj.api.lookup(napi.PlaceID(332), napi.LookupDetails())
+    result = apiobj.api.details(napi.PlaceID(332), napi.LookupDetails())
 
     assert result is not None
 
@@ -121,7 +121,7 @@ def test_lookup_in_placex_with_geometry(apiobj):
     apiobj.add_placex(place_id=332,
                       geometry='LINESTRING(23 34, 23.1 34)')
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(geometry_output=napi.GeometryFormat.GEOJSON))
 
     assert result.geometry == {'geojson': '{"type":"LineString","coordinates":[[23,34],[23.1,34]]}'}
@@ -144,7 +144,7 @@ def test_lookup_placex_with_address_details(apiobj):
                               country_code='pl',
                               rank_search=17, rank_address=16)
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(address_details=True))
 
     assert result.address_rows == [
@@ -177,7 +177,7 @@ def test_lookup_place_with_linked_places_none_existing(apiobj):
                      country_code='pl', linked_place_id=45,
                      rank_search=27, rank_address=26)
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(linked_places=True))
 
     assert result.linked_rows == []
@@ -197,7 +197,7 @@ def test_lookup_place_with_linked_places_existing(apiobj):
                      country_code='pl', linked_place_id=332,
                      rank_search=27, rank_address=26)
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(linked_places=True))
 
     assert result.linked_rows == [
@@ -220,7 +220,7 @@ def test_lookup_place_with_parented_places_not_existing(apiobj):
                      country_code='pl', parent_place_id=45,
                      rank_search=27, rank_address=26)
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(parented_places=True))
 
     assert result.parented_rows == []
@@ -240,7 +240,7 @@ def test_lookup_place_with_parented_places_existing(apiobj):
                      country_code='pl', parent_place_id=332,
                      rank_search=27, rank_address=26)
 
-    result = apiobj.api.lookup(napi.PlaceID(332),
+    result = apiobj.api.details(napi.PlaceID(332),
                                napi.LookupDetails(parented_places=True))
 
     assert result.parented_rows == [
@@ -263,7 +263,7 @@ def test_lookup_in_osmline(apiobj, idobj):
                        indexed_date=import_date,
                        geometry='LINESTRING(23 34, 23 35)')
 
-    result = apiobj.api.lookup(idobj, napi.LookupDetails())
+    result = apiobj.api.details(idobj, napi.LookupDetails())
 
     assert result is not None
 
@@ -310,13 +310,13 @@ def test_lookup_in_osmline_split_interpolation(apiobj):
                        startnumber=11, endnumber=20, step=1)
 
     for i in range(1, 6):
-        result = apiobj.api.lookup(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
+        result = apiobj.api.details(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
         assert result.place_id == 1000
     for i in range(7, 11):
-        result = apiobj.api.lookup(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
+        result = apiobj.api.details(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
         assert result.place_id == 1001
     for i in range(12, 22):
-        result = apiobj.api.lookup(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
+        result = apiobj.api.details(napi.OsmID('W', 9, str(i)), napi.LookupDetails())
         assert result.place_id == 1002
 
 
@@ -340,7 +340,7 @@ def test_lookup_osmline_with_address_details(apiobj):
                               country_code='pl',
                               rank_search=17, rank_address=16)
 
-    result = apiobj.api.lookup(napi.PlaceID(9000),
+    result = apiobj.api.details(napi.PlaceID(9000),
                                napi.LookupDetails(address_details=True))
 
     assert result.address_rows == [
@@ -383,7 +383,7 @@ def test_lookup_in_tiger(apiobj):
                       osm_type='W', osm_id=6601223,
                       geometry='LINESTRING(23 34, 23 35)')
 
-    result = apiobj.api.lookup(napi.PlaceID(4924), napi.LookupDetails())
+    result = apiobj.api.details(napi.PlaceID(4924), napi.LookupDetails())
 
     assert result is not None
 
@@ -441,7 +441,7 @@ def test_lookup_tiger_with_address_details(apiobj):
                               country_code='us',
                               rank_search=17, rank_address=16)
 
-    result = apiobj.api.lookup(napi.PlaceID(9000),
+    result = apiobj.api.details(napi.PlaceID(9000),
                                napi.LookupDetails(address_details=True))
 
     assert result.address_rows == [
@@ -483,7 +483,7 @@ def test_lookup_in_postcode(apiobj):
                         indexed_date=import_date,
                         geometry='POINT(-9.45 5.6)')
 
-    result = apiobj.api.lookup(napi.PlaceID(554), napi.LookupDetails())
+    result = apiobj.api.details(napi.PlaceID(554), napi.LookupDetails())
 
     assert result is not None
 
@@ -537,7 +537,7 @@ def test_lookup_postcode_with_address_details(apiobj):
                               country_code='gb',
                               rank_search=17, rank_address=16)
 
-    result = apiobj.api.lookup(napi.PlaceID(9000),
+    result = apiobj.api.details(napi.PlaceID(9000),
                                napi.LookupDetails(address_details=True))
 
     assert result.address_rows == [
@@ -570,7 +570,7 @@ def test_lookup_missing_object(apiobj, objid):
     apiobj.add_placex(place_id=1, osm_type='N', osm_id=55,
                       class_='place', type='suburb')
 
-    assert apiobj.api.lookup(objid, napi.LookupDetails()) is None
+    assert apiobj.api.details(objid, napi.LookupDetails()) is None
 
 
 @pytest.mark.parametrize('gtype', (napi.GeometryFormat.KML,
@@ -580,5 +580,5 @@ def test_lookup_unsupported_geometry(apiobj, gtype):
     apiobj.add_placex(place_id=332)
 
     with pytest.raises(ValueError):
-        apiobj.api.lookup(napi.PlaceID(332),
+        apiobj.api.details(napi.PlaceID(332),
                           napi.LookupDetails(geometry_output=gtype))

--- a/test/python/api/test_api_details.py
+++ b/test/python/api/test_api_details.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2023 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
-Tests for lookup API call.
+Tests for details API call.
 """
 import datetime as dt
 

--- a/test/python/api/test_api_lookup.py
+++ b/test/python/api/test_api_lookup.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2023 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for lookup API call.
+"""
+import pytest
+
+import nominatim.api as napi
+
+def test_lookup_empty_list(apiobj):
+    assert apiobj.api.lookup([]) == []
+
+
+def test_lookup_non_existing(apiobj):
+    assert apiobj.api.lookup((napi.PlaceID(332), napi.OsmID('W', 4),
+                              napi.OsmID('W', 4, 'highway'))) == []
+
+
+@pytest.mark.parametrize('idobj', (napi.PlaceID(332), napi.OsmID('W', 4),
+                                   napi.OsmID('W', 4, 'highway')))
+def test_lookup_single_placex(apiobj, idobj):
+    apiobj.add_placex(place_id=332, osm_type='W', osm_id=4,
+                     class_='highway', type='residential',
+                     name={'name': 'Road'}, address={'city': 'Barrow'},
+                     extratags={'surface': 'paved'},
+                     parent_place_id=34, linked_place_id=55,
+                     admin_level=15, country_code='gb',
+                     housenumber='4',
+                     postcode='34425', wikipedia='en:Faa',
+                     rank_search=27, rank_address=26,
+                     importance=0.01,
+                     centroid=(23, 34),
+                     geometry='LINESTRING(23 34, 23.1 34, 23.1 34.1, 23 34)')
+
+    result = apiobj.api.lookup([idobj])
+
+    assert len(result) == 1
+
+    result = result[0]
+
+    assert result.source_table.name == 'PLACEX'
+    assert result.category == ('highway', 'residential')
+    assert result.centroid == (pytest.approx(23.0), pytest.approx(34.0))
+
+    assert result.place_id == 332
+    assert result.osm_object == ('W', 4)
+
+    assert result.names == {'name': 'Road'}
+    assert result.address == {'city': 'Barrow'}
+    assert result.extratags == {'surface': 'paved'}
+
+    assert result.housenumber == '4'
+    assert result.postcode == '34425'
+    assert result.wikipedia == 'en:Faa'
+
+    assert result.rank_search == 27
+    assert result.rank_address == 26
+    assert result.importance == pytest.approx(0.01)
+
+    assert result.country_code == 'gb'
+
+    assert result.address_rows is None
+    assert result.linked_rows is None
+    assert result.parented_rows is None
+    assert result.name_keywords is None
+    assert result.address_keywords is None
+
+    assert result.geometry == {}
+
+
+def test_lookup_multiple_places(apiobj):
+    apiobj.add_placex(place_id=332, osm_type='W', osm_id=4,
+                     class_='highway', type='residential',
+                     name={'name': 'Road'}, address={'city': 'Barrow'},
+                     extratags={'surface': 'paved'},
+                     parent_place_id=34, linked_place_id=55,
+                     admin_level=15, country_code='gb',
+                     housenumber='4',
+                     postcode='34425', wikipedia='en:Faa',
+                     rank_search=27, rank_address=26,
+                     importance=0.01,
+                     centroid=(23, 34),
+                     geometry='LINESTRING(23 34, 23.1 34, 23.1 34.1, 23 34)')
+    apiobj.add_osmline(place_id=4924, osm_id=9928,
+                       parent_place_id=12,
+                       startnumber=1, endnumber=4, step=1,
+                       country_code='gb', postcode='34425',
+                       address={'city': 'Big'},
+                       geometry='LINESTRING(23 34, 23 35)')
+
+
+    result = apiobj.api.lookup((napi.OsmID('W', 1),
+                                napi.OsmID('W', 4),
+                                napi.OsmID('W', 9928)), napi.LookupDetails())
+
+    assert len(result) == 2
+
+    assert set(r.place_id for r in result) == {332, 4924}

--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -384,3 +384,63 @@ class TestDetailsEndpoint:
 
         with pytest.raises(FakeError, match='^404 -- .*found'):
             await glue.details_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
+
+
+# lookup_endpoint()
+
+class TestLookupEndpoint:
+
+    @pytest.fixture(autouse=True)
+    def patch_lookup_func(self, monkeypatch):
+        self.results = [napi.SearchResult(napi.SourceTable.PLACEX,
+                                          ('place', 'thing'),
+                                          napi.Point(1.0, 2.0))]
+        async def _lookup(*args, **kwargs):
+            return napi.SearchResults(self.results)
+
+        monkeypatch.setattr(napi.NominatimAPIAsync, 'lookup', _lookup)
+
+
+    @pytest.mark.asyncio
+    async def test_lookup_no_params(self):
+        a = FakeAdaptor()
+        a.params['format'] = 'json'
+
+        res = await glue.lookup_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
+
+        assert res.output == '[]'
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('param', ['w', 'bad', ''])
+    async def test_lookup_bad_params(self, param):
+        a = FakeAdaptor()
+        a.params['format'] = 'json'
+        a.params['osm_ids'] = f'W34,{param},N33333'
+
+        res = await glue.lookup_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
+
+        assert len(json.loads(res.output)) == 1
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('param', ['p234234', '4563'])
+    async def test_lookup_bad_osm_type(self, param):
+        a = FakeAdaptor()
+        a.params['format'] = 'json'
+        a.params['osm_ids'] = f'W34,{param},N33333'
+
+        res = await glue.lookup_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
+
+        assert len(json.loads(res.output)) == 1
+
+
+    @pytest.mark.asyncio
+    async def test_lookup_working(self):
+        a = FakeAdaptor()
+        a.params['format'] = 'json'
+        a.params['osm_ids'] = 'N23,W34'
+
+        res = await glue.lookup_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
+
+        assert len(json.loads(res.output)) == 1

--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -335,7 +335,7 @@ class TestDetailsEndpoint:
             self.lookup_args.extend(args[1:])
             return self.result
 
-        monkeypatch.setattr(napi.NominatimAPIAsync, 'lookup', _lookup)
+        monkeypatch.setattr(napi.NominatimAPIAsync, 'details', _lookup)
 
 
     @pytest.mark.asyncio

--- a/test/python/cli/test_cmd_api.py
+++ b/test/python/cli/test_cmd_api.py
@@ -81,7 +81,7 @@ class TestCliDetailsCall:
         result = napi.DetailedResult(napi.SourceTable.PLACEX, ('place', 'thing'),
                                      napi.Point(1.0, -3.0))
 
-        monkeypatch.setattr(napi.NominatimAPI, 'lookup',
+        monkeypatch.setattr(napi.NominatimAPI, 'details',
                             lambda *args: result)
 
     @pytest.mark.parametrize("params", [('--node', '1'),


### PR DESCRIPTION
This implements the `/lookup` endpoint in Python.

The initial idea was to make this simply a different fronting to the already existing API lookup() function (implementing the details endpoint). However, this turned out to impractical because `/lookup` needs to reuse the output formatting of reverse/search rather than details. So this shifts function in the API around a bit: there is now a details() function and a lookup() function which implement the respective functionality of the public API. Internally, they still end up both using the same implementation for retrieving the data from the DB.