### PR TITLE
when adding Tiger data, check first if database is in frozen state

### DIFF
--- a/.github/actions/build-nominatim/action.yml
+++ b/.github/actions/build-nominatim/action.yml
@@ -29,8 +29,8 @@ runs:
             if [ "$FLAVOUR" == "oldstuff" ]; then
                 pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==1.4 GeoAlchemy2==0.10.0 datrie asyncpg
             else
-                sudo apt-get install -y -qq python3-icu python3-datrie python3-pyosmium python3-jinja2 python3-psutil python3-psycopg2 python3-dotenv python3-yaml python3-asyncpg
-                pip3 install sqlalchemy GeoAlchemy2
+                sudo apt-get install -y -qq python3-icu python3-datrie python3-pyosmium python3-jinja2 python3-psutil python3-psycopg2 python3-dotenv python3-yaml
+                pip3 install sqlalchemy GeoAlchemy2 asyncpg
             fi
           shell: bash
           env:

--- a/nominatim/tools/freeze.py
+++ b/nominatim/tools/freeze.py
@@ -50,3 +50,9 @@ def drop_flatnode_file(fpath: Optional[Path]) -> None:
     """
     if fpath and fpath.exists():
         fpath.unlink()
+
+def is_frozen(conn: Connection) -> bool:
+    """ Returns true if database is in a frozen state
+    """
+
+    return conn.table_exists('place') is False

--- a/test/python/tools/test_freeze.py
+++ b/test/python/tools/test_freeze.py
@@ -30,6 +30,8 @@ def test_drop_tables(temp_db_conn, temp_db_cursor, table_factory):
     for table in NOMINATIM_RUNTIME_TABLES + NOMINATIM_DROP_TABLES:
         table_factory(table)
 
+    assert not freeze.is_frozen(temp_db_conn)
+
     freeze.drop_update_tables(temp_db_conn)
 
     for table in NOMINATIM_RUNTIME_TABLES:
@@ -37,6 +39,8 @@ def test_drop_tables(temp_db_conn, temp_db_cursor, table_factory):
 
     for table in NOMINATIM_DROP_TABLES:
         assert not temp_db_cursor.table_exists(table)
+
+    assert freeze.is_frozen(temp_db_conn)
 
 def test_drop_flatnode_file_no_file():
     freeze.drop_flatnode_file(None)
@@ -46,7 +50,7 @@ def test_drop_flatnode_file_file_already_gone(tmp_path):
     freeze.drop_flatnode_file(tmp_path / 'something.store')
 
 
-def test_drop_flatnode_file_delte(tmp_path):
+def test_drop_flatnode_file_delete(tmp_path):
     flatfile = tmp_path / 'flatnode.store'
     flatfile.write_text('Some content')
 


### PR DESCRIPTION
- new `nominatim.freeze.is_frozen` to check if database can be updated
- when users import TIGER data check and warn if database is frozen (related to https://github.com/osm-search/Nominatim/discussions/3048)

Includes change to Github Action setup to avoid "database "test_nominatim_python_unittest" is
being accessed by other users" errors, similar to https://github.com/osm-search/Nominatim/pull/3045