### PR TITLE
Add deprecation warnings and check for osm2pgsql version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,3 +271,7 @@ if (INSTALL_MUNIN_PLUGINS)
                   munin/nominatim_requests
             DESTINATION ${NOMINATIM_MUNINDIR})
 endif()
+
+message(WARNING "Building with CMake is deprecated and will be removed in Nominatim 5.0."
+                "Use Nominatim pip packages instead.\n"
+                "See https://nominatim.org/release-docs/develop/admin/Installation/#downloading-and-building-nominatim")

--- a/docs/admin/Deployment-PHP.md
+++ b/docs/admin/Deployment-PHP.md
@@ -1,5 +1,8 @@
 # Deploying Nominatim using the PHP frontend
 
+!!! danger
+    The PHP frontend is deprecated and will be removed in Nominatim 5.0.
+
 The Nominatim API is implemented as a PHP application. The `website/` directory
 in the project directory contains the configured website. You can serve this
 in a production environment with any web server that is capable to run

--- a/docs/admin/Import.md
+++ b/docs/admin/Import.md
@@ -302,6 +302,9 @@ To run Nominatim via webservers like Apache or nginx, please continue reading
 
 #### Testing the PHP frontend
 
+!!! danger
+    The PHP fronted is deprecated and will be removed in Nominatim 5.0.
+
 You can run a small test server with the PHP frontend like this:
 
 ```sh

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -72,7 +72,7 @@ For running the Python frontend:
     * [starlette](https://www.starlette.io/)
   * [uvicorn](https://www.uvicorn.org/)
 
-For running the legacy PHP frontend:
+For running the legacy PHP frontend (deprecated, will be removed in Nominatim 5.0):
 
   * [PHP](https://php.net) (7.3+)
   * PHP-pgsql
@@ -194,6 +194,7 @@ sudo make install
     cmake: `cmake -DBUILD_MODULE=on ../Nominatim`. To compile the module
     you need to have the server development headers for PostgreSQL installed.
     On Ubuntu/Debian run: `sudo apt install postgresql-server-dev-<postgresql version>`
+    The legacy tokenizer is deprecated and will be removed in Nominatim 5.0
 
 
 Nominatim installs itself into `/usr/local` per default. To choose a different

--- a/docs/admin/Migration.md
+++ b/docs/admin/Migration.md
@@ -1,12 +1,17 @@
 # Database Migrations
 
-Since version 3.7.0 Nominatim offers automatic migrations. Please follow
+Nominatim offers automatic migrations since version 3.7. Please follow
 the following steps:
 
-* stop any updates that are potentially running
-* update Nominatim to the newer version
-* go to your project directory and run `nominatim admin --migrate`
-* (optionally) restart updates
+* Stop any updates that are potentially running
+* Update the backend: `pip install -U nominatim-db`
+* Go to your project directory and run `nominatim admin --migrate`
+* Update the frontend: `pip install -U nominatim-api`
+* (optionally) Restart updates
+
+If you are still using CMake for the installation of Nominatim, then you
+need to update the software in one step before migrating the database.
+It is not recommended to do this while the machine is serving requests.
 
 Below you find additional migrations and hints about other structural and
 breaking changes. **Please read them before running the migration.**

--- a/docs/customize/SQLite.md
+++ b/docs/customize/SQLite.md
@@ -12,10 +12,15 @@ To use a SQLite database, you need to install:
 
 * SQLite (>= 3.30)
 * Spatialite (> 5.0.0)
+* aiosqlite
 
 On Ubuntu/Debian, you can run:
 
     sudo apt install sqlite3 libsqlite3-mod-spatialite libspatialite7
+
+Install the aiosqlite Python package in your virtual environment:
+
+    /srv/nominatim-venv/bin/pip install aiosqlite
 
 ## Creating a new SQLite database
 

--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -17,6 +17,11 @@ they can be configured.
 
 ## Legacy tokenizer
 
+!!! danger
+    The Legacy tokenizer is deprecated and will be removed in Nominatim 5.0.
+    If you still use a database with the legacy tokenizer, you must reimport
+    it using the ICU tokenizer below.
+
 The legacy tokenizer implements the analysis algorithms of older Nominatim
 versions. It uses a special Postgresql module to normalize names and queries.
 This tokenizer is automatically installed and used when upgrading an older

--- a/src/nominatim_db/cli.py
+++ b/src/nominatim_db/cli.py
@@ -119,7 +119,13 @@ class CommandlineParser:
         log.warning('Using project directory: %s', str(args.project_dir))
 
         try:
-            return args.command.run(args)
+            ret = args.command.run(args)
+
+            if args.config.TOKENIZER == 'legacy':
+                log.warning('WARNING: the "legacy" tokenizer is deprecated '
+                            'and will be removed in Nominatim 5.0.')
+
+            return ret
         except UsageError as exception:
             if log.isEnabledFor(logging.DEBUG):
                 raise # use Python's exception printing
@@ -169,6 +175,8 @@ class AdminServe:
         if args.engine == 'php':
             if args.config.lib_dir.php is None:
                 raise UsageError("PHP frontend not configured.")
+            LOG.warning('\n\nWARNING: the PHP frontend is deprecated '
+                        'and will be removed in Nominatim 5.0.\n\n')
             run_php_server(args.server, args.project_dir / 'website')
         else:
             asyncio.run(self.run_uvicorn(args))

--- a/src/nominatim_db/tokenizer/legacy_tokenizer.py
+++ b/src/nominatim_db/tokenizer/legacy_tokenizer.py
@@ -38,10 +38,12 @@ LOG = logging.getLogger()
 def create(dsn: str, data_dir: Path) -> 'LegacyTokenizer':
     """ Create a new instance of the tokenizer provided by this module.
     """
+    LOG.warning('WARNING: the legacy tokenizer is deprecated '
+                'and will be removed in Nominatim 5.0.')
     return LegacyTokenizer(dsn, data_dir)
 
 
-def _install_module(config_module_path: str, src_dir: Path, module_dir: Path) -> str:
+def _install_module(config_module_path: str, src_dir: Optional[Path], module_dir: Path) -> str:
     """ Copies the PostgreSQL normalisation module into the project
         directory if necessary. For historical reasons the module is
         saved in the '/module' subdirectory and not with the other tokenizer
@@ -54,6 +56,10 @@ def _install_module(config_module_path: str, src_dir: Path, module_dir: Path) ->
     if config_module_path:
         LOG.info("Using custom path for database module at '%s'", config_module_path)
         return config_module_path
+
+    # Otherwise a source dir must be given.
+    if src_dir is None:
+        raise UsageError("The legacy tokenizer cannot be used with the Nominatim pip module.")
 
     # Compatibility mode for builddir installations.
     if module_dir.exists() and src_dir.samefile(module_dir):

--- a/src/nominatim_db/version.py
+++ b/src/nominatim_db/version.py
@@ -62,6 +62,7 @@ NOMINATIM_VERSION = parse_version('4.4.99-1')
 
 POSTGRESQL_REQUIRED_VERSION = (9, 6)
 POSTGIS_REQUIRED_VERSION = (2, 2)
+OSM2PGSQL_REQUIRED_VERSION = (1, 8)
 
 # Cmake sets a variable @GIT_HASH@ by executing 'git --log'. It is not run
 # on every execution of 'make'.

--- a/test/python/tools/conftest.py
+++ b/test/python/tools/conftest.py
@@ -7,10 +7,23 @@
 import pytest
 
 @pytest.fixture
-def osm2pgsql_options(temp_db):
-    """ A standard set of options for osm2pgsql.
+def osm2pgsql_options(temp_db, tmp_path):
+    """ A standard set of options for osm2pgsql
+        together with a osm2pgsql mock that just reflects the command line.
     """
-    return dict(osm2pgsql='echo',
+    osm2pgsql_exec = tmp_path / 'osm2pgsql_mock'
+
+    osm2pgsql_exec.write_text("""#!/bin/sh
+
+if [ "$*" = "--version" ]; then
+  >&2 echo "2024-08-09 11:16:23  osm2pgsql version 11.7.2 (11.7.2)"
+else
+  echo "$@"
+fi
+    """)
+    osm2pgsql_exec.chmod(0o777)
+
+    return dict(osm2pgsql=str(osm2pgsql_exec),
                 osm2pgsql_cache=10,
                 osm2pgsql_style='style.file',
                 threads=1,


### PR DESCRIPTION
This adds warnings in code and documentation about the deprecations as announced [at the end of last year](https://nominatim.org/2023/12/19/roadmap-nominatim5.html): PHP, legacy tokenizer and CMake.

With an external osm2pgsql as the default, it also becomes important to ensure that it's version is recent enough. Minimum version needed is 1.8, which is available in Debian Bookworm, Debian Bullseye (through backports) and Ubuntu 24.04. The version shipped with Ubunutu 22.04 is too old.