### PR TITLE
Parameterise the distance threshold for point searches

### DIFF
--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -438,6 +438,23 @@ NOMINATIM_TABLESPACE_AUX_INDEX
 :    Indexes on auxiliary data tables.
 
 
+#### NOMINATIM_SEARCH_DIAM
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Threshold distance for point searches |
+| **Format:**        | float |
+| **Default:**       | 0.006 |
+| **After Changes:** | run `nominatim refresh --website --functions` |
+
+When modified, it will affect the search for points with a search range
+greater than or equal to 16 (streets and buildings). It will represent
+the maximum distance a feature can be away from the search point to be returned.
+If no element is found, it will return "Unable to geocode".
+
+Since SRID 4326 is being used, the parameter unit will be decimal degrees.
+
+
 ### Replication Update Settings
 
 #### NOMINATIM_REPLICATION_URL
@@ -626,6 +643,27 @@ setting to restrict the number of geometry types that may be requested
 with a single query.
 
 Setting this parameter to 0 disables polygon output completely.
+
+
+#### NOMINATIM_SEARCH_ACCURACY
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Accuracy for search diameter |
+| **Format:**        | float |
+| **Default:**       | 1 |
+| **After Changes:** | run `nominatim refresh --website` |
+
+The accuracy with which the point search will be performed, varying the initial search
+diameter which depends on NOMINATIM_REVERSE_SEARCH_DIAM parameter. It will be a
+multiplicative factor from 0 to 1.
+
+With the value 0 the accuracy will be maximum since 0 will be multiplied by the search
+diameter and the distance between the point obtained from latitude and longitude will
+have to be less than or equal to 0.
+
+At value 1 the search distance will be the default one asociated to the search diameter.
+
 
 ### Logging Settings
 

