### PR TITLE
Fix name lookup for housenames

### DIFF
--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -273,8 +273,8 @@ BEGIN
   END IF;
 
   RETURN ST_Envelope(ST_Collect(
-                     ST_Project(geom, radius, 0.785398)::geometry,
-                     ST_Project(geom, radius, 3.9269908)::geometry));
+                     ST_Project(geom::geography, radius, 0.785398)::geometry,
+                     ST_Project(geom::geography, radius, 3.9269908)::geometry));
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE;

--- a/nominatim/api/reverse.py
+++ b/nominatim/api/reverse.py
@@ -87,7 +87,7 @@ def _locate_interpolation(table: SaFromClause) -> SaLabel:
 def _is_address_point(table: SaFromClause) -> SaColumn:
     return sa.and_(table.c.rank_address == 30,
                    sa.or_(table.c.housenumber != None,
-                          table.c.name.has_key('housename')))
+                          table.c.name.has_key('addr:housename')))
 
 
 def _get_closest(*rows: Optional[SaRow]) -> Optional[SaRow]:

--- a/nominatim/api/search/db_searches.py
+++ b/nominatim/api/search/db_searches.py
@@ -111,7 +111,7 @@ def _filter_by_layer(table: SaFromClause, layers: DataLayer) -> SaColumn:
         orexpr.append(table.c.rank_address.between(1, 29))
         orexpr.append(sa.and_(table.c.rank_address == 30,
                               sa.or_(table.c.housenumber != None,
-                                     table.c.address.has_key('housename'))))
+                                     table.c.address.has_key('addr:housename'))))
     elif layers & DataLayer.POI:
         orexpr.append(sa.and_(table.c.rank_address == 30,
                               table.c.class_.not_in(('place', 'building'))))

--- a/test/python/api/test_api_reverse.py
+++ b/test/python/api/test_api_reverse.py
@@ -60,7 +60,8 @@ def test_reverse_ignore_unindexed(apiobj):
                                               (0.7, napi.DataLayer.RAILWAY, 226),
                                               (0.7, napi.DataLayer.NATURAL, 227),
                                               (0.70003, napi.DataLayer.MANMADE | napi.DataLayer.RAILWAY, 225),
-                                              (0.70003, napi.DataLayer.MANMADE | napi.DataLayer.NATURAL, 225)])
+                                              (0.70003, napi.DataLayer.MANMADE | napi.DataLayer.NATURAL, 225),
+                                              (5, napi.DataLayer.ADDRESS, 229)])
 def test_reverse_rank_30_layers(apiobj, y, layer, place_id):
     apiobj.add_placex(place_id=223, class_='place', type='house',
                       housenumber='1',
@@ -83,6 +84,11 @@ def test_reverse_rank_30_layers(apiobj, y, layer, place_id):
                       rank_address=0,
                       rank_search=30,
                       centroid=(1.3, 0.70005))
+    apiobj.add_placex(place_id=229, class_='place', type='house',
+                      name={'addr:housename': 'Old Cottage'},
+                      rank_address=30,
+                      rank_search=30,
+                      centroid=(1.3, 5))
 
     assert apiobj.api.reverse((1.3, y), layers=layer).place_id == place_id
 


### PR DESCRIPTION
This fixes a regression where addresses that have a house name in place of a housenumber were no longer considered addresses.

Also fixes a compatibility issue with the latest Postgis 3.4 release. The ST_Project function has changed behaviour for geometries.