### PR TITLE
Docs: reintroduce amenity parameter for structured search

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -31,7 +31,7 @@ The search term may be specified with two different sets of parameters:
     [birmingham, pilkington avenue](https://nominatim.openstreetmap.org/search?q=birmingham,+pilkington+avenue).
     Commas are optional, but improve performance by reducing the complexity of the search.
 
-
+* `amenity=<name and/or type of POI>`
 * `street=<housenumber> <streetname>`
 * `city=<city>`
 * `county=<county>`


### PR DESCRIPTION
Somehow the `amenity` parameter for structured search got lost in the new-style documentation. It was not supposed to be a hidden feature.