### PR TITLE
add missing space in taginfo listing

### DIFF
--- a/settings/taginfo.lua
+++ b/settings/taginfo.lua
@@ -35,7 +35,7 @@ function print_taginfo()
     for _, k in ipairs(flex.TAGINFO_MAIN.keys) do
         local desc = get_key_description(k, 'POI/feature in the search database')
         if flex.TAGINFO_MAIN.delete_tags[k] ~= nil then
-            desc.description = string.format('%s(except for values: %s).', desc.description,
+            desc.description = string.format('%s (except for values: %s).', desc.description,
                                 table.concat(flex.TAGINFO_MAIN.delete_tags[k], ', '))
         end
         table.insert(tags, desc)


### PR DESCRIPTION
say https://taginfo.openstreetmap.org/tags/shop=guns#projects was listing description

`POI/feature in the search database(except for values: no).`

BTW - would it be useful to notify about retagging such as `shop=guns` to `shop=gun` before they happen (or after they happen?). It was suggested to me in https://www.openstreetmap.org/changeset/148979715 that doing it would be useful but I am not entirely sure about it.

Or would it be useful in cases where specific tag value is reported as supported, and not useful when key in general is supported?