### PR TITLE
After install point user to '/status' not '/' path

### DIFF
--- a/vagrant/Install-on-Ubuntu-22.sh
+++ b/vagrant/Install-on-Ubuntu-22.sh
@@ -252,7 +252,8 @@ else                                  #DOCS:
     sudo systemctl restart apache2
 fi                                    #DOCS:
 
-# The Nominatim API is now available at `http://localhost/nominatim/`.
+# The Nominatim API is now available at `http://localhost/nominatim/`. Point your browser
+# to the status output `http://localhost/nominatim/status` to test if everything is ok.
 
 fi   #DOCS:
 
@@ -298,6 +299,7 @@ else                                  #DOCS:
     sudo systemctl restart nginx
 fi                                    #DOCS:
 
-# The Nominatim API is now available at `http://localhost/nominatim/`.
+# The Nominatim API is now available at `http://localhost/nominatim/`. Point your browser
+# to the status output `http://localhost/nominatim/status` to test if everything is ok.
 
 fi   #DOCS:

--- a/vagrant/Install-on-Ubuntu-24.sh
+++ b/vagrant/Install-on-Ubuntu-24.sh
@@ -250,7 +250,8 @@ else                                  #DOCS:
     sudo systemctl restart apache2
 fi                                    #DOCS:
 
-# The Nominatim API is now available at `http://localhost/nominatim/`.
+# The Nominatim API is now available at `http://localhost/nominatim/`. Point your browser
+# to the status output `http://localhost/nominatim/status` to test if everything is ok.
 
 fi   #DOCS:
 
@@ -296,6 +297,7 @@ else                                  #DOCS:
     sudo systemctl restart nginx
 fi                                    #DOCS:
 
-# The Nominatim API is now available at `http://localhost/nominatim/`.
+# The Nominatim API is now available at `http://localhost/nominatim/`. Point your browser
+# to the status output `http://localhost/nominatim/status` to test if everything is ok.
 
 fi   #DOCS:


### PR DESCRIPTION
At https://nominatim.org/release-docs/latest/admin/Deployment-Python/ (very last line) we already point users to the status endpoint because there is no default redirect if no endpoint is selected. Do the same in the Ubuntu install instructions. Avoids confusion like https://github.com/osm-search/Nominatim/discussions/3471#discussioncomment-10000220 had.