### PR TITLE
Added a module to split Japanese words

### DIFF
--- a/nominatim/api/search/icu_tokenizer.py
+++ b/nominatim/api/search/icu_tokenizer.py
@@ -217,16 +217,6 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                                   for p in phrases)))
         return normalized
 
-    def split_key_japanese_phrases(
-        self, phrases: List[qmod.Phrase]
-    ) -> List[qmod.Phrase]:
-        """Split a Japanese address using japanese_tokenizer.
-        """
-        splited_address = list(filter(lambda p: p.text,
-                                (qmod.Phrase(p.ptype, icu_tokenizer_japanese.transliterate(p.text))
-                                for p in phrases)))
-        return splited_address
-
     def split_query(self, query: qmod.QueryStruct) -> Tuple[QueryParts, WordDict]:
         """ Transliterate the phrases and split them into tokens.
 

--- a/nominatim/api/search/icu_tokenizer_japanese.py
+++ b/nominatim/api/search/icu_tokenizer_japanese.py
@@ -1,0 +1,67 @@
+# from nominatim.tokenizer.sanitizers.tag_japanese import convert_kanji_sequence_to_number
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2023 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+This file divides Japanese addresses into three categories:
+prefecture, municipality, and other.
+The division is not strict but simple using these keywords.
+Based on this division, icu_tokenizer.py inserts
+a SOFT_PHRASE break between the divided words 
+and penalizes the words with this SOFT_PHRASE
+to lower the search priority.
+"""
+import re
+from typing import List
+from nominatim.api.search import query as qmod
+
+def transliterate(text: str) -> str:
+    """
+    This function performs a division on the given text using a regular expression.
+    """
+    pattern_full = r'''
+               (...??[都道府県])            # [group1] prefecture
+               (.+?[市区町村])              # [group2] municipalities (city/wards/towns/villages)
+               (.+)                         # [group3] other words
+               '''
+    pattern_1 = r'''
+               (...??[都道府県])            # [group1] prefecture
+               (.+)                         # [group3] other words
+               '''
+    pattern_2 = r'''
+               (.+?[市区町村])              # [group2] municipalities (city/wards/towns/villages)
+               (.+)                         # [group3] other words
+               '''
+    result_full = re.match(pattern_full, text, re.VERBOSE)
+    result_1 = re.match(pattern_1, text, re.VERBOSE)
+    result_2 = re.match(pattern_2, text, re.VERBOSE)
+    if result_full is not None:
+        joined_group = ''.join([
+                                result_full.group(1),
+                                ', ',
+                                result_full.group(2),
+                                ', ',
+                                result_full.group(3)
+                               ])
+        return joined_group
+    if result_1 is not None:
+        joined_group = ''.join([result_1.group(1),', ',result_1.group(2)])
+        return joined_group
+    if result_2 is not None:
+        joined_group = ''.join([result_2.group(1),', ',result_2.group(2)])
+        return joined_group
+    return text
+
+def split_key_japanese_phrases(
+    phrases: List[qmod.Phrase]
+) -> List[qmod.Phrase]:
+    """Split a Japanese address using japanese_tokenizer.
+    """
+    splited_address = list(filter(lambda p: p.text,
+                            (qmod.Phrase(p.ptype, transliterate(p.text))
+                            for p in phrases)))
+    return splited_address

--- a/nominatim/api/search/query.py
+++ b/nominatim/api/search/query.py
@@ -29,6 +29,7 @@ class BreakType(enum.Enum):
     """ Break created as a result of tokenization.
         This may happen in languages without spaces between words.
     """
+    SOFT_PHRASE = ':'
 
 
 class TokenType(enum.Enum):

--- a/nominatim/api/search/query.py
+++ b/nominatim/api/search/query.py
@@ -30,7 +30,11 @@ class BreakType(enum.Enum):
         This may happen in languages without spaces between words.
     """
     SOFT_PHRASE = ':'
-
+    """ Break created as a result of a module of Japanese tokenization
+        (icu_tokenizer_japanese.py).
+        This may happen between the words administrative divisions:
+        cities, municipalities, and below.
+    """
 
 class TokenType(enum.Enum):
     """ Type of token.

--- a/nominatim/api/search/token_assignment.py
+++ b/nominatim/api/search/token_assignment.py
@@ -30,7 +30,8 @@ PENALTY_TOKENCHANGE = {
     qmod.BreakType.PHRASE: 0.0,
     qmod.BreakType.WORD: 0.1,
     qmod.BreakType.PART: 0.2,
-    qmod.BreakType.TOKEN: 0.4
+    qmod.BreakType.TOKEN: 0.4,
+    qmod.BreakType.SOFT_PHRASE: 0.0
 }
 
 TypedRangeSeq = List[TypedRange]

