### PR TITLE
Make sure the place name always comes first in output

### DIFF
--- a/nominatim/api/results.py
+++ b/nominatim/api/results.py
@@ -491,24 +491,6 @@ def _result_row_to_address_row(row: SaRow, isaddress: Optional[bool] = None) -> 
                        distance=row.distance)
 
 
-def _get_housenumber_details(results: List[BaseResultT]) -> Tuple[List[int], List[int]]:
-    places = []
-    hnrs = []
-    for result in results:
-        if result.place_id:
-            housenumber = -1
-            if result.source_table in (SourceTable.TIGER, SourceTable.OSMLINE):
-                if result.housenumber is not None:
-                    housenumber = int(result.housenumber)
-                elif result.extratags is not None and 'startnumber' in result.extratags:
-                    # details requests do not come with a specific house number
-                    housenumber = int(result.extratags['startnumber'])
-            places.append(result.place_id)
-            hnrs.append(housenumber)
-
-    return places, hnrs
-
-
 def _get_address_lookup_id(result: BaseResultT) -> int:
     assert result.place_id
     if result.source_table != SourceTable.PLACEX or result.rank_search > 27:
@@ -569,7 +551,7 @@ def _setup_address_details(result: BaseResultT) -> None:
             extratags=result.extratags or {},
             admin_level=result.admin_level,
             fromarea=True, isaddress=True,
-            rank_address=result.rank_address, distance=0.0))
+            rank_address=result.rank_address or 100, distance=0.0))
     if result.source_table == SourceTable.PLACEX and result.address:
         housenumber = result.address.get('housenumber')\
                       or result.address.get('streetnumber')\

--- a/test/bdd/api/search/queries.feature
+++ b/test/bdd/api/search/queries.feature
@@ -2,6 +2,14 @@
 Feature: Search queries
     Generic search result correctness
 
+    Scenario: Search for natural object
+        When sending json search query "Samina"
+          | accept-language |
+          | en |
+        Then results contain
+          | ID | class    | type  | display_name    |
+          | 0  | waterway | river | Samina, Austria |
+
     Scenario: House number search for non-street address
         When sending json search query "6 Silum, Liechtenstein" with address
           | accept-language |


### PR DESCRIPTION
The order got confused when switching to the Python version of `get_addressdata()`

Also deleted some now unused code.