### PR TITLE
Further tweak detection of queries that would return a massive amount of results

### DIFF
--- a/nominatim/api/search/db_search_fields.py
+++ b/nominatim/api/search/db_search_fields.py
@@ -224,14 +224,15 @@ def lookup_by_names(name_tokens: List[int], addr_tokens: List[int]) -> List[Fiel
     return lookup
 
 
-def lookup_by_any_name(name_tokens: List[int], addr_tokens: List[int]) -> List[FieldLookup]:
+def lookup_by_any_name(name_tokens: List[int], addr_tokens: List[int],
+                       lookup_type: str) -> List[FieldLookup]:
     """ Create a lookup list where name tokens are looked up via index
         and only one of the name tokens must be present.
         Potential address tokens are used to restrict the search further.
     """
     lookup = [FieldLookup('name_vector', name_tokens, 'lookup_any')]
     if addr_tokens:
-        lookup.append(FieldLookup('nameaddress_vector', addr_tokens, 'restrict'))
+        lookup.append(FieldLookup('nameaddress_vector', addr_tokens, lookup_type))
 
     return lookup
 


### PR DESCRIPTION
The search code has some protection mechanisms to avoid queries that would return a lot of results. This works well for such underspecified queries as 'main st' or 'de la' but it unfortunately also triggers for properly formulated queries like 'main st, stockton'.

The problematic part for these queries is not so much the large amount of results but the fact that all queries have an 'ORDER BY' over the accuracy (the measure how well the result fits the query). So when handling these queries, Postgres needs to compute this measure over all results, sort and return the n best ones.

This PR changes the mechanism to switch of the ORDER BY for queries where there are too many results expected. You'd still get results but simply a random matching set, not necessarily the best matching set.

This change is not entirely unproblematic. After removing the ORDER BY clause, the Postgres query planner is then convinced that it is faster to scan the entire 90GB search_name table than to use our lean 6GB index. Fixing that properly requires to restructure the search_name table. For now, ***if you apply this change, you must increase the seq_page_cost parameter in Postgres***. A value of 3.0 seems to do work okay.

Fixes #3163.