### PR TITLE
Add data warn if frozen

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,3 +16,7 @@ ignored-classes=NominatimArgs,closing
 disable=too-few-public-methods,duplicate-code,too-many-ancestors,bad-option-value,no-self-use,not-context-manager,use-dict-literal,chained-comparison,attribute-defined-outside-init,too-many-boolean-expressions,contextmanager-generator-missing-cleanup
 
 good-names=i,j,x,y,m,t,fd,db,cc,x1,x2,y1,y2,pt,k,v,nr
+
+[DESIGN]
+
+max-returns=7

--- a/docs/admin/Advanced-Installations.md
+++ b/docs/admin/Advanced-Installations.md
@@ -239,6 +239,6 @@ If you are using the legacy tokenizer you might also have to switch to the
 PostgreSQL module that was compiled on your target machine. If you get errors
 that PostgreSQL cannot find or access `nominatim.so` then rerun
 
-   nominatim refresh --functions
+    nominatim refresh --functions
 
 on the target machine to update the the location of the module.


### PR DESCRIPTION
For https://github.com/osm-search/Nominatim/discussions/3494

```
$ nominatim import --osm-file country1.pbf --no-updates
$ nominatim add-data --file country2.pbf
Using project directory: /home/vagrant/nominatim-project
Database is marked frozen. New data can't be added.
```

The [documentation](https://nominatim.org/release-docs/develop/admin/Import/) seems to cover it already: `Warning:
The data structure for updates are also required when adding additional data after the import, for example [TIGER housenumber data](https://nominatim.org/release-docs/develop/customize/Tiger/). If you plan to use those, you must not use the --no-updates parameter. Do a normal import, add the external data and once you are done with everything run nominatim freeze.`

I added a new pylint exception. Happy to restructure the code instead or limit the exception to just that file if you have ideas.