### PR TITLE
Update Output place_id documentation to match implementation

### DIFF
--- a/docs/api/Output.md
+++ b/docs/api/Output.md
@@ -12,7 +12,7 @@ a single place (for reverse) of the following format:
 
 ```
   {
-    "place_id": "100149",
+    "place_id": 100149,
     "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
     "osm_type": "node",
     "osm_id": "107775",


### PR DESCRIPTION
The current documentation represents that place_id is output as a string, but in fact the implementation provides it as a number 