### PR TITLE
Fix returned HTTP error when query runs too long

### DIFF
--- a/nominatim/server/falcon/server.py
+++ b/nominatim/server/falcon/server.py
@@ -10,6 +10,7 @@ Server implementation using the falcon webserver framework.
 from typing import Optional, Mapping, cast, Any, List
 from pathlib import Path
 import datetime as dt
+import asyncio
 
 from falcon.asgi import App, Request, Response
 
@@ -164,6 +165,8 @@ def get_application(project_dir: Path,
               middleware=middleware)
     app.add_error_handler(HTTPNominatimError, nominatim_error_handler)
     app.add_error_handler(TimeoutError, timeout_error_handler)
+    # different from TimeoutError in Python <= 3.10
+    app.add_error_handler(asyncio.TimeoutError, timeout_error_handler)
 
     legacy_urls = api.config.get_bool('SERVE_LEGACY_URLS')
     for name, func in api_impl.ROUTES:

--- a/nominatim/server/starlette/server.py
+++ b/nominatim/server/starlette/server.py
@@ -10,6 +10,7 @@ Server implementation using the starlette webserver framework.
 from typing import Any, Optional, Mapping, Callable, cast, Coroutine, Dict, Awaitable
 from pathlib import Path
 import datetime as dt
+import asyncio
 
 from starlette.applications import Starlette
 from starlette.routing import Route
@@ -144,7 +145,8 @@ def get_application(project_dir: Path,
         middleware.append(Middleware(FileLoggingMiddleware, file_name=log_file))
 
     exceptions: Dict[Any, Callable[[Request, Exception], Awaitable[Response]]] = {
-        TimeoutError: timeout_error
+        TimeoutError: timeout_error,
+        asyncio.TimeoutError: timeout_error
     }
 
     async def _shutdown() -> None:


### PR DESCRIPTION
The code was only catching the generic TimeoutError. In Python <= 3.10 asyncio.TimeoutError is still something distinct, so catch them both.

Fixes #3303.