### PR TITLE
Import documentation: reverse-only only a little faster import

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -153,7 +153,7 @@ if you plan to use the installation only for exports to a
 [photon](https://photon.komoot.io/) database, then you can set up a database
 without search indexes. Add `--reverse-only` to your setup command above.
 
-This saves about 5% of disk space.
+This saves about 5% of disk space, import time won't be significant faster.
 
 ### Filtering Imported Data
 


### PR DESCRIPTION
As discussed in https://github.com/osm-search/Nominatim/issues/3374#issuecomment-2019548650

10% might even be optimistic. The 'post-process tables' step on a planet import can take as little as 1 hour only.