### PR TITLE
Fix compilation of legacy module for PostgreSQL 16

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -134,6 +134,10 @@ jobs:
         needs: create-archive
         runs-on: ubuntu-20.04
 
+        strategy:
+            matrix:
+                postgresql: ["13", "16"]
+
         steps:
             - uses: actions/download-artifact@v4
               with:
@@ -149,11 +153,13 @@ jobs:
 
             - uses: ./Nominatim/.github/actions/setup-postgresql
               with:
-                  postgresql-version: 13
+                  postgresql-version: ${{ matrix.postgresql }}
                   postgis-version: 3
 
             - name: Install Postgresql server dev
-              run: sudo apt-get install postgresql-server-dev-13
+              run: sudo apt-get install postgresql-server-dev-$PGVER
+              env:
+                PGVER: ${{ matrix.postgresql }}
 
             - uses: ./Nominatim/.github/actions/build-nominatim
               with:

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,6 +1,6 @@
 # just use the pgxs makefile
 
-foreach(suffix ${PostgreSQL_ADDITIONAL_VERSIONS} "15" "14" "13" "12" "11" "10" "9.6")
+foreach(suffix ${PostgreSQL_ADDITIONAL_VERSIONS} "16" "15" "14" "13" "12" "11" "10" "9.6")
     list(APPEND PG_CONFIG_HINTS
          "/usr/pgsql-${suffix}/bin")
 endforeach()

--- a/module/nominatim.c
+++ b/module/nominatim.c
@@ -11,9 +11,11 @@
 #include "mb/pg_wchar.h"
 #include <utfasciitable.h>
 
-#ifdef PG_MODULE_MAGIC
-PG_MODULE_MAGIC;
+#if PG_MAJORVERSION_NUM > 15
+#include "varatt.h"
 #endif
+
+PG_MODULE_MAGIC;
 
 Datum transliteration( PG_FUNCTION_ARGS );
 Datum gettokenstring( PG_FUNCTION_ARGS );


### PR DESCRIPTION
The macros used in the PostgreSQL transliteration module for the legacy tokenizer require an additional include file in PostgresSQL 16. This adds the include and adds a test for PG16 to the CI.

If you still depend on the legacy tokenizer, please consider a reimport of your database with the standard ICU tokenizer. The legacy tokenizer is deprecated and will be removed in Nominatim 5 by the end of the year.