### PR TITLE
Make sure SQLAlchemy can handle the loaded dialect

### DIFF
--- a/src/nominatim_api/sql/async_core_library.py
+++ b/src/nominatim_api/sql/async_core_library.py
@@ -7,15 +7,17 @@
 """
 Import the base library to use with asynchronous SQLAlchemy.
 """
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, ungrouped-imports, unused-import
 
 from typing import Any
 
 try:
+    import sqlalchemy.dialects.postgresql.psycopg
     import psycopg
     PGCORE_LIB = 'psycopg'
     PGCORE_ERROR: Any = psycopg.Error
 except ModuleNotFoundError:
+    import sqlalchemy.dialects.postgresql.asyncpg
     import asyncpg
     PGCORE_LIB = 'asyncpg'
     PGCORE_ERROR = asyncpg.PostgresError


### PR DESCRIPTION
The psycopg dialect was only added in SQLAlchemy 2.0. To avoid loading errors when SQLAlchemy 1.4 is installed together with psycopg3, check that the dialect is really available.

Should fix issues like #3297.

