### PR TITLE
Proposal for documentation extension

### DIFF
--- a/docs/admin/Advanced-Installations.md
+++ b/docs/admin/Advanced-Installations.md
@@ -197,7 +197,10 @@ target machine.
     of a full database.
 
 Next install Nominatim on the target machine by following the standard installation
-instructions. Again, make sure to use the same version as the source machine.
+instructions. Again, make sure to use the same version as the source machine and ensure 
+the target machine has equal system requirements than the local source system. As 
+`pg_restore` is running actual SQL commands, you need identical hardware settings at 
+this step in order to build all indexes correctly.
 
 Create a project directory on your destination machine and set up the `.env`
 file to match the configuration on the source machine. Finally run


### PR DESCRIPTION
This PR refers to further analysis I spent based on [this](https://github.com/osm-search/Nominatim/discussions/3225) discussion.


I have `pg_restore`'ed from a 64 GB machine to a 32 GB machine or so, and it went fine, seemingly. Nominatim works as expected and there is no reason to believe something is off. However, there was 1 subtle line in the PostgreSQL logs that I overread: 

```
ERROR:  temporary file size exceeds temp_file_limit (30852179kB)
```

This has most likely resulted in skipping index creation on `planet_osm_nodes` (containing 3.2B entries for Europe since I don't use a flatnode file) and thus, `nominatim replication` taking literally forever because of slow query performance on that table. It was very time consuming to find out the root cause of this and its so subtle that I found it useful to extend the documentation.

Adding the equal amount of memory to the target SQL instance at least during the restore process is essential.
