### PR TITLE
Lookup postcode areas for postcode results

### DIFF
--- a/lib-sql/indices.sql
+++ b/lib-sql/indices.sql
@@ -21,6 +21,11 @@ CREATE INDEX IF NOT EXISTS idx_placex_parent_place_id
   ON placex USING BTREE (parent_place_id) {{db.tablespace.search_index}}
   WHERE parent_place_id IS NOT NULL;
 ---
+-- Used to find postcode areas after a search in location_postcode.
+CREATE INDEX IF NOT EXISTS idx_placex_postcode_areas
+  ON placex USING BTREE (country_code, postcode) {{db.tablespace.search_index}}
+  WHERE osm_type = 'R' AND class = 'boundary' AND type = 'postal_code';
+---
 CREATE INDEX IF NOT EXISTS idx_placex_geometry ON placex
   USING GIST (geometry) {{db.tablespace.search_index}};
 -- Index is needed during import but can be dropped as soon as a full

--- a/nominatim/api/search/db_searches.py
+++ b/nominatim/api/search/db_searches.py
@@ -609,7 +609,6 @@ class PostcodeSearch(AbstractSearch):
                                                AND osm_type = 'R'"""))\
                              .where(p.c.country_code == row.country_code)\
                              .where(p.c.postcode == row.postcode)\
-                             .where(_exclude_places(p))\
                              .limit(1)
             for prow in await conn.execute(placex_sql, _details_to_bind_params(details)):
                 result = nres.create_from_placex_row(prow, nres.SearchResult)
@@ -618,8 +617,9 @@ class PostcodeSearch(AbstractSearch):
                 result = nres.create_from_postcode_row(row, nres.SearchResult)
 
             assert result
-            result.accuracy = row.accuracy
-            results.append(result)
+            if result.place_id not in details.excluded:
+                result.accuracy = row.accuracy
+                results.append(result)
 
         return results
 

--- a/nominatim/api/search/db_searches.py
+++ b/nominatim/api/search/db_searches.py
@@ -602,7 +602,21 @@ class PostcodeSearch(AbstractSearch):
 
         results = nres.SearchResults()
         for row in await conn.execute(sql, _details_to_bind_params(details)):
-            result = nres.create_from_postcode_row(row, nres.SearchResult)
+            p = conn.t.placex
+            placex_sql = _select_placex(p).add_columns(p.c.importance)\
+                             .where(sa.text("""class = 'boundary'
+                                               AND type = 'postal_code'
+                                               AND osm_type = 'R'"""))\
+                             .where(p.c.country_code == row.country_code)\
+                             .where(p.c.postcode == row.postcode)\
+                             .where(_exclude_places(p))\
+                             .limit(1)
+            for prow in await conn.execute(placex_sql, _details_to_bind_params(details)):
+                result = nres.create_from_placex_row(prow, nres.SearchResult)
+                break
+            else:
+                result = nres.create_from_postcode_row(row, nres.SearchResult)
+
             assert result
             result.accuracy = row.accuracy
             results.append(result)

--- a/nominatim/tools/migration.py
+++ b/nominatim/tools/migration.py
@@ -382,3 +382,13 @@ def add_improved_geometry_reverse_placenode_index(conn: Connection, **_: Any) ->
                        WHERE rank_address between 4 and 25 AND type != 'postcode'
                          AND name is not null AND linked_place_id is null AND osm_type = 'N'
                     """)
+
+@_migration(4, 4, 99, 0)
+def create_postcode_ara_lookup_index(conn: Connection, **_: Any) -> None:
+    """ Create index needed for looking up postcode areas from postocde points.
+    """
+    with conn.cursor() as cur:
+        cur.execute("""CREATE INDEX IF NOT EXISTS idx_placex_postcode_areas
+                       ON placex USING BTREE (country_code, postcode)
+                       WHERE osm_type = 'R' AND class = 'boundary' AND type = 'postal_code'
+                    """)

--- a/nominatim/version.py
+++ b/nominatim/version.py
@@ -34,7 +34,7 @@ class NominatimVersion(NamedTuple):
         return f"{self.major}.{self.minor}.{self.patch_level}-{self.db_patch_level}"
 
 
-NOMINATIM_VERSION = NominatimVersion(4, 4, 0, 0)
+NOMINATIM_VERSION = NominatimVersion(4, 4, 99, 0)
 
 POSTGRESQL_REQUIRED_VERSION = (9, 6)
 POSTGIS_REQUIRED_VERSION = (2, 2)

--- a/test/bdd/api/details/simple.feature
+++ b/test/bdd/api/details/simple.feature
@@ -3,14 +3,6 @@
 Feature: Object details
     Check details page for correctness
 
-    Scenario: Details by place ID
-        When sending details query for 107077
-        Then the result is valid json
-        And results contain
-            | place_id |
-            | 107077   |
-
-
     Scenario Outline: Details via OSM id
         When sending details query for <type><id>
         Then the result is valid json

--- a/test/bdd/db/query/postcodes.feature
+++ b/test/bdd/db/query/postcodes.feature
@@ -96,6 +96,8 @@ Feature: Querying fo postcode variants
            | postcode | E4 7EA, United Kingdom |
 
 
+    @fail-legacy
+    @v1-api-python-only
     Scenario: Postcode areas are preferred over postcode points
         Given the grid with origin DE
             | 1 | 2 |

--- a/test/bdd/db/query/postcodes.feature
+++ b/test/bdd/db/query/postcodes.feature
@@ -95,3 +95,19 @@ Feature: Querying fo postcode variants
            | type     | display_name |
            | postcode | E4 7EA, United Kingdom |
 
+
+    Scenario: Postcode areas are preferred over postcode points
+        Given the grid with origin DE
+            | 1 | 2 |
+            | 4 | 3 |
+        Given the places
+            | osm | class    | type        | postcode | geometry    |
+            | R23 | boundary | postal_code | 12345    | (1,2,3,4,1) |
+        When importing
+        Then location_postcode contains exactly
+          | country | postcode |
+          | de      | 12345    |
+        When sending search query "12345, de"
+        Then results contain
+          | osm |
+          | R23 |


### PR DESCRIPTION
Postcode searches only use the artificial postcode table to do their lookup. This table does not have the full areas that are sometimes available in the OSM data. Add an additional lookup in the placex table to look for postcode areas with the same country and postcode and return the boundary=postal_code objects instead of the artficial postcode result were available.

Needs a new index over postcode areas.