### PR TITLE
Add script to generate taginfo project description

### DIFF
--- a/.github/actions/build-nominatim/action.yml
+++ b/.github/actions/build-nominatim/action.yml
@@ -25,7 +25,7 @@ runs:
           shell: bash
         - name: Install${{ matrix.flavour }} prerequisites
           run: |
-            sudo apt-get install -y -qq libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libpq-dev libproj-dev libicu-dev liblua${LUA_VERSION}-dev lua${LUA_VERSION}
+            sudo apt-get install -y -qq libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libpq-dev libproj-dev libicu-dev liblua${LUA_VERSION}-dev lua${LUA_VERSION} lua-dkjson
             if [ "$FLAVOUR" == "oldstuff" ]; then
                 pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==1.4 GeoAlchemy2==0.10.0 datrie asyncpg
             else

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -250,6 +250,9 @@ jobs:
             - name: Prepare import environment
               run: |
                   mv Nominatim/test/testdb/apidb-test-data.pbf test.pbf
+                  mv Nominatim/settings/flex-base.lua flex-base.lua
+                  mv Nominatim/settings/import-extratags.lua import-extratags.lua
+                  mv Nominatim/settings/taginfo.lua taginfo.lua
                   rm -rf Nominatim
                   mkdir data-env-reverse
               working-directory: /home/nominatim
@@ -257,6 +260,10 @@ jobs:
             - name: Print version
               run: nominatim --version
               working-directory: /home/nominatim/nominatim-project
+
+            - name: Print taginfo
+              run: lua taginfo.lua
+              working-directory: /home/nominatim
 
             - name: Collect host OS information
               run: nominatim admin --collect-os-info

--- a/settings/import-extratags.lua
+++ b/settings/import-extratags.lua
@@ -7,7 +7,6 @@ flex.set_main_tags{
     historic = 'always',
     military = 'always',
     natural = 'named',
-    landuse = 'named',
     highway = {'always',
                street_lamp = 'named',
                traffic_signals = 'named',

--- a/settings/import-full.lua
+++ b/settings/import-full.lua
@@ -7,7 +7,6 @@ flex.set_main_tags{
     historic = 'always',
     military = 'always',
     natural = 'named',
-    landuse = 'named',
     highway = {'always',
                street_lamp = 'named',
                traffic_signals = 'named',

--- a/settings/taginfo.lua
+++ b/settings/taginfo.lua
@@ -1,0 +1,74 @@
+-- Prints taginfo project description in the standard output
+--
+
+-- create fake "osm2pgsql" table for flex-base, originally created by the main C++ program
+osm2pgsql = {}
+function osm2pgsql.define_table(...) end
+
+-- provide path to flex-style lua file
+flex = require('import-extratags')
+local json = require ('dkjson')
+
+
+------------ helper functions ---------------------
+
+function get_key_description(key, description)
+    local desc = {}
+    desc.key = key
+    desc.description = description
+    set_keyorder(desc, {'key', 'description'})
+    return desc
+end
+
+-- Sets the key order for the resulting JSON table
+function set_keyorder(table, order)
+    setmetatable(table, {
+        __jsonorder = order
+    })
+end
+
+
+-- Prints the collected tags in the required format in JSON
+function print_taginfo()
+    local tags = {}
+
+    for _, k in ipairs(flex.TAGINFO_MAIN.keys) do
+        local desc = get_key_description(k, 'POI/feature in the search database')
+        if flex.TAGINFO_MAIN.delete_tags[k] ~= nil then
+            desc.description = string.format('%s(except for values: %s).', desc.description,
+                                table.concat(flex.TAGINFO_MAIN.delete_tags[k], ', '))
+        end
+        table.insert(tags, desc)
+    end
+
+    for k, _ in pairs(flex.TAGINFO_NAME_KEYS) do
+        local desc = get_key_description(k, 'Searchable name of the place.')
+        table.insert(tags, desc)
+    end
+    for k, _ in pairs(flex.TAGINFO_ADDRESS_KEYS) do
+        local desc = get_key_description(k, 'Used to determine the address of a place.')
+        table.insert(tags, desc)
+    end
+
+    local format = {
+        data_format = 1,
+        data_url = 'http://nominatim.openstreetmap.org/taginfo.json',
+        project = {
+            name = 'Nominatim',
+            description = 'OSM search engine.',
+            project_url = 'http://nominatim.openstreetmap.org',
+            doc_url = 'http://wiki.osm.org/wiki/Nominatim',
+            contact_name = 'Sarah Hoffmann',
+            contact_email = 'lonvia@denofr.de'
+        }
+    }
+    format.tags = tags
+
+    set_keyorder(format, {'data_format', 'data_url', 'project', 'tags'})
+    set_keyorder(format.project, {'name', 'description', 'project_url', 'doc_url',
+                    'contact_name', 'contact_email'})
+
+    print(json.encode(format))
+end
+
+print_taginfo()

--- a/vagrant/Install-on-Ubuntu-20.sh
+++ b/vagrant/Install-on-Ubuntu-20.sh
@@ -23,7 +23,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
     sudo apt install -y php-cgi
     sudo apt install -y build-essential cmake g++ libboost-dev libboost-system-dev \
                         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
-                        libbz2-dev libpq-dev liblua5.3-dev lua5.3 \
+                        libbz2-dev libpq-dev liblua5.3-dev lua5.3 lua-dkjson \
                         postgresql-12-postgis-3 \
                         postgresql-contrib-12 postgresql-12-postgis-3-scripts \
                         php-cli php-pgsql php-intl libicu-dev python3-dotenv \

--- a/vagrant/Install-on-Ubuntu-22.sh
+++ b/vagrant/Install-on-Ubuntu-22.sh
@@ -23,7 +23,7 @@ export DEBIAN_FRONTEND=noninteractive #DOCS:
     sudo apt install -y php-cgi
     sudo apt install -y build-essential cmake g++ libboost-dev libboost-system-dev \
                         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
-                        libbz2-dev libpq-dev liblua5.3-dev lua5.3 \
+                        libbz2-dev libpq-dev liblua5.3-dev lua5.3 lua-dkjson \
                         postgresql-server-dev-14 postgresql-14-postgis-3 \
                         postgresql-contrib-14 postgresql-14-postgis-3-scripts \
                         php-cli php-pgsql php-intl libicu-dev python3-dotenv \


### PR DESCRIPTION
As mentioned in #2938, Nominatim now uses [flex style](https://nominatim.org/release-docs/develop/customize/Import-Styles/) to import places into the database. The flex-style files are present in the [settings](https://github.com/osm-search/Nominatim/tree/master/settings) folder. These files contain the OSM tags which are being used by Nominatim.
The script collects these tags and prints the Taginfo project description in the required [format](https://wiki.openstreetmap.org/wiki/Taginfo/Projects#Project_Files).

It should be noted that `delete` and `extra` tags are not considered in the description because these tags are not part of the search process. These tags are either completely ignored or are just used for displaying extra information with the search results.