--- a/test/python/api/search/test_icu_japanese_query_analyzer.py
+++ b/test/python/api/search/test_icu_japanese_query_analyzer.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2023 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for query analyzer for ICU tokenizer.
+"""
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from nominatim.api import NominatimAPIAsync
+from nominatim.api.search.query import Phrase, PhraseType, BreakType
+import nominatim.api.search.icu_tokenizer as tok
+
+async def add_word(conn, word_id, word_token, wtype, word, info = None):
+    t = conn.t.meta.tables['word']
+    await conn.execute(t.insert(), {'word_id': word_id,
+                                    'word_token': word_token,
+                                    'type': wtype,
+                                    'word': word,
+                                    'info': info})
+
+
+def make_phrase(query):
+    return [Phrase(PhraseType.NONE, s) for s in query.split(',')]
+@pytest_asyncio.fixture
+async def conn(table_factory):
+    """ Create an asynchronous SQLAlchemy engine for the test DB.
+    """
+    table_factory('nominatim_properties',
+                  definition='property TEXT, value TEXT',
+                  content=(('tokenizer_import_normalisation', ':: lower();'),
+                           ('tokenizer_import_transliteration', "'1' > '/1/'; 'ä' > 'ä '")))
+    table_factory('word',
+                  definition='word_id INT, word_token TEXT, type TEXT, word TEXT, info JSONB')
+
+    api = NominatimAPIAsync(Path('/invalid'), {})
+    async with api.begin() as conn:
+        yield conn
+    await api.close()
+@pytest.mark.asyncio
+async def test_soft_phrase(conn):
+    ana = await tok.create_query_analyzer(conn)
+
+    await add_word(conn, 100, 'da', 'w', None)
+    await add_word(conn, 101, 'ban', 'w', None)
+    await add_word(conn, 102, 'fu', 'w', None)
+    await add_word(conn, 103, 'shi', 'w', None)
+
+    await add_word(conn, 1, 'da ban fu', 'W', '大阪府')
+    await add_word(conn, 2, 'da ban shi', 'W', '大阪市')
+    await add_word(conn, 3, 'da ban', 'W', '大阪')
+    query = await ana.analyze_query(make_phrase('大阪府大阪市大阪'))
+    assert query.nodes[0].btype == BreakType.START
+    assert query.nodes[1].btype == BreakType.SOFT_PHRASE
+    assert query.nodes[2].btype == BreakType.SOFT_PHRASE
+    assert query.nodes[3].btype == BreakType.END
+
+    query2 = await ana.analyze_query(make_phrase('大阪府大阪'))
+    assert query2.nodes[1].btype == BreakType.SOFT_PHRASE
+
+    query3 = await ana.analyze_query(make_phrase('大阪市大阪'))
+    assert query3.nodes[1].btype == BreakType.SOFT_PHRASE
+
+@pytest.mark.asyncio
+async def test_penalty_soft_phrase(conn):
+    ana = await tok.create_query_analyzer(conn)
+
+    await add_word(conn, 104, 'da', 'w', 'da')
+    await add_word(conn, 105, 'ban', 'w', 'ban')
+    await add_word(conn, 107, 'shi', 'w', 'shi')
+    
+    await add_word(conn, 2, 'da ban shi', 'W', '大阪市')
+    await add_word(conn, 3, 'da ban', 'W', '大阪')
+    await add_word(conn, 4, 'da ban shi da ban', 'W', '大阪市大阪')
+    
+    query = await ana.analyze_query(make_phrase('da ban shi da ban'))
+    
+    torder = [(tl.tokens[0].penalty, tl.tokens[0].lookup_word) for tl in query.nodes[0].starting]
+    torder.sort()
+
+    assert torder[-1][-1] == '大阪市大阪'


### PR DESCRIPTION
In these codes, Japanese addresses are divided into three categories based on administrative divisions: cities, municipalities, and below.
Nominatim uses ICU (International Components for Unicode) transliteration for user-entered addresses to split them into meaningful words. Here is an example of debugging. There are many candidates.
![image](https://github.com/osm-search/Nominatim/assets/50738317/95efbe7f-907f-46d6-a2c1-cef63c7c81a7)
Fig. 1 The example of debugging.

To help make this division more accurate, when there are large administrative divisions (prefecture and city) in the string, we pre-separate them in the algorithm and put "," markers between the split words. 
This "," is set to BreakType.SOFT_PHRASE in the program and words with this node are penalized with a lower search priority.
The node relationship is as follows
(1)--da->(2)--ban->(3)--shi->(4)--da->(5)--ban->(6)
||                          　　　　^^                                  ||
|+------大阪市--------------+ +-------大阪--------+|
+-------------------大阪市大阪---------------------+

As a result of this change, "大阪市大阪" with SOFT_PHRASE is penalized more and given lower search priority than "大阪市", the name of a city (the fifth value from the left is the penalty value).
![image](https://github.com/osm-search/Nominatim/assets/50738317/e83e84ed-a181-47fe-995b-2fcdeb0ff818)
Fig. 2 Before the change.
![image](https://github.com/osm-search/Nominatim/assets/50738317/4de27430-4533-4a6e-9739-49adb5e33624)
Fig. 3 After the change.