### PR TITLE
Make tablespace arguments work again for flex tables

### DIFF
--- a/nominatim/tools/exec_utils.py
+++ b/nominatim/tools/exec_utils.py
@@ -57,6 +57,11 @@ def run_osm2pgsql(options: Mapping[str, Any]) -> None:
         if options['tablespaces'][key]:
             cmd.extend((param, options['tablespaces'][key]))
 
+    if options['tablespaces']['main_data']:
+        env['NOMINATIM_TABLESPACE_PLACE_DATA'] = options['tablespaces']['main_data']
+    if options['tablespaces']['main_index']:
+        env['NOMINATIM_TABLESPACE_PLACE_INDEX'] = options['tablespaces']['main_index']
+
     if options.get('disable_jit', False):
         env['PGOPTIONS'] = '-c jit=off -c max_parallel_workers_per_gather=0'
 

--- a/settings/flex-base.lua
+++ b/settings/flex-base.lua
@@ -30,6 +30,8 @@ local place_table = osm2pgsql.define_table{
         { column = 'extratags', type = 'hstore' },
         { column = 'geometry', type = 'geometry', projection = 'WGS84', not_null = true },
     },
+    data_tablespace = os.getenv("NOMINATIM_TABLESPACE_PLACE_DATA"),
+    index_tablespace = os.getenv("NOMINATIM_TABLESPACE_PLACE_INDEX"),
     indexes = {}
 }
 


### PR DESCRIPTION
When using flex table, the mechanism of handing in the table space arguments for osm2pgsql via the command line does not work anymore. Use environment variables instead which are then read in the lua script.