### PR TITLE
Parameterise the search only within countries

### DIFF
--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -627,6 +627,23 @@ with a single query.
 
 Setting this parameter to 0 disables polygon output completely.
 
+
+#### NOMINATIM_SEARCH_WITHIN_COUNTRIES
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Disable search for elements that are not in the country grid |
+| **Format:**        | boolean |
+| **Default:**       | no |
+| **After Changes:** | run `nominatim refresh --website` |
+
+Enable to search elements just within countries.
+
+When enabled, if, despite not finding a point within the static grid of countries, it
+finds a geometry of a region, do not return the geometry.
+Return "Unable to geocode" instead.
+
+
 ### Logging Settings
 
 #### NOMINATIM_LOG_DB

--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -85,6 +85,11 @@ class ReverseGeocode
 
     protected function lookupLargeArea($sPointSQL, $iMaxRank)
     {
+        if(CONST_Search_WithinCountries
+            and $this->lookupInCountry($sPointSQL, $iMaxRank) == null){
+                return  null;
+        }
+
         if ($iMaxRank > 4) {
             $aPlace = $this->lookupPolygon($sPointSQL, $iMaxRank);
             if ($aPlace) {

--- a/lib-php/ReverseGeocode.php
+++ b/lib-php/ReverseGeocode.php
@@ -85,9 +85,9 @@ class ReverseGeocode
 
     protected function lookupLargeArea($sPointSQL, $iMaxRank)
     {
-        if(CONST_Search_WithinCountries
-            and $this->lookupInCountry($sPointSQL, $iMaxRank) == null){
-                return  null;
+        $sCountryCode = $this->getCountryCode($sPointSQL);
+        if (CONST_Search_WithinCountries and $sCountryCode == null) {
+            return  null;
         }
 
         if ($iMaxRank > 4) {
@@ -99,12 +99,12 @@ class ReverseGeocode
 
         // If no polygon which contains the searchpoint is found,
         // searches in the country_osm_grid table for a polygon.
-        return  $this->lookupInCountry($sPointSQL, $iMaxRank);
+        return  $this->lookupInCountry($sPointSQL, $iMaxRank, $sCountryCode);
     }
 
-    protected function lookupInCountry($sPointSQL, $iMaxRank)
+    protected function getCountryCode($sPointSQL)
     {
-        Debug::newFunction('lookupInCountry');
+        Debug::newFunction('getCountryCode');
         // searches for polygon in table country_osm_grid which contains the searchpoint
         // and searches for the nearest place node to the searchpoint in this polygon
         $sSQL = 'SELECT country_code FROM country_osm_grid';
@@ -116,8 +116,12 @@ class ReverseGeocode
             null,
             'Could not determine country polygon containing the point.'
         );
-        Debug::printVar('Country code', $sCountryCode);
+        return $sCountryCode;
+    }
 
+    protected function lookupInCountry($sPointSQL, $iMaxRank, $sCountryCode)
+    {
+        Debug::newFunction('lookupInCountry');
         if ($sCountryCode) {
             if ($iMaxRank > 4) {
                 // look for place nodes with the given country code

--- a/lib-php/admin/warm.php
+++ b/lib-php/admin/warm.php
@@ -41,6 +41,7 @@ loadSettings($aCMDResult['project-dir'] ?? getcwd());
 @define('CONST_Use_US_Tiger_Data', getSettingBool('USE_US_TIGER_DATA'));
 @define('CONST_MapIcon_URL', getSetting('MAPICON_URL', false));
 @define('CONST_TokenizerDir', CONST_InstallDir.'/tokenizer');
+@define('CONST_Search_WithinCountries', getSetting('SEARCH_WITHIN_COUNTRIES', false));
 
 require_once(CONST_LibDir.'/Geocode.php');
 

--- a/nominatim/tools/refresh.py
+++ b/nominatim/tools/refresh.py
@@ -120,6 +120,7 @@ PHP_CONST_DEFS = (
     ('Search_NameOnlySearchFrequencyThreshold', 'SEARCH_NAME_ONLY_THRESHOLD', str),
     ('Use_US_Tiger_Data', 'USE_US_TIGER_DATA', bool),
     ('MapIcon_URL', 'MAPICON_URL', str),
+    ('Search_WithinCountries', 'SEARCH_WITHIN_COUNTRIES', bool),
 )
 
 

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -214,6 +214,12 @@ NOMINATIM_SERVE_LEGACY_URLS=yes
 # of connections _per worker_.
 NOMINATIM_API_POOL_SIZE=10
 
+# Search elements just within countries
+# If, despite not finding a point within the static grid of countries, it
+# finds a geometry of a region, do not return the geometry. Return "Unable
+# to geocode" instead.
+NOMINATIM_SEARCH_WITHIN_COUNTRIES=False
+
 ### Log settings
 #
 # The following options allow to enable logging of API requests.


### PR DESCRIPTION
If, despite not finding a point within the static grid of countries, it finds a geometry of a region, do not return the geometry. Return "Unable to geocode" instead. By default this parameter is False for Nominating to work as before.