### PR TITLE
Reduce default importance

### DIFF
--- a/lib-sql/functions/importance.sql
+++ b/lib-sql/functions/importance.sql
@@ -130,7 +130,7 @@ BEGIN
 
   -- Still nothing? Fall back to a default.
   IF result.importance is null THEN
-    result.importance := 0.75001 - (rank_search::float / 40);
+    result.importance := 0.40001 - (rank_search::float / 75);
   END IF;
 
 {% if 'secondary_importance' in db.tables %}

--- a/nominatim/api/results.py
+++ b/nominatim/api/results.py
@@ -233,7 +233,7 @@ class BaseResult:
             of the value or an artificial value computed from the place's
             search rank.
         """
-        return self.importance or (0.7500001 - (self.rank_search/40.0))
+        return self.importance or (0.40001 - (self.rank_search/75.0))
 
 
     def localize(self, locales: Locales) -> None:

--- a/nominatim/api/search/db_searches.py
+++ b/nominatim/api/search/db_searches.py
@@ -700,7 +700,7 @@ class PlaceSearch(AbstractSearch):
                or (details.viewbox is not None and details.viewbox.area < 0.5):
                 sql = sql.order_by(
                         penalty - sa.case((tsearch.c.importance > 0, tsearch.c.importance),
-                                    else_=0.75001-(sa.cast(tsearch.c.search_rank, sa.Float())/40)))
+                                    else_=0.40001-(sa.cast(tsearch.c.search_rank, sa.Float())/75)))
             sql = sql.add_columns(t.c.importance)
 
 

--- a/test/python/api/test_result_formatting_v1.py
+++ b/test/python/api/test_result_formatting_v1.py
@@ -77,7 +77,7 @@ def test_search_details_minimal():
             'admin_level': 15,
             'names': {},
             'localname': '',
-            'calculated_importance': pytest.approx(0.0000001),
+            'calculated_importance': pytest.approx(0.00001),
             'rank_address': 30,
             'rank_search': 30,
             'isarea': False,

--- a/test/python/api/test_results.py
+++ b/test/python/api/test_results.py
@@ -37,7 +37,7 @@ def test_minimal_detailed_result():
 
     assert res.lon == 23.1
     assert res.lat == 0.5
-    assert res.calculated_importance() == pytest.approx(0.0000001)
+    assert res.calculated_importance() == pytest.approx(0.00001)
 
 def test_detailed_result_custom_importance():
     res = DetailedResult(SourceTable.PLACEX,


### PR DESCRIPTION
The importance of a place is usually computed from the page importance of the wikipedia page of the place. Only if there is no such page does the place get a default importance that is derived from its search rank. The formula for the default importance was created when wikipedia/wikidata tags were rather rare in OSM. The formula therefore tries to compute a value that is equivalent to the wikipedia importances. 15 years down the road pretty much all significant places in OSM have their wikipedia tag and absence of such tag is a good indicator that a place is less well known. It is time to reduce the default importance and give wikipedia-tagged places a bit of a boost that way.

This mainly effects smaller peaks, streams and lakes, which tended to show up too soon in the results.