### PR TITLE
Do not allow to mix structured and unstructured search

### DIFF
--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -508,9 +508,8 @@ class TestSearchEndPointSearch:
         a.params['q'] = 'something'
         a.params['city'] = 'ignored'
 
-        res = await glue.search_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
-
-        assert len(json.loads(res.output)) == 1
+        with pytest.raises(FakeError, match='^400 -- .*cannot be used together'):
+            res = await glue.search_endpoint(napi.NominatimAPIAsync(Path('/invalid')), a)
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Until now Nominatim would simply ignore structured parameters when 'q' was present. This may have led to unexpected results. This changes the API to return an error in such a case, so the user is aware that part of their query is being ignored.

See #3136 for background.