### PR TITLE
Add documentation for installing a secondary importance file

### DIFF
--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -75,14 +75,17 @@ This data is available as a binary download. Put it into your project directory:
 
     cd $PROJECT_DIR
     wget https://nominatim.org/data/wikimedia-importance.sql.gz
+    wget -O secondary_importance.sql.gz https://nominatim.org/data/wikimedia-secondary-importance.sql.gz
 
-The file is about 400MB and adds around 4GB to the Nominatim database.
+The files are about 400MB and add around 4GB to the Nominatim database. For
+more information about importance,
+see [Importance Customization](../customize/Importance.md).
 
 !!! tip
     If you forgot to download the wikipedia rankings, then you can
     also add importances after the import. Download the SQL files, then
-    run `nominatim refresh --wiki-data --importance`. Updating
-    importances for a planet will take a couple of hours.
+    run `nominatim refresh --wiki-data --secondary-importance --importance`.
+    Updating importances for a planet will take a couple of hours.
 
 ### External postcodes
 

--- a/docs/customize/Importance.md
+++ b/docs/customize/Importance.md
@@ -12,7 +12,7 @@ customize them.
 The main value for importance is derived from page ranking values for Wikipedia
 pages for a place. For places that do not have their own
 Wikipedia page, a formula is used that derives a static importance from the
-places [search rank](../customize/Ranking.md#search-rank).
+place's [search rank](../customize/Ranking.md#search-rank).
 
 In a second step, a secondary importance value is added which is meant to
 represent how well-known the general area is where the place is located. It
@@ -21,7 +21,13 @@ importance values.
 
 nominatim.org has preprocessed importance tables for the
 [primary Wikipedia rankings](https://nominatim.org/data/wikimedia-importance.sql.gz)
-and for a secondary importance based on the number of tile views on openstreetmap.org.
+and for [secondary importance](https://nominatim.org/data/wikimedia-secondary-importance.sql.gz)
+based on Wikipedia importance of the administrative areas.
+
+The source code for creating these files is avaible in the Github projects
+[osm-search/wikipedia-wikidata](https://github.com/osm-search/wikipedia-wikidata)
+and
+[osm-search/secondary-importance](https://github.com/osm-search/secondary-importance).
 
 ### Customizing secondary importance
 
@@ -41,8 +47,8 @@ table will be ignored. You must furthermore create an index as follows:
 CREATE INDEX ON secondary_importance USING gist(ST_ConvexHull(gist))
 ```
 
-The following raster2pgsql command will create a table that conforms to
-the requirements:
+The following raster2pgsql command will create a table from a tiff file
+that conforms to the requirements:
 
 ```
 raster2pgsql -I -C -Y -d -t 128x128 input.tiff public.secondary_importance


### PR DESCRIPTION
nominatim.org now provides an official file for [secondary importance](https://nominatim.org/release-docs/develop/customize/Importance/). It is computed using the wikipedia-based importances of places and administrative boundaries. See https://github.com/osm-search/secondary-importance for source code how to compute the file.

This adds download of this file to the official import instructions.

Many thanks to @mtmail for implementing the computation of the file.

Closes #2268, #882.