### PR TITLE
Implement a lighter format for wikipedia importance tables

### DIFF
--- a/lib-sql/functions/importance.sql
+++ b/lib-sql/functions/importance.sql
@@ -65,7 +65,7 @@ BEGIN
   RETURN NULL;
 END;
 $$
-LANGUAGE plpgsql IMMUTABLE STRICT;
+LANGUAGE plpgsql IMMUTABLE;
 
 {% else %}
 

--- a/lib-sql/tables.sql
+++ b/lib-sql/tables.sql
@@ -273,28 +273,15 @@ GRANT SELECT ON import_polygon_delete TO "{{config.DATABASE_WEBUSER}}";
 DROP SEQUENCE IF EXISTS file;
 CREATE SEQUENCE file start 1;
 
--- null table so it won't error
--- deliberately no drop - importing the table is expensive and static, if it is already there better to avoid removing it
-CREATE TABLE IF NOT EXISTS wikipedia_article (
-    language text NOT NULL,
-    title text NOT NULL,
-    langcount integer,
-    othercount integer,
-    totalcount integer,
-    lat double precision,
-    lon double precision,
-    importance double precision,
-    osm_type character(1),
-    osm_id bigint,
-    wd_page_title text,
-    instance_of text
-);
-
-CREATE TABLE IF NOT EXISTS wikipedia_redirect (
-    language text,
-    from_title text,
-    to_title text
-);
+{% if 'wikimedia_importance' not in db.tables and 'wikipedia_article' not in db.tables %}
+-- create dummy tables here, if nothing was imported
+CREATE TABLE wikimedia_importance (
+  language TEXT NOT NULL,
+  title TEXT NOT NULL,
+  importance double precision NOT NULL,
+  wikidata TEXT
+)  {{db.tablespace.address_data}};
+{% endif %}
 
 -- osm2pgsql does not create indexes on the middle tables for Nominatim
 -- Add one for lookup of associated street relations.

--- a/nominatim/db/utils.py
+++ b/nominatim/db/utils.py
@@ -92,6 +92,11 @@ class CopyBuffer:
         return self
 
 
+    def size(self) -> int:
+        """ Return the number of bytes the buffer currently contains.
+        """
+        return self.buffer.tell()
+
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self.buffer is not None:
             self.buffer.close()
@@ -115,7 +120,10 @@ class CopyBuffer:
 
     def copy_out(self, cur: Cursor, table: str, columns: Optional[Iterable[str]] = None) -> None:
         """ Copy all collected data into the given table.
+
+            The buffer is empty and reusable after this operation.
         """
         if self.buffer.tell() > 0:
             self.buffer.seek(0)
             cur.copy_from(self.buffer, table, columns=columns)
+            self.buffer = io.StringIO()

--- a/nominatim/tools/check_database.py
+++ b/nominatim/tools/check_database.py
@@ -248,7 +248,10 @@ def check_existance_wikipedia(conn: Connection, _: Configuration) -> CheckResult
         return CheckState.NOT_APPLICABLE
 
     with conn.cursor() as cur:
-        cnt = cur.scalar('SELECT count(*) FROM wikipedia_article')
+        if conn.table_exists('wikimedia_importance'):
+            cnt = cur.scalar('SELECT count(*) FROM wikimedia_importance')
+        else:
+            cnt = cur.scalar('SELECT count(*) FROM wikipedia_article')
 
         return CheckState.WARN if cnt == 0 else CheckState.OK
 

--- a/test/python/cli/test_cmd_refresh.py
+++ b/test/python/cli/test_cmd_refresh.py
@@ -28,6 +28,7 @@ class TestRefresh:
                              ('website', 'setup_website'),
                              ])
     def test_refresh_command(self, mock_func_factory, command, func):
+        mock_func_factory(nominatim.tools.refresh, 'create_functions')
         func_mock = mock_func_factory(nominatim.tools.refresh, func)
 
         assert self.call_nominatim('refresh', '--' + command) == 0
@@ -71,6 +72,7 @@ class TestRefresh:
 
         assert self.call_nominatim('refresh', '--wiki-data') == 1
 
+
     def test_refresh_secondary_importance_file_not_found(self):
         assert self.call_nominatim('refresh', '--secondary-importance') == 1
 
@@ -84,16 +86,18 @@ class TestRefresh:
         assert mocks[1].called == 1
 
 
-    def test_refresh_importance_computed_after_wiki_import(self, monkeypatch):
+    def test_refresh_importance_computed_after_wiki_import(self, monkeypatch, mock_func_factory):
         calls = []
         monkeypatch.setattr(nominatim.tools.refresh, 'import_wikipedia_articles',
                             lambda *args, **kwargs: calls.append('import') or 0)
         monkeypatch.setattr(nominatim.tools.refresh, 'recompute_importance',
                             lambda *args, **kwargs: calls.append('update'))
+        func_mock = mock_func_factory(nominatim.tools.refresh, 'create_functions')
 
         assert self.call_nominatim('refresh', '--importance', '--wiki-data') == 0
 
         assert calls == ['import', 'update']
