### PR TITLE
Fix merging of linked names into unnamed boundaries

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -88,12 +88,18 @@ BEGIN
       -- Add all names from the place nodes that deviate from the name
       -- in the relation with the prefix '_place_'. Deviation means that
       -- either the value is different or a given key is missing completely
-      SELECT hstore(array_agg('_place_' || key), array_agg(value)) INTO extra_names
-        FROM each(location.name - result.name);
-      {% if debug %}RAISE WARNING 'Extra names: %', extra_names;{% endif %}
+      IF result.name is null THEN
+        SELECT hstore(array_agg('_place_' || key), array_agg(value))
+          INTO result.name
+          FROM each(location.name);
+      ELSE
+        SELECT hstore(array_agg('_place_' || key), array_agg(value)) INTO extra_names
+          FROM each(location.name - result.name);
+        {% if debug %}RAISE WARNING 'Extra names: %', extra_names;{% endif %}
 
-      IF extra_names is not null THEN
-          result.name := result.name || extra_names;
+        IF extra_names is not null THEN
+            result.name := result.name || extra_names;
+        END IF;
       END IF;
 
       {% if debug %}RAISE WARNING 'Final names: %', result.name;{% endif %}

--- a/test/bdd/db/import/linking.feature
+++ b/test/bdd/db/import/linking.feature
@@ -290,3 +290,23 @@ Feature: Linking of places
          | R1     | 'linked_place' : 'city', 'wikidata': 'Q1234'  |
          | R2     | 'wikidata': 'Q1234'                     |
 
+
+    Scenario: Boundaries without names inherit names from linked places
+        Given the 0.05 grid
+         | 1 |   | 2 |
+         |   | 9 |   |
+         | 4 |   | 3 |
+        Given the places
+         | osm | class    | type           | extra+wikidata | admin | geometry    |
+         | R1  | boundary | administrative | 34             | 8     | (1,2,3,4,1) |
+        And the places
+         | osm | class    | type           | name+name  |
+         | N9  | place    | city           | LabelPlace |
+        And the relations
+         | id | members  |
+         | 1  | N9:label |
+        When importing
+        Then placex contains
+         | object     | name+_place_name  |
+         | R1         | LabelPlace |
+


### PR DESCRIPTION
When merging names of linked places into the list of names of a boundary which has no names itself, the result was still an empty list because in SQL most operations that involve a NULL operator have a NULL result.