### PR TITLE
Extend use of custom result formatters to CLI tool

### DIFF
--- a/docs/customize/Result-Formatting.md
+++ b/docs/customize/Result-Formatting.md
@@ -180,6 +180,26 @@ me@machine:planet-project$
 They will also emit full error messages when there is a problem with the
 code you need to debug.
 
+!!! danger
+    In some cases, when you make an error with your import statement, the
+    CLI will not give you an error but instead tell you, that the API
+    commands are no longer available:
+
+        me@machine: nominatim status
+        usage: nominatim [-h] [--version] {import,freeze,replication,special-phrases,add-data,index,refresh,admin} ...
+        nominatim: error: argument subcommand: invalid choice: 'status'
+
+    This happens because the CLI tool is meant to still work when the
+    nominatim-api package is not installed. Import errors involving
+    `nominatim_api` are interpreted as "package not installed".
+
+    Use the help command to find out which is the offending import that
+    could not be found:
+
+        me@machine: nominatim -h
+        ... [other help text] ...
+        Nominatim API package not found (was looking for module: nominatim_api.xxx).
+
 ## Reference
 
 ### FormatDispatcher

--- a/docs/customize/Result-Formatting.md
+++ b/docs/customize/Result-Formatting.md
@@ -66,6 +66,8 @@ For example, let us extend the result for the status call in text format
 and add the server URL. Such a formatter would look like this:
 
 ``` python
+from nominatim_api import StatusResult
+
 @dispatch.format_func(StatusResult, 'text')
 def _format_status_text(result, _):
     header = 'Status for server nominatim.openstreetmap.org'
@@ -86,6 +88,8 @@ as adding formatting functions for all result types using the custom
 format name:
 
 ``` python
+from nominatim_api import StatusResult
+
 @dispatch.format_func(StatusResult, 'chatty')
 def _format_status_text(result, _):
     if result.status:

--- a/src/nominatim_api/__init__.py
+++ b/src/nominatim_api/__init__.py
@@ -39,6 +39,7 @@ from .results import (SourceTable as SourceTable,
                       SearchResult as SearchResult,
                       SearchResults as SearchResults)
 from .localization import (Locales as Locales)
-from .result_formatting import (FormatDispatcher as FormatDispatcher)
+from .result_formatting import (FormatDispatcher as FormatDispatcher,
+                                load_format_dispatcher as load_format_dispatcher)
 
 from .version import NOMINATIM_API_VERSION as __version__

--- a/src/nominatim_api/v1/__init__.py
+++ b/src/nominatim_api/v1/__init__.py
@@ -11,9 +11,3 @@ Implementation of API version v1 (aka the legacy version).
 #pylint: disable=useless-import-alias
 
 from .server_glue import ROUTES as ROUTES
-
-from . import format as _format
-
-list_formats = _format.dispatch.list_formats
-supports_format = _format.dispatch.supports_format
-format_result = _format.dispatch.format_result

--- a/src/nominatim_db/cli.py
+++ b/src/nominatim_db/cli.py
@@ -243,7 +243,8 @@ def get_set_parser() -> CommandlineParser:
             raise ex
 
         parser.parser.epilog = \
-            '\n\nNominatim API package not found. The following commands are not available:'\
+            f'\n\nNominatim API package not found (was looking for module: {ex.name}).'\
+            '\nThe following commands are not available:'\
             '\n    export, convert, serve, search, reverse, lookup, details, status'\
             "\n\nRun 'pip install nominatim-api' to install the package."
 

