### PR TITLE
Improve handling of postcode areas

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -1265,6 +1265,8 @@ BEGIN
     END IF;
   ELSEIF NEW.rank_address > 25 THEN
     max_rank := 25;
+  ELSEIF NEW.class in ('place','boundary') and NEW.type in ('postcode','postal_code') THEN
+    max_rank := NEW.rank_search;
   ELSE
     max_rank := NEW.rank_address;
   END IF;


### PR DESCRIPTION
Address ranks handle a bit special for postcodes because they tell where the postcode appears in the address display, which is not necessarily related to how much area they cover. So they don't really fit into the usual rank hierarchy. This becomes a problem when computing the "address" of the postcode. If the address is restricted to places with a lower rank address, that is usually not enough. So use the search rank instead which describes the extend of the area. This is already done for postcode points.

Also make sure that the postcode always comes first in the display name.