### PR TITLE
Extratags should become null when empty

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -2,7 +2,7 @@
 --
 -- This file is part of Nominatim. (https://nominatim.org)
 --
--- Copyright (C) 2022 by the Nominatim developer community.
+-- Copyright (C) 2024 by the Nominatim developer community.
 -- For a full list of authors see the git log.
 
 -- Trigger functions for the placex table.
@@ -794,6 +794,9 @@ BEGIN
   result := deleteLocationArea(NEW.partition, NEW.place_id, NEW.rank_search);
 
   NEW.extratags := NEW.extratags - 'linked_place'::TEXT;
+  IF NEW.extratags = ''::hstore THEN
+    NEW.extratags := NULL;
+  END IF;
 
   -- NEW.linked_place_id contains the precomputed linkee. Save this and restore
   -- the previous link status.

--- a/test/bdd/db/update/linked_places.feature
+++ b/test/bdd/db/update/linked_places.feature
@@ -258,7 +258,7 @@ Feature: Updates of linked places
         When marking for delete N1
         Then placex contains
             | object | extratags |
-            | R1     |  |
+            | R1     | - |
 
     Scenario: Update linked_place info when linkee type changes
         Given the 0.1 grid


### PR DESCRIPTION
Removing the artifical entries in the extratags may lead to an empty hstore. Set it to null in that case.

Fixes #3055.