### PR TITLE
Fix timezone handling for timestamps from the database

### DIFF
--- a/nominatim/api/status.py
+++ b/nominatim/api/status.py
@@ -37,7 +37,10 @@ async def get_status(conn: SearchConnection) -> StatusResult:
     status.data_updated = await conn.scalar(sql)
 
     if status.data_updated is not None:
-        status.data_updated = status.data_updated.replace(tzinfo=dt.timezone.utc)
+        if status.data_updated.tzinfo is None:
+            status.data_updated = status.data_updated.replace(tzinfo=dt.timezone.utc)
+        else:
+            status.data_updated = status.data_updated.astimezone(dt.timezone.utc)
 
     # Database version
     try:


### PR DESCRIPTION
This fixes the handling of timezone aware timestamps from the database, that got broken when SQLite support was added. The code now carefully checks if a timezone-aware or non-aware timestamp is returned and either converts to UTC or interprets as UTC directly. When creating the SQLite database, make sure to convert to UTC before inserting any data because SQLite is always unaware of timezones.