### PR TITLE
Github Actions: now use setup-python v4->v5

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,7 +65,7 @@ jobs:
             - name: Unpack Nominatim
               run: tar xf nominatim-src.tar.bz2
 
-            - uses: actions/setup-python@v4
+            - uses: actions/setup-python@v5
               with:
                 python-version: 3.7
               if: matrix.flavour == 'oldstuff'


### PR DESCRIPTION
This resolves a deprecation warning

"The following actions uses Node.js version which is deprecated and will be forced to run on node20: `actions/setup-python@v4`."