### PR TITLE
Introduce timeouts for queries

### DIFF
--- a/nominatim/api/connection.py
+++ b/nominatim/api/connection.py
@@ -51,8 +51,7 @@ class SearchConnection:
         """ Execute a 'scalar()' query on the connection.
         """
         log().sql(self.connection, sql, params)
-        async with asyncio.timeout(self.query_timeout):
-            return await self.connection.scalar(sql, params)
+        return await asyncio.wait_for(self.connection.scalar(sql, params), self.query_timeout)
 
 
     async def execute(self, sql: 'sa.Executable',
@@ -61,8 +60,7 @@ class SearchConnection:
         """ Execute a 'execute()' query on the connection.
         """
         log().sql(self.connection, sql, params)
-        async with asyncio.timeout(self.query_timeout):
-            return await self.connection.execute(sql, params)
+        return await asyncio.wait_for(self.connection.execute(sql, params), self.query_timeout)
 
 
     async def get_property(self, name: str, cached: bool = True) -> str:

--- a/nominatim/api/connection.py
+++ b/nominatim/api/connection.py
@@ -9,6 +9,7 @@ Extended SQLAlchemy connection class that also includes access to the schema.
 """
 from typing import cast, Any, Mapping, Sequence, Union, Dict, Optional, Set, \
                    Awaitable, Callable, TypeVar
+import asyncio
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -34,6 +35,14 @@ class SearchConnection:
         self.t = tables # pylint: disable=invalid-name
         self._property_cache = properties
         self._classtables: Optional[Set[str]] = None
+        self.query_timeout: Optional[int] = None
+
+
+    def set_query_timeout(self, timeout: Optional[int]) -> None:
+        """ Set the timeout after which a query over this connection
+            is cancelled.
+        """
+        self.query_timeout = timeout
 
 
     async def scalar(self, sql: sa.sql.base.Executable,
@@ -42,7 +51,8 @@ class SearchConnection:
         """ Execute a 'scalar()' query on the connection.
         """
         log().sql(self.connection, sql, params)
-        return await self.connection.scalar(sql, params)
+        async with asyncio.timeout(self.query_timeout):
+            return await self.connection.scalar(sql, params)
 
 
     async def execute(self, sql: 'sa.Executable',
@@ -51,7 +61,8 @@ class SearchConnection:
         """ Execute a 'execute()' query on the connection.
         """
         log().sql(self.connection, sql, params)
-        return await self.connection.execute(sql, params)
+        async with asyncio.timeout(self.query_timeout):
+            return await self.connection.execute(sql, params)
 
 
     async def get_property(self, name: str, cached: bool = True) -> str:

--- a/nominatim/api/core.py
+++ b/nominatim/api/core.py
@@ -194,7 +194,9 @@ class NominatimAPIAsync:
 
         async with self.begin() as conn:
             conn.set_query_timeout(self.query_timeout)
-            geocoder = ForwardGeocoder(conn, ntyp.SearchDetails.from_kwargs(params))
+            geocoder = ForwardGeocoder(conn, ntyp.SearchDetails.from_kwargs(params),
+                                       self.config.get_int('REQUEST_TIMEOUT') \
+                                         if self.config.REQUEST_TIMEOUT else None)
             phrases = [Phrase(PhraseType.NONE, p.strip()) for p in query.split(',')]
             return await geocoder.lookup(phrases)
 
@@ -252,7 +254,9 @@ class NominatimAPIAsync:
                 if amenity:
                     details.layers |= ntyp.DataLayer.POI
 
-            geocoder = ForwardGeocoder(conn, details)
+            geocoder = ForwardGeocoder(conn, details,
+                                       self.config.get_int('REQUEST_TIMEOUT') \
+                                         if self.config.REQUEST_TIMEOUT else None)
             return await geocoder.lookup(phrases)
 
 
@@ -276,7 +280,9 @@ class NominatimAPIAsync:
                 if details.keywords:
                     await make_query_analyzer(conn)
 
-            geocoder = ForwardGeocoder(conn, details)
+            geocoder = ForwardGeocoder(conn, details,
+                                       self.config.get_int('REQUEST_TIMEOUT') \
+                                         if self.config.REQUEST_TIMEOUT else None)
             return await geocoder.lookup_pois(categories, phrases)
 
 

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -215,8 +215,14 @@ NOMINATIM_SERVE_LEGACY_URLS=yes
 NOMINATIM_API_POOL_SIZE=10
 
 # Timeout is seconds after which a single query to the database is cancelled.
+# The user receives a 503 response, when a query times out.
 # When empty, then timeouts are disabled.
-NOMINATIM_QUERY_TIMEOUT=60
+NOMINATIM_QUERY_TIMEOUT=10
+
+# Maximum time a single request is allowed to take. When the timeout is
+# exceeeded, the available results are returned.
+# When empty, then timouts are disabled.
+NOMINATIM_REQUEST_TIMEOUT=60
 
 # Search elements just within countries
 # If, despite not finding a point within the static grid of countries, it

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -214,6 +214,10 @@ NOMINATIM_SERVE_LEGACY_URLS=yes
 # of connections _per worker_.
 NOMINATIM_API_POOL_SIZE=10
 
+# Timeout is seconds after which a single query to the database is cancelled.
+# When empty, then timeouts are disabled.
+NOMINATIM_QUERY_TIMEOUT=60
+
 # Search elements just within countries
 # If, despite not finding a point within the static grid of countries, it
 # finds a geometry of a region, do not return the geometry. Return "Unable


### PR DESCRIPTION
Two timeouts are configurable: NOMINATIM_QUERY_TIMEOUT sets the maximum time a single DB query may take. Exceeding the timeout leads to an exception and a 503 being returned. NOMINATIM_REQUEST_TIMEOUT sets the maximum time a single request may sue to find a result. When this timeout is exceeded, the results gathered so far are returned.