### PR TITLE
Search postcodes for highway areas around the area

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -1241,7 +1241,9 @@ BEGIN
           OR ST_GeometryType(NEW.geometry) not in ('ST_LineString','ST_MultiLineString')
           OR ST_Length(NEW.geometry) < 0.02)
   THEN
-    NEW.postcode := get_nearest_postcode(NEW.country_code, NEW.geometry);
+    NEW.postcode := get_nearest_postcode(NEW.country_code,
+                                         CASE WHEN NEW.rank_address > 25
+                                              THEN NEW.centroid ELSE NEW.geometry END);
   END IF;
 
   {% if debug %}RAISE WARNING 'place update % % finished.', NEW.osm_type, NEW.osm_id;{% endif %}

--- a/test/bdd/api/reverse/queries.feature
+++ b/test/bdd/api/reverse/queries.feature
@@ -39,7 +39,7 @@ Feature: Reverse geocoding
           | way      | highway  |
         And result addresses contain
           | road                | postcode | country_code |
-          | Upper Kingston Road | 30607    | us |
+          | Upper Kingston Road | 36067    | us |
 
     Scenario: Interpolated house number
         When sending v1/reverse at 47.118533,9.57056562

--- a/test/bdd/db/import/postcodes.feature
+++ b/test/bdd/db/import/postcodes.feature
@@ -115,6 +115,23 @@ Feature: Import of postcodes
             | object | postcode |
             | W93    | 45023    |
 
+    Scenario: Road areas get postcodes from nearby named buildings without other info
+        Given the grid with origin US
+            | 10 |   |   |   | 11 |
+            | 13 |   |   |   | 12 |
+            |    | 1 | 2 |   |    |
+            |    | 4 | 3 |   |    |
+        And the named places
+            | osm | class    | type           | geometry         |
+            | W93 | highway  | pedestriant    | (10,11,12,13,10) |
+        And the named places
+            | osm | class    | type        | addr+postcode | geometry    |
+            | W22 | building | yes         | 45023         | (1,2,3,4,1) |
+        When importing
+        Then placex contains
+            | object | postcode |
+            | W93    | 45023    |
+
     Scenario: Roads get postcodes from nearby unnamed buildings without other info
         Given the grid with origin US
             | 10 |   |   |   | 11 |


### PR DESCRIPTION
So far the code would only accept postcodes that are inside the area, which really doesn't make sense for a pedestrian area.

Fixes #3304.