### PR TITLE
Use import date from osm2pgsql property table if available

### DIFF
--- a/nominatim/clicmd/setup.py
+++ b/nominatim/clicmd/setup.py
@@ -219,12 +219,11 @@ class SetupAll:
         """ Determine the database date and set the status accordingly.
         """
         with connect(dsn) as conn:
-            if not offline:
-                try:
-                    dbdate = status.compute_database_date(conn)
-                    status.set_status(conn, dbdate)
-                    LOG.info('Database is at %s.', dbdate)
-                except Exception as exc: # pylint: disable=broad-except
-                    LOG.error('Cannot determine date of database: %s', exc)
-
             properties.set_property(conn, 'database_version', str(NOMINATIM_VERSION))
+
+            try:
+                dbdate = status.compute_database_date(conn, offline)
+                status.set_status(conn, dbdate)
+                LOG.info('Database is at %s.', dbdate)
+            except Exception as exc: # pylint: disable=broad-except
+                LOG.error('Cannot determine date of database: %s', exc)

--- a/test/python/db/test_status.py
+++ b/test/python/db/test_status.py
@@ -31,6 +31,22 @@ def setup_status_table(status_table):
     pass
 
 
+@pytest.mark.parametrize('offline', [True, False])
+def test_compute_database_date_from_osm2pgsql(table_factory, temp_db_conn, offline):
+    table_factory('osm2pgsql_properties', 'property TEXT, value TEXT',
+                  content=(('current_timestamp', '2024-01-03T23:45:54Z'), ))
+
+    date = nominatim.db.status.compute_database_date(temp_db_conn, offline=offline)
+    assert date == iso_date('2024-01-03T23:45:54')
+
+
+def test_compute_database_date_from_osm2pgsql_nodata(table_factory, temp_db_conn):
+    table_factory('osm2pgsql_properties', 'property TEXT, value TEXT')
+
+    with pytest.raises(UsageError, match='Cannot determine database date from data in offline mode'):
+        nominatim.db.status.compute_database_date(temp_db_conn, offline=True)
+
+
 def test_compute_database_date_place_empty(place_table, temp_db_conn):
     with pytest.raises(UsageError):
         nominatim.db.status.compute_database_date(temp_db_conn)


### PR DESCRIPTION
Newer versions of osm2pgsql have a property table which saves the date of the imported data as determined from the file. Have Nominatim use that date if available, so we can save the lookup in the global OSM database. 