### PR TITLE
These days the OSM wikipedia tab no longer contains URLs

### DIFF
--- a/lib-sql/functions/importance.sql
+++ b/lib-sql/functions/importance.sql
@@ -62,10 +62,6 @@ BEGIN
   WHILE langs[i] IS NOT NULL LOOP
     wiki_article := extratags->(case when langs[i] in ('english','country') THEN 'wikipedia' ELSE 'wikipedia:'||langs[i] END);
     IF wiki_article is not null THEN
-      wiki_article := regexp_replace(wiki_article,E'^(.*?)([a-z]{2,3}).wikipedia.org/wiki/',E'\\2:');
-      wiki_article := regexp_replace(wiki_article,E'^(.*?)([a-z]{2,3}).wikipedia.org/w/index.php\\?title=',E'\\2:');
-      wiki_article := regexp_replace(wiki_article,E'^(.*?)/([a-z]{2,3})/wiki/',E'\\2:');
-      --wiki_article := regexp_replace(wiki_article,E'^(.*?)([a-z]{2,3})[=:]',E'\\2:');
       wiki_article := replace(wiki_article,' ','_');
       IF strpos(wiki_article, ':') IN (3,4) THEN
         wiki_article_language := lower(trim(split_part(wiki_article, ':', 1)));


### PR DESCRIPTION
I believe supporting Wikipedia values containing URLs is no longer needed.

Out of 1.7m values in OSM planet only 68 contain either 'http' or 'https'. 3 contain 'wikipedia.org', 21 '/wiki/', 517 don't contain any colon. Together less than 0.03%. I'd consider them all data errors. For example language prefix forgotten, ; instead of :, wikidata ids.

The `lower(trim(` on the `wiki_article_language` is probably also not needed. I found only 5 values where the language was uppercase, none with spaces.
