### PR TITLE
Add support for psycopg 3 in the frontend

### DIFF
--- a/.github/actions/build-nominatim/action.yml
+++ b/.github/actions/build-nominatim/action.yml
@@ -30,7 +30,7 @@ runs:
                 pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==1.4 GeoAlchemy2==0.10.0 datrie asyncpg
             else
                 sudo apt-get install -y -qq python3-icu python3-datrie python3-pyosmium python3-jinja2 python3-psutil python3-psycopg2 python3-dotenv python3-yaml
-                pip3 install sqlalchemy GeoAlchemy2 asyncpg
+                pip3 install sqlalchemy GeoAlchemy2 psycopg
             fi
           shell: bash
           env:

--- a/nominatim/db/async_core_library.py
+++ b/nominatim/db/async_core_library.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2023 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Import the base libary to use with asynchronous SQLAlchemy.
+"""
+# pylint: disable=invalid-name
+
+from typing import Any
+
+try:
+    import psycopg
+    PGCORE_LIB = 'psycopg'
+    PGCORE_ERROR: Any = psycopg.Error
+except ModuleNotFoundError:
+    import asyncpg
+    PGCORE_LIB = 'asyncpg'
+    PGCORE_ERROR = asyncpg.PostgresError


### PR DESCRIPTION
Starting with SQLAlchemy2 psycopg 3 can be used interchangably with asyncpg as the underlying asynchronous connector library to Postgresql. This adds support for running with psycopg 3 and also makes it the default as it is a tiny bit faster.