--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -255,7 +255,7 @@ class ReverseGeocode
     {
         Debug::newFunction('lookupPoint');
         // Find the nearest point
-        $fSearchDiam = 0.006;
+        $fSearchDiam = CONST_Search_Diam;
         $oResult = null;
         $aPlace = null;
 

--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -129,7 +129,7 @@ class ReverseGeocode
                 $sSQL .= ' and indexed_status = 0 and linked_place_id is null';
                 $sSQL .= ' AND ST_Buffer(geometry, reverse_place_diameter(rank_search)) && '.$sPointSQL;
                 $sSQL .= ') as a ';
-                $sSQL .= 'WHERE distance <= reverse_place_diameter(rank_search)';
+                $sSQL .= 'WHERE distance <= ('.CONST_ReverseSearchAccuracy.' * reverse_place_diameter(rank_search))';
                 $sSQL .= ' ORDER BY rank_search DESC, distance ASC';
                 $sSQL .= ' LIMIT 1';
                 Debug::printSQL($sSQL);
@@ -227,7 +227,7 @@ class ReverseGeocode
                 $sSQL .= ' ORDER BY rank_search DESC, distance ASC';
                 $sSQL .= ' limit 100) as a';
                 $sSQL .= ' WHERE ST_Contains((SELECT geometry FROM placex WHERE place_id = '.$iPlaceID.'), geometry )';
-                $sSQL .= ' AND distance <= reverse_place_diameter(rank_search)';
+                $sSQL .= ' AND distance <= ('.CONST_ReverseSearchAccuracy. '* reverse_place_diameter(rank_search))';
                 $sSQL .= ' ORDER BY rank_search DESC, distance ASC';
                 $sSQL .= ' LIMIT 1';
                 Debug::printSQL($sSQL);
@@ -255,7 +255,7 @@ class ReverseGeocode
     {
         Debug::newFunction('lookupPoint');
         // Find the nearest point
-        $fSearchDiam = CONST_Search_Diam;
+        $fSearchDiam = CONST_ReverseSearchAccuracy * CONST_ReverseSearchDiam;
         $oResult = null;
         $aPlace = null;
 

--- a/lib-php/admin/warm.php
+++ b/lib-php/admin/warm.php
@@ -41,6 +41,8 @@ loadSettings($aCMDResult['project-dir'] ?? getcwd());
 @define('CONST_Use_US_Tiger_Data', getSettingBool('USE_US_TIGER_DATA'));
 @define('CONST_MapIcon_URL', getSetting('MAPICON_URL', false));
 @define('CONST_TokenizerDir', CONST_InstallDir.'/tokenizer');
+@define('CONST_ReverseSearchDiam', getSetting('REVERSE_SEARCH_DIAM', 0.006));
+@define('CONST_ReverseSearchAccuracy', getSetting('REVERSE_SEARCH_ACCURACY', 1));
 
 require_once(CONST_LibDir.'/Geocode.php');
 

--- a/lib-sql/functions/ranking.sql
+++ b/lib-sql/functions/ranking.sql
@@ -13,20 +13,20 @@ CREATE OR REPLACE FUNCTION reverse_place_diameter(rank_search SMALLINT)
   AS $$
 BEGIN
   IF rank_search <= 4 THEN
-    RETURN 5.0;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 250;
   ELSIF rank_search <= 8 THEN
-    RETURN 1.8;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 90;
   ELSIF rank_search <= 12 THEN
-    RETURN 0.6;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 30;
   ELSIF rank_search <= 17 THEN
-    RETURN 0.16;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 8;
   ELSIF rank_search <= 18 THEN
-    RETURN 0.08;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 4;
   ELSIF rank_search <= 19 THEN
-    RETURN 0.04;
+    RETURN  {{config.REVERSE_SEARCH_DIAM}}  * 2;
   END IF;
 
-  RETURN 0.02;
+  RETURN  {{config.REVERSE_SEARCH_DIAM}} ;
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE;

--- a/nominatim/tools/refresh.py
+++ b/nominatim/tools/refresh.py
@@ -120,7 +120,8 @@ PHP_CONST_DEFS = (
     ('Search_NameOnlySearchFrequencyThreshold', 'SEARCH_NAME_ONLY_THRESHOLD', str),
     ('Use_US_Tiger_Data', 'USE_US_TIGER_DATA', bool),
     ('MapIcon_URL', 'MAPICON_URL', str),
-    ('Search_Diam', 'SEARCH_DIAM', float),
+    ('ReverseSearchDiam', 'REVERSE_SEARCH_DIAM', float),
+    ('ReverseSearchAccuracy', 'REVERSE_SEARCH_ACCURACY', float),
 )
 
 

--- a/nominatim/tools/refresh.py
+++ b/nominatim/tools/refresh.py
@@ -120,6 +120,7 @@ PHP_CONST_DEFS = (
     ('Search_NameOnlySearchFrequencyThreshold', 'SEARCH_NAME_ONLY_THRESHOLD', str),
     ('Use_US_Tiger_Data', 'USE_US_TIGER_DATA', bool),
     ('MapIcon_URL', 'MAPICON_URL', str),
+    ('Search_Diam', 'SEARCH_DIAM', float),
 )
 
 
@@ -195,6 +196,9 @@ def _quote_php_variable(var_type: Type[Any], config: Configuration,
         return 'true' if config.get_bool(conf_name) else 'false'
 
     if var_type == int:
+        return cast(str, getattr(config, conf_name))
+
+    if var_type == float:
         return cast(str, getattr(config, conf_name))
 
     if not getattr(config, conf_name):

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -138,6 +138,12 @@ NOMINATIM_TABLESPACE_AUX_DATA=
 # Tablespace for indexes for auxilary data, e.g. TIGER data, postcodes.
 NOMINATIM_TABLESPACE_AUX_INDEX=
 
+# When modified, it will affect the search for points with a search range
+# greater than or equal to 16 (streets and buildings). It will represent 
+# the maximum distance a feature can be away from the search point to be returned.
+# If no element is found, it will return "Unable to geocode".
+NOMINATIM_REVERSE_SEARCH_DIAM = 0.006
+
 
 ### Replication settings
 #
@@ -197,11 +203,6 @@ NOMINATIM_SEARCH_BATCH_MODE=no
 # against the name, otherwise it uses indexes for name and address.
 NOMINATIM_SEARCH_NAME_ONLY_THRESHOLD=500
 
-# Threshold distance for point searches
-# If a point of the sea relatively far from the coast was selected, it will 
-# return the error "Unable to geocode".
-NOMINATIM_SEARCH_DIAM = 0.006
-
 # Maximum number of OSM ids accepted by /lookup.
 NOMINATIM_LOOKUP_MAX_COUNT=50
 
@@ -213,6 +214,17 @@ NOMINATIM_POLYGON_OUTPUT_MAX_TYPES=1
 # When running one of the Python enignes, they will add endpoint aliases
 # under <endpoint>.php
 NOMINATIM_SERVE_LEGACY_URLS=yes
+
+# The accuracy with which the point search will be performed, varying the initial search
+# diameter which depends on NOMINATIM_REVERSE_SEARCH_DIAM parameter. It will be a
+# multiplicative factor from 0 to 1.
+# 
+# With the value 0 the accuracy will be maximum since 0 will be multiplied by the search
+# diameter and the distance between the point obtained from latitude and longitude will
+# have to be less than or equal to 0.
+#
+# At value 1 the search distance will be the default one asociated to the search diameter.
+NOMINATIM_REVERSE_SEARCH_ACCURACY = 1
 
 ### Log settings
 #

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -197,6 +197,11 @@ NOMINATIM_SEARCH_BATCH_MODE=no
 # against the name, otherwise it uses indexes for name and address.
 NOMINATIM_SEARCH_NAME_ONLY_THRESHOLD=500
 
+# Threshold distance for point searches
+# If a point of the sea relatively far from the coast was selected, it will 
+# return the error "Unable to geocode".
+NOMINATIM_SEARCH_DIAM = 0.006
+
 # Maximum number of OSM ids accepted by /lookup.
 NOMINATIM_LOOKUP_MAX_COUNT=50
 


### PR DESCRIPTION
Modify $fSearchDiam so it can be a env parameter. If a point of the sea relatively far from the coast was selected, it will return the error "Unable to geocode".