### PR TITLE
feat-3416: configurable-output-name-tags

### DIFF
--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -689,6 +689,25 @@ results gathered so far.
 Note that under high load you may observe that users receive different results
 than usual without seeing an error. This may cause some confusion.
 
+
+#### NOMINATIM_OUTPUT_NAMES
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Determines which name tags is chosen for a place |
+| **Format:**        | string |
+| **Default:**       | name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref |
+| **Comment:**       | Python frontend only |
+
+
+Accepts Coma separated values, `:XX` at the end identifies language specific tags
+else value is identified as general tag. Tags will be added based on the given order.
+
+Take `name:XX,name,brand` for example:
+first name will added as language tag for given languages,
+then name and brand will added as place name tags
+
+
 ### Logging Settings
 
 #### NOMINATIM_LOG_DB

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -220,6 +220,12 @@ NOMINATIM_REQUEST_TIMEOUT=60
 # to geocode" instead.
 NOMINATIM_SEARCH_WITHIN_COUNTRIES=False
 
+# Determines which name tags is chosen for a place.
+# Accepts Coma separated values, `:XX` at the end identifies 
+# language specific tags else value is identified as general tag. 
+# Tags will be added based on the given order.
+NOMINATIM_OUTPUT_NAMES=name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref
+
 ### Log settings
 #
 # The following options allow to enable logging of API requests.

--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -25,9 +25,7 @@ class Locales:
         self.name_tags: List[str] = []
 
         # Build the list of supported tags.
-        # It is now configurable with env setting NOMINATIM_OUTPUT_NAMES
-        # e.g. NOMINATIM_OUTPUT_NAMES =
-        # name:XX,name,brand,official_name:XX,short_name:XX,official_name,shirt_name,ref
+        # Uses hard-coded when environment config not provided
         nominatim_output_names = os.getenv("NOMINATIM_OUTPUT_NAMES")
         if nominatim_output_names is None:
             self._build_default_output_name_tags()
@@ -36,6 +34,9 @@ class Locales:
 
 
     def _build_default_output_name_tags(self) -> None:
+        """
+        Build the list of supported tags. Hard-coded implementation.
+        """
         self._add_lang_tags("name")
         self._add_tags("name", "brand")
         self._add_lang_tags("official_name", "short_name")
@@ -43,6 +44,16 @@ class Locales:
 
 
     def _build_output_name_tags(self, nominatim_output_names: str) -> None:
+        """
+        Build the list of supported tags. Dynamic implementation.
+        Configurable through `NOMINATIM_OUTPUT_NAMES` environment config
+        Configuration input format: 
+        `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
+            - Coma separated
+            - `:XX` identifies lang tags
+            - consecutive `:XX` identifies multiple lang tags to-be added at the same time
+            - subsequent parts after lang tags (till next lang tag) identifies batch of tags
+        """
         nominatim_output_names = nominatim_output_names.split(",")
         lang_tags = []
         tags = []

--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -7,62 +7,43 @@
 """
 Helper functions for localizing names of results.
 """
-import re
 from typing import List, Mapping, Optional
-
-from .config import Configuration
+import re
 
 
 class Locales:
     """ Helper class for localization of names.
 
-    It takes a list of language prefixes in their order of preferred
-    usage.
-    It takes config object as input which enables to configure the 
-    list of supported tags. Setting name: `OUTPUT_NAMES`
-    How to use?
-    e.g. `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
-        - Coma separated
-        - `:XX` identifies lang tags
-        - consecutive `:XX` identifies multiple lang tags to-be added at the same time
-        - subsequent parts after lang tags (till next lang tag) identifies batch of tags
+    Keyword arguments:
+    langs: List[str] -- list of language prefixes in 
+        their order of preferred usage.
+    output_name_tags_config: str -- string object 
+        containing output name tags in their order of preferred usage.
+        default -- 
+        `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
     """
 
