### PR TITLE
Do not restrict by viewbox when housenumber or postcode is available

### DIFF
--- a/nominatim/api/search/db_searches.py
+++ b/nominatim/api/search/db_searches.py
@@ -663,7 +663,7 @@ class PlaceSearch(AbstractSearch):
                 sql = sql.where(tsearch.c.centroid
                                          .intersects(VIEWBOX_PARAM,
                                                      use_index=details.viewbox.area < 0.2))
-            elif self.expected_count >= 10000:
+            elif not self.postcodes and not self.housenumbers and self.expected_count >= 10000:
                 sql = sql.where(tsearch.c.centroid
                                          .intersects(VIEWBOX2_PARAM,
                                                      use_index=details.viewbox.area < 0.5))


### PR DESCRIPTION
Postcodes already restrict the number of results to check sufficiently.

Housenumber searches lead to dd results in connection with hard restrictions to viewbox. You might get a street in the viewbox or even no result at all, even though the address exists outside.

Fixes #3274.