### PR TITLE
geocodejson output: make sure a level is only printed once

### DIFF
--- a/nominatim/api/v1/format_json.py
+++ b/nominatim/api/v1/format_json.py
@@ -246,10 +246,13 @@ def format_base_geocodejson(results: Union[napi.ReverseResults, napi.SearchResul
 
             out.key('admin').start_object()
             if result.address_rows:
+                seen = {}
                 for line in result.address_rows:
                     if line.isaddress and (line.admin_level or 15) < 15 and line.local_name \
-                       and line.category[0] == 'boundary' and line.category[1] == 'administrative':
+                      and line.category[0] == 'boundary' and line.category[1] == 'administrative' \
+                      and line.admin_level not in seen:
                         out.keyval(f"level{line.admin_level}", line.local_name)
+                        seen[line.admin_level] = True
             out.end_object().next()
 
         out.end_object().next().end_object().next()


### PR DESCRIPTION
Another fix to https://github.com/osm-search/Nominatim/issues/3382

Example:
`curl 'https://nominatim.osm.org/reverse?lat=51.01762378&lon=-3.1520338&format=geocodejson'` prints
`[...]"admin":{"level10":"Bishop's Hull","level10":"Bradford-on-Tone","level6":"Som[...]`

Browsers and Nominatim CLI handle duplicate keys by selecting the last occurrence ("Bradford-on-Tone") while the fix I added selects the first ("Bishop's Hull"). 

https://nominatim.openstreetmap.org/ui/details.html?osmtype=W&osmid=6011967
![image](https://github.com/osm-search/Nominatim/assets/3727288/f3ee8fd8-7fef-4d40-91b3-3d0e2eb82aca)
