### PR TITLE
Send explicit charset in content-type when returning json

### DIFF
--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -67,7 +67,7 @@ def test_adaptor_parse_format_use_configured():
     adaptor = FakeAdaptor(params={'format': 'json'})
 
     assert adaptor.parse_format(napi.StatusResult, 'text') == 'json'
-    assert adaptor.content_type == 'application/json'
+    assert adaptor.content_type == 'application/json; charset=utf-8'
 
 
 def test_adaptor_parse_format_invalid_value():
@@ -132,7 +132,7 @@ class TestAdaptorRaiseError:
 
 
     def test_json(self):
-        self.adaptor.content_type = 'application/json'
+        self.adaptor.content_type = 'application/json; charset=utf-8'
 
         err = self.run_raise_error('TEST', 501)
 
@@ -189,7 +189,7 @@ def test_build_response_with_status():
     assert isinstance(resp, FakeResponse)
     assert resp.status == 404
     assert resp.output == 'stuff\nmore stuff'
-    assert resp.content_type == 'application/json'
+    assert resp.content_type == 'application/json; charset=utf-8'
 
 
 def test_build_response_jsonp_with_json():
@@ -201,7 +201,7 @@ def test_build_response_jsonp_with_json():
     assert isinstance(resp, FakeResponse)
     assert resp.status == 200
     assert resp.output == 'test.func({})'
-    assert resp.content_type == 'application/javascript'
+    assert resp.content_type == 'application/javascript; charset=utf-8'
 
 
 def test_build_response_jsonp_without_json():
@@ -270,7 +270,7 @@ class TestStatusEndpoint:
 
         assert isinstance(resp, FakeResponse)
         assert resp.status == 200
-        assert resp.content_type == 'application/json'
+        assert resp.content_type == 'application/json; charset=utf-8'
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The PHP code used to send a content type of 'application/json; charset=utf-8', i.e. with an explicit encoding specification. Neither falcon nor starlette do this for their default content types. The reasoning being that json is utf-8 per definition.

Turns out there are quite a few applications out there that will use some local encoding when the charset is not explicitly given. So lets be nice to those applications and bring the charset back.