### PR TITLE
Vagrant install: remove custom python path

### DIFF
--- a/vagrant/Install-on-Ubuntu-24.sh
+++ b/vagrant/Install-on-Ubuntu-24.sh
@@ -176,7 +176,6 @@ Requires=nominatim.socket
 
 [Service]
 Type=simple
-Environment="PYTHONPATH=/usr/local/lib/nominatim/lib-python/"
 User=www-data
 Group=www-data
 WorkingDirectory=$USERHOME/nominatim-project


### PR DESCRIPTION
Not needed anymore, now that Nominatim is installed within the virtual environment.

See #3511.