### PR TITLE
docs: use nominatim-project everywhere

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -14,15 +14,15 @@ to a single Nominatim setup: configuration, extra data, etc. Create a project
 directory apart from the Nominatim software and change into the directory:
 
 ```
-mkdir ~/nominatim-planet
-cd ~/nominatim-planet
+mkdir ~/nominatim-project
+cd ~/nominatim-project
 ```
 
 In the following, we refer to the project directory as `$PROJECT_DIR`. To be
 able to copy&paste instructions, you can export the appropriate variable:
 
 ```
-export PROJECT_DIR=~/nominatim-planet
+export PROJECT_DIR=~/nominatim-project
 ```
 
 The Nominatim tool assumes per default that the current working directory is


### PR DESCRIPTION
Keeping it the same as other documentation and example scripts

```
grep -rl 'nominatim-planet' .
./docs/admin/Import.md
grep -rl 'nominatim-project' .
./vagrant/Install-on-Ubuntu-20.sh
./vagrant/Install-on-Ubuntu-22.sh
./docs/admin/Deployment-PHP.md
./docs/admin/Deployment-Python.md
./README.md
./.github/workflows/ci-tests.yml
./VAGRANT.md
```