-    def __init__(self, langs: Optional[List[str]] = None, config: Optional[Configuration] = None):
+    def __init__(
+        self,
+        langs: Optional[List[str]] = None,
+        output_name_tags_config: str = (
+            "name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref"
+        )
+    ):
         self.languages = langs or []
         self.name_tags: List[str] = []
 
         # Build the list of supported tags
-        # Uses hard-coded when config `OUTPUT_NAMES` not provided
-        if config and config.OUTPUT_NAMES != '':
-            self._build_output_name_tags(config.OUTPUT_NAMES)
-        else:
-            self._build_default_output_name_tags()
-
-
-    def _build_default_output_name_tags(self) -> None:
-        """
-        Build the list of supported tags. Hard-coded implementation.
-        """
-        self._add_lang_tags("name")
-        self._add_tags("name", "brand")
-        self._add_lang_tags("official_name", "short_name")
-        self._add_tags("official_name", "short_name", "ref")
+        self._build_output_name_tags(output_name_tags_config)
 
 
     def _build_output_name_tags(self, nominatim_output_names: str) -> None:
         """
         Build the list of supported tags. Dynamic implementation.
-        How to use?
-        e.g. `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
-            - Coma separated
-            - `:XX` identifies lang tags
-            - consecutive `:XX` identifies multiple lang tags to-be added at the same time
-            - subsequent parts after lang tags (till next lang tag) identifies batch of tags
         """
-        nominatim_output_names = nominatim_output_names.split(",")
-        lang_tags = []
-        tags = []
+        nominatim_output_names: List[str] = nominatim_output_names.split(",")
+        lang_tags: List[str] = []
+        tags: List[str] = []
         for name in nominatim_output_names:
             if name.endswith(":XX"): # Identifies Lang Tag
                 lang_tags.append(name[:-3])

--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -7,7 +7,7 @@
 """
 Helper functions for localizing names of results.
 """
-from typing import List, Mapping, Optional
+from typing import Mapping, List, Optional
 
 import re
 

--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -7,30 +7,37 @@
 """
 Helper functions for localizing names of results.
 """
-from typing import Mapping, List, Optional
-
 import re
-import os
+from typing import List, Mapping, Optional
+
+from .config import Configuration
 
 
 class Locales:
     """ Helper class for localization of names.
 
-        It takes a list of language prefixes in their order of preferred
-        usage.
+    It takes a list of language prefixes in their order of preferred
+    usage.
+    It takes config object as input which enables to configure the 
+    list of supported tags. Setting name: `OUTPUT_NAMES`
+    How to use?
+    e.g. `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
+        - Coma separated
+        - `:XX` identifies lang tags
+        - consecutive `:XX` identifies multiple lang tags to-be added at the same time
+        - subsequent parts after lang tags (till next lang tag) identifies batch of tags
     """
 
-    def __init__(self, langs: Optional[List[str]] = None):
+    def __init__(self, langs: Optional[List[str]] = None, config: Optional[Configuration] = None):
         self.languages = langs or []
         self.name_tags: List[str] = []
 
-        # Build the list of supported tags.
-        # Uses hard-coded when environment config not provided
-        nominatim_output_names = os.getenv("NOMINATIM_OUTPUT_NAMES")
-        if nominatim_output_names is None:
-            self._build_default_output_name_tags()
+        # Build the list of supported tags
+        # Uses hard-coded when config `OUTPUT_NAMES` not provided
+        if config and config.OUTPUT_NAMES != '':
+            self._build_output_name_tags(config.OUTPUT_NAMES)
         else:
-            self._build_output_name_tags(nominatim_output_names)
+            self._build_default_output_name_tags()
 
 
     def _build_default_output_name_tags(self) -> None:
@@ -46,9 +53,8 @@ class Locales:
     def _build_output_name_tags(self, nominatim_output_names: str) -> None:
         """
         Build the list of supported tags. Dynamic implementation.
-        Configurable through `NOMINATIM_OUTPUT_NAMES` environment config
-        Configuration input format: 
-        `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
+        How to use?
+        e.g. `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
             - Coma separated
             - `:XX` identifies lang tags
             - consecutive `:XX` identifies multiple lang tags to-be added at the same time

--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -8,6 +8,7 @@
 Helper functions for localizing names of results.
 """
 from typing import List, Mapping, Optional
