### PR TITLE
Documentation: python frontend doesnt need website directory

### DIFF
--- a/vagrant/Install-on-Ubuntu-22.sh
+++ b/vagrant/Install-on-Ubuntu-22.sh
@@ -271,7 +271,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    root $USERHOME/nominatim-project/website;
+    root $USERHOME/nominatim-project/;
     index /search;
 
     location /nominatim/ {

--- a/vagrant/Install-on-Ubuntu-24.sh
+++ b/vagrant/Install-on-Ubuntu-24.sh
@@ -273,7 +273,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    root $USERHOME/nominatim-project/website;
+    root $USERHOME/nominatim-project/;
     index /search;
 
     location /nominatim/ {


### PR DESCRIPTION
The `Install-on-Ubuntu-*.sh` scripts setup a Nominatim python frontend. The python frontend doesn't create a `website` directory. The nginx configuration works fine either way but it's confusing to users (e.g. https://github.com/osm-search/Nominatim/discussions/3471)