--- a/src/nominatim_db/clicmd/api.py
+++ b/src/nominatim_db/clicmd/api.py
@@ -122,10 +122,16 @@ def _print_output(formatter: napi.FormatDispatcher, result: Any,
     output = formatter.format_result(result, fmt, options)
     if formatter.get_content_type(fmt) == CONTENT_JSON:
         # reformat the result, so it is pretty-printed
-        json.dump(json.loads(output), sys.stdout, indent=4, ensure_ascii=False)
+        try:
+            json.dump(json.loads(output), sys.stdout, indent=4, ensure_ascii=False)
+        except json.decoder.JSONDecodeError as err:
+            # Catch the error here, so that data can be debugged,
+            # when people are developping custom result formatters.
+            LOG.fatal("Parsing json failed: %s\nUnformatted output:\n%s", err, output)
     else:
         sys.stdout.write(output)
     sys.stdout.write('\n')
+
 
 class APISearch:
     """\

--- a/src/nominatim_db/clicmd/args.py
+++ b/src/nominatim_db/clicmd/args.py
@@ -137,6 +137,7 @@ class NominatimArgs:
 
     # Arguments to all query functions
     format: str
+    list_formats: bool
     addressdetails: bool
     extratags: bool
     namedetails: bool

--- a/test/python/api/test_result_formatting_v1_reverse.py
+++ b/test/python/api/test_result_formatting_v1_reverse.py
@@ -15,7 +15,7 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
-import nominatim_api.v1 as api_impl
+from nominatim_api.v1.format import dispatch as v1_format
 import nominatim_api as napi
 
 FORMATS = ['json', 'jsonv2', 'geojson', 'geocodejson', 'xml']
@@ -26,7 +26,7 @@ def test_format_reverse_minimal(fmt):
                                  ('amenity', 'post_box'),
                                  napi.Point(0.3, -8.9))
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt, {})
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt, {})
 
     if fmt == 'xml':
         root = ET.fromstring(raw)
@@ -38,7 +38,7 @@ def test_format_reverse_minimal(fmt):
 
 @pytest.mark.parametrize('fmt', FORMATS)
 def test_format_reverse_no_result(fmt):
-    raw = api_impl.format_result(napi.ReverseResults(), fmt, {})
+    raw = v1_format.format_result(napi.ReverseResults(), fmt, {})
 
     if fmt == 'xml':
         root = ET.fromstring(raw)
@@ -55,7 +55,7 @@ def test_format_reverse_with_osm_id(fmt):
                                  place_id=5564,
                                  osm_object=('N', 23))
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt, {})
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt, {})
 
     if fmt == 'xml':
         root = ET.fromstring(raw).find('result')
@@ -103,7 +103,7 @@ def test_format_reverse_with_address(fmt):
                                  ]))
     reverse.localize(napi.Locales())
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'addressdetails': True})
 
 
@@ -167,7 +167,7 @@ def test_format_reverse_geocodejson_special_parts():
 
     reverse.localize(napi.Locales())
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), 'geocodejson',
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), 'geocodejson',
                                  {'addressdetails': True})
 
     props = json.loads(raw)['features'][0]['properties']['geocoding']
@@ -183,7 +183,7 @@ def test_format_reverse_with_address_none(fmt):
                                  napi.Point(1.0, 2.0),
                                  address_rows=napi.AddressLines())
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'addressdetails': True})
 
 
@@ -213,7 +213,7 @@ def test_format_reverse_with_extratags(fmt):
                                  napi.Point(1.0, 2.0),
                                  extratags={'one': 'A', 'two':'B'})
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'extratags': True})
 
     if fmt == 'xml':
@@ -235,7 +235,7 @@ def test_format_reverse_with_extratags_none(fmt):
                                  ('place', 'thing'),
                                  napi.Point(1.0, 2.0))
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'extratags': True})
 
     if fmt == 'xml':
@@ -258,7 +258,7 @@ def test_format_reverse_with_namedetails_with_name(fmt):
                                  napi.Point(1.0, 2.0),
                                  names={'name': 'A', 'ref':'1'})
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'namedetails': True})
 
     if fmt == 'xml':
@@ -280,7 +280,7 @@ def test_format_reverse_with_namedetails_without_name(fmt):
                                  ('place', 'thing'),
                                  napi.Point(1.0, 2.0))
 
-    raw = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                  {'namedetails': True})
 
     if fmt == 'xml':
@@ -302,7 +302,7 @@ def test_search_details_with_icon_available(fmt):
                                  ('amenity', 'restaurant'),
                                  napi.Point(1.0, 2.0))
 
-    result = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    result = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                     {'icon_base_url': 'foo'})
 
     js = json.loads(result)
@@ -316,7 +316,7 @@ def test_search_details_with_icon_not_available(fmt):
                                  ('amenity', 'tree'),
                                  napi.Point(1.0, 2.0))
 
-    result = api_impl.format_result(napi.ReverseResults([reverse]), fmt,
+    result = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                     {'icon_base_url': 'foo'})
 
     assert 'icon' not in json.loads(result)

--- a/test/python/cli/test_cmd_api.py
+++ b/test/python/cli/test_cmd_api.py
@@ -13,6 +13,15 @@ import pytest
 import nominatim_db.clicmd.api
 import nominatim_api as napi
 
+@pytest.mark.parametrize('call', ['search', 'reverse', 'lookup', 'details', 'status'])
+def test_list_format(cli_call, call):
+    assert 0 == cli_call(call, '--list-formats')
+
+
+@pytest.mark.parametrize('call', ['search', 'reverse', 'lookup', 'details', 'status'])
+def test_bad_format(cli_call, call):
+    assert 1 == cli_call(call, '--format', 'rsdfsdfsdfsaefsdfsd')
+
 
 class TestCliStatusCall:
 


### PR DESCRIPTION
The API functions of the nominatim CLI tool can now also show the outputs created by custom result formatters. There is a new option `--list-formats` for all of them, which can be used to check, which formats are configured. This should particularly come in handy when you are writing your own formatters. In contrast to the server, the CLI tool will properly report on any exceptions in the code with the usual Python backtrace making debugging easy.

Also corrects and improves the documentation on result formatters:
* add section about error message formatting
* add some missing imports in the examples
* add a hint about debugging formatters using the CLI tool
* correct a comment that indicated that new formats must be implemented for all result types, that's simply not true