### PR TITLE
Be more precise on what is deleted on updates

### DIFF
--- a/lib-sql/functions/place_triggers.sql
+++ b/lib-sql/functions/place_triggers.sql
@@ -37,7 +37,7 @@ BEGIN
   -- Remove the place from the list of places to be deleted
   DELETE FROM place_to_be_deleted pdel
     WHERE pdel.osm_type = NEW.osm_type and pdel.osm_id = NEW.osm_id
-          and pdel.class = NEW.class;
+          and pdel.class = NEW.class and pdel.type = NEW.type;
 
   -- Have we already done this place?
   SELECT * INTO existing

--- a/test/bdd/osm2pgsql/update/tags.feature
+++ b/test/bdd/osm2pgsql/update/tags.feature
@@ -488,3 +488,26 @@ Feature: Tag evaluation
         Then placex contains exactly
           | object       | type     | admin_level |
           | R10:boundary | informal | 4           |
+
+
+    Scenario: Main tag and geometry is changed
+        When loading osm data
+          """
+          n1 x40 y40
+          n2 x40.0001 y40
+          n3 x40.0001 y40.0001
+          n4 x40 y40.0001
+          w5 Tbuilding=house,name=Foo Nn1,n2,n3,n4,n1
+          """
+        Then place contains exactly
+          | object      | type  |
+          | W5:building | house |
+
+        When updating osm data
+          """
+          n1 x39.999 y40
+          w5 Tbuilding=terrace,name=Bar Nn1,n2,n3,n4,n1
+          """
+        Then place contains exactly
+          | object      | type    |
+          | W5:building | terrace |


### PR DESCRIPTION
Older osm2pgsql versions would send one delete and two inserts for ways and relations where the dependencies have changed. That trips the code part which removes items from the internal to-be-deleted list. The result is that older data wasn't deleted. Recent osm2pgsql only send the insert once but we want the code to be robust anyway.

Note that due to this bug the production servers currently have about 1.3M duplications. Time for a reimport.

Fixes #3168.