+        assert func_mock.called == 1
 
     @pytest.mark.parametrize('params', [('--data-object', 'w234'),
                                         ('--data-object', 'N23', '--data-object', 'N24'),

--- a/test/python/mocks.py
+++ b/test/python/mocks.py
@@ -54,16 +54,17 @@ class MockPlacexTable:
 
     def add(self, osm_type='N', osm_id=None, cls='amenity', typ='cafe', names=None,
             admin_level=None, address=None, extratags=None, geom='POINT(10 4)',
-            country=None, housenumber=None):
+            country=None, housenumber=None, rank_search=30):
         with self.conn.cursor() as cur:
             psycopg2.extras.register_hstore(cur)
             cur.execute("""INSERT INTO placex (place_id, osm_type, osm_id, class,
                                                type, name, admin_level, address,
-                                               housenumber,
+                                               housenumber, rank_search,
                                                extratags, geometry, country_code)
-                            VALUES(nextval('seq_place'), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                            VALUES(nextval('seq_place'), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
                         (osm_type, osm_id or next(self.idseq), cls, typ, names,
-                         admin_level, address, housenumber, extratags, 'SRID=4326;' + geom,
+                         admin_level, address, housenumber, rank_search,
+                         extratags, 'SRID=4326;' + geom,
                          country))
         self.conn.commit()
 

--- a/test/python/tools/test_refresh.py
+++ b/test/python/tools/test_refresh.py
@@ -35,8 +35,7 @@ def test_refresh_import_secondary_importance_testdb(dsn, src_dir, temp_db_conn, 
 @pytest.mark.parametrize("replace", (True, False))
 def test_refresh_import_wikipedia(dsn, src_dir, table_factory, temp_db_cursor, replace):
     if replace:
-        table_factory('wikipedia_article')
-        table_factory('wikipedia_redirect')
+        table_factory('wikimedia_importance')
 
     # use the small wikipedia file for the API testdb
     assert refresh.import_wikipedia_articles(dsn, src_dir / 'test' / 'testdb') == 0

--- a/test/python/tools/test_refresh_wiki_data.py
+++ b/test/python/tools/test_refresh_wiki_data.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2022 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for correctly assigning wikipedia pages to places.
+"""
+import gzip
+import csv
+
+import pytest
+
+from nominatim.tools.refresh import import_wikipedia_articles, recompute_importance, create_functions
+
+@pytest.fixture
+def wiki_csv(tmp_path, sql_preprocessor):
+    def _import(data):
+        with gzip.open(tmp_path / 'wikimedia-importance.csv.gz', mode='wt') as fd:
+            writer = csv.DictWriter(fd, fieldnames=['language', 'type', 'title',
+                                                    'importance', 'wikidata_id'],
+                                    delimiter='\t', quotechar='|')
+            writer.writeheader()
+            for lang, title, importance, wd in data:
+                writer.writerow({'language': lang, 'type': 'a',
+                                 'title': title, 'importance': str(importance),
+                                 'wikidata_id' : wd})
+        return tmp_path
+
+    return _import
+
+
+@pytest.mark.parametrize('extra', [{'wikipedia:en': 'Test'},
+                                   {'wikipedia': 'en:Test'},
+                                   {'wikidata': 'Q123'}])
+def test_wikipedia(dsn, temp_db_conn, temp_db_cursor, def_config, wiki_csv, placex_table, extra):
+    import_wikipedia_articles(dsn, wiki_csv([('en', 'Test', 0.3, 'Q123')]))
+    create_functions(temp_db_conn, def_config)
+
+    content = temp_db_cursor.row_set(
+        'SELECT language, title, importance, wikidata FROM wikimedia_importance')
+    assert content == set([('en', 'Test', 0.3, 'Q123')])
+
+    placex_table.add(osm_id=12, extratags=extra)
+
+    recompute_importance(temp_db_conn)
+
+    content = temp_db_cursor.row_set('SELECT wikipedia, importance FROM placex')
+    assert content == set([('en:Test', 0.3)])
+
+
+def test_wikipedia_no_match(dsn, temp_db_conn, temp_db_cursor, def_config, wiki_csv,
+                            placex_table):
+    import_wikipedia_articles(dsn, wiki_csv([('de', 'Test', 0.3, 'Q123')]))
+    create_functions(temp_db_conn, def_config)
+
+    placex_table.add(osm_id=12, extratags={'wikipedia': 'en:Test'}, rank_search=10)
+
+    recompute_importance(temp_db_conn)
+
+    content = temp_db_cursor.row_set('SELECT wikipedia, importance FROM placex')
+    assert list(content) == [(None, pytest.approx(0.26667666))]


### PR DESCRIPTION
Adds support for the new simpler CSV format for wikipedia importance values. This also comes with a much simplified table structure: redirects and articles are now in the same table and all unnecessary information has been dropped leaving only wikipedia article, wikidata ID and importance.

Support for the old-style wikipedia importance dumps remains in place for now. There will be official CSV dumps once we have removed the last obstacles in the generation process in https://github.com/osm-search/wikipedia-wikidata.