### PR TITLE
Docs: correct URL of an internal link

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -228,7 +228,7 @@ to load the OSM data into the PostgreSQL database. This step is very demanding
 in terms of RAM usage. osm2pgsql and PostgreSQL are running in parallel at 
 this point. PostgreSQL blocks at least the part of RAM that has been configured
 with the `shared_buffers` parameter during
-[PostgreSQL tuning](Installation.md#postgresql-tuning)
+[PostgreSQL tuning](Installation.md#tuning-the-postgresql-database)
 and needs some memory on top of that. osm2pgsql needs at least 2GB of RAM for
 its internal data structures, potentially more when it has to process very large
 relations. In addition it needs to maintain a cache for node locations. The size


### PR DESCRIPTION
The title changed therefore the URL became slightly different (https://nominatim.org/release-docs/develop/admin/Installation/#tuning-the-postgresql-database)