+
 import re
 
 

--- a/test/python/api/test_localization.py
+++ b/test/python/api/test_localization.py
@@ -10,7 +10,7 @@ Test functions for adapting results to the user's locale.
 import os
 import pytest
 
-from nominatim_api import Locales
+from nominatim_api import Locales, Configuration
 
 def test_display_name_empty_names():
     l = Locales(['en', 'de'])
@@ -58,9 +58,6 @@ def test_configurable_output_name_tags():
     """
     tests the output name tags when environment config is provided
     """
-    os.environ["NOMINATIM_OUTPUT_NAMES"] = (
-        "name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref"
-    )
     name_tags = {
         "name",
         "_place_name",
@@ -68,12 +65,19 @@ def test_configurable_output_name_tags():
         "_place_brand",
         "official_name",
         "_place_official_name",
-        "short_name",
-        "_place_short_name",
+        "shirt_name",
+        "_place_shirt_name",
         "ref",
         "_place_ref",
     }
-    l = Locales()
+    for name in list(name_tags): name_tags.add(f"{name}:en")
+    cfg = Configuration(
+        project_dir=None,
+        environ={
+            "NOMINATIM_OUTPUT_NAMES":"name:XX,name,brand,official_name:XX,shirt_name:XX,official_name,shirt_name,ref"
+        }
+    )
+    l = Locales(['en'], config=cfg)
     assert set(l.name_tags).difference(name_tags) == set()
 
 

--- a/test/python/api/test_localization.py
+++ b/test/python/api/test_localization.py
@@ -55,13 +55,43 @@ def test_from_language_preferences(langstr, langlist):
 
 
 def test_configurable_output_name_tags():
-    os.environ['NOMINATIM_OUTPUT_NAMES'] = 'name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref'
-    name_tags = {'name', '_place_name', 'brand', '_place_brand', 'official_name', '_place_official_name', 'short_name', '_place_short_name', 'ref', '_place_ref'}
+    """
+    tests the output name tags when environment config is provided
+    """
+    os.environ["NOMINATIM_OUTPUT_NAMES"] = (
+        "name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref"
+    )
+    name_tags = {
+        "name",
+        "_place_name",
+        "brand",
+        "_place_brand",
+        "official_name",
+        "_place_official_name",
+        "short_name",
+        "_place_short_name",
+        "ref",
+        "_place_ref",
+    }
     l = Locales()
     assert set(l.name_tags).difference(name_tags) == set()
 
 
 def test_default_output_name_tags():
-    name_tags = {'name', '_place_name', 'brand', '_place_brand', 'official_name', '_place_official_name', 'short_name', '_place_short_name', 'ref', '_place_ref'}
+    """
+    tests the default setting (previously hardcoded) in case environment config is not provided
+    """
+    name_tags = {
+        "name",
+        "_place_name",
+        "brand",
+        "_place_brand",
+        "official_name",
+        "_place_official_name",
+        "short_name",
+        "_place_short_name",
+        "ref",
+        "_place_ref",
+    }
     l = Locales()
     assert set(l.name_tags).difference(name_tags) == set()

--- a/test/python/api/test_localization.py
+++ b/test/python/api/test_localization.py
@@ -7,6 +7,7 @@
 """
 Test functions for adapting results to the user's locale.
 """
+import os
 import pytest
 
 from nominatim_api import Locales
@@ -51,3 +52,16 @@ def test_display_name_preference():
                           ('en,fr;garbage,de', ['en', 'de'])])
 def test_from_language_preferences(langstr, langlist):
     assert Locales.from_accept_languages(langstr).languages == langlist
