### PR TITLE
chore: Increase minimum required SQLAlchemy version to 2.0.31

### DIFF
--- a/.github/actions/build-nominatim/action.yml
+++ b/.github/actions/build-nominatim/action.yml
@@ -27,7 +27,7 @@ runs:
           run: |
             sudo apt-get install -y -qq libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libpq-dev libproj-dev libicu-dev liblua${LUA_VERSION}-dev lua${LUA_VERSION} lua-dkjson nlohmann-json3-dev libspatialite7 libsqlite3-mod-spatialite
             if [ "$FLAVOUR" == "oldstuff" ]; then
-                pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==1.4.31 datrie asyncpg aiosqlite
+                pip3 install MarkupSafe==2.0.1 python-dotenv psycopg2==2.7.7 jinja2==2.8 psutil==5.4.2 pyicu==2.9 osmium PyYAML==5.1 sqlalchemy==2.0.31 datrie asyncpg aiosqlite
             else
                 sudo apt-get install -y -qq python3-icu python3-datrie python3-pyosmium python3-jinja2 python3-psutil python3-psycopg2 python3-dotenv python3-yaml
                 pip3 install sqlalchemy psycopg aiosqlite

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -49,7 +49,7 @@ For running Nominatim:
   * [Python Dotenv](https://github.com/theskumar/python-dotenv)
   * [psutil](https://github.com/giampaolo/psutil)
   * [Jinja2](https://palletsprojects.com/p/jinja/)
-  * [SQLAlchemy](https://www.sqlalchemy.org/) (1.4.31+ with greenlet support)
+  * [SQLAlchemy](https://www.sqlalchemy.org/) (2.0.31+ with greenlet support)
   * [asyncpg](https://magicstack.github.io/asyncpg) (0.8+)
   * [PyICU](https://pypi.org/project/PyICU/)
   * [PyYaml](https://pyyaml.org/) (5.1+)


### PR DESCRIPTION
I've been running a Nominatim instance with SQLAlchemy v2 for about a week now, it works fine:

```
[root@nominatim ~]# pacman -Q | grep -e nominatim -e sqlalchemy
nominatim 4.4.0-1
nominatim-ui 3.5.3-1
python-sqlalchemy 2.0.27-1
[root@nominatim ~]# systemctl status nominatim | grep 'Active:'
     Active: active (running) since Mon 2024-06-17 17:59:19 CEST; 1 week 5 days ago
[root@nominatim ~]# sudo -u nominatim -H nominatim reverse --lat 51.redacted --lon 12.redacted | jq .display_name
2024-06-30 12:25:18: Using project directory: /var/lib/nominatim
"redacted, Leipzig, Sachsen, 04317, Deutschland"
[root@nominatim ~]# curl -sk 'https://nominatim.redacted.com/reverse?lat=51.redacted&lon=12.redacted&zoom=18&format=jsonv2' | jq .address.city
"Leipzig"
```

Also, the author of [this comment from 2024-01-11]( https://github.com/osm-search/Nominatim/discussions/3297#discussioncomment-8095053) seems to use SQLAlchemy v2 as a solution for their problem.