+
+
+def test_configurable_output_name_tags():
+    os.environ['NOMINATIM_OUTPUT_NAMES'] = 'name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref'
+    name_tags = {'name', '_place_name', 'brand', '_place_brand', 'official_name', '_place_official_name', 'short_name', '_place_short_name', 'ref', '_place_ref'}
+    l = Locales()
+    assert set(l.name_tags).difference(name_tags) == set()
+
+
+def test_default_output_name_tags():
+    name_tags = {'name', '_place_name', 'brand', '_place_brand', 'official_name', '_place_official_name', 'short_name', '_place_short_name', 'ref', '_place_ref'}
+    l = Locales()
+    assert set(l.name_tags).difference(name_tags) == set()

--- a/test/python/api/test_localization.py
+++ b/test/python/api/test_localization.py
@@ -7,10 +7,9 @@
 """
 Test functions for adapting results to the user's locale.
 """
-import os
 import pytest
 
-from nominatim_api import Locales, Configuration
+from nominatim_api import Locales
 
 def test_display_name_empty_names():
     l = Locales(['en', 'de'])
@@ -58,34 +57,38 @@ def test_configurable_output_name_tags():
     """
     tests the output name tags when environment config is provided
     """
-    name_tags = {
+    name_tags = [
+        "name:en",
+        "_place_name:en",
         "name",
         "_place_name",
         "brand",
         "_place_brand",
+        "official_name:en",
+        "_place_official_name:en",
+        "shirt_name:en",
+        "_place_shirt_name:en",
         "official_name",
         "_place_official_name",
         "shirt_name",
         "_place_shirt_name",
         "ref",
         "_place_ref",
-    }
-    for name in list(name_tags): name_tags.add(f"{name}:en")
-    cfg = Configuration(
-        project_dir=None,
-        environ={
-            "NOMINATIM_OUTPUT_NAMES":"name:XX,name,brand,official_name:XX,shirt_name:XX,official_name,shirt_name,ref"
-        }
+    ]
+    l = Locales(
+        ['en'],
+        output_name_tags_config=(
+            "name:XX,name,brand,official_name:XX,shirt_name:XX,official_name,shirt_name,ref"
+        )
     )
-    l = Locales(['en'], config=cfg)
-    assert set(l.name_tags).difference(name_tags) == set()
+    assert l.name_tags == name_tags
 
 
 def test_default_output_name_tags():
     """
     tests the default setting (previously hardcoded) in case environment config is not provided
     """
-    name_tags = {
+    name_tags = [
         "name",
         "_place_name",
         "brand",
@@ -96,6 +99,6 @@ def test_default_output_name_tags():
         "_place_short_name",
         "ref",
         "_place_ref",
-    }
+    ]
     l = Locales()
-    assert set(l.name_tags).difference(name_tags) == set()
+    assert l.name_tags == name_tags


### PR DESCRIPTION
This PR makes the hard-coded list of output name tags configurable, addressing issue #3416. It allows users to specify their preferred output name tags via an environment setting `NOMINATIM_OUTPUT_NAMES` as suggested in the issue #3416.


## Description

- Moved previously hard-coded settings as a default behavior in case environment config is not provided to function `_build_default_output_name_tags`
- Added new function `_build_output_name_tags`
    - Executes when environment config `NOMINATIM_OUTPUT_NAMES` is provided
    - Configuration input format: `name:XX,name,brand,official_name:XX,short_name:XX,official_name,short_name,ref`
        - Coma separated
        - `:XX` identifies lang tags
        - consecutive `:XX` identifies multiple lang tags to-be added at the same time
        - subsequent parts after lang tags (till next lang tag) identifies batch of tags


## Related Issue

#3416

## Motivation and Context

- This change makes the hard-coded list of output name tags configurable. It allows users to specify their preferred output name tags via an environment setting `NOMINATIM_OUTPUT_NAMES` as suggested in the issue.
- Resolves #3416

## How Has This Been Tested?

- Added pytest cases to test the implementation
- `test_default_output_name_tags` tests the default setting (previously hardcoded) in case environment config is not provided
- `test_configurable_output_name_tags` tests the output name tags when environment config is provided

Change will not affect other areas of code since previous behavior is preserved while enhancing the configurability if required