### PR TITLE
Don't use OS environment variables when an explicit environment was set

### DIFF
--- a/src/nominatim_db/config.py
+++ b/src/nominatim_db/config.py
@@ -61,7 +61,7 @@ class Configuration:
 
     def __init__(self, project_dir: Optional[Union[Path, str]],
                  environ: Optional[Mapping[str, str]] = None) -> None:
-        self.environ = environ or os.environ
+        self.environ = os.environ if environ is None else environ
         self.config_dir = paths.CONFIG_DIR
         self._config = dotenv_values(str(self.config_dir / 'env.defaults'))
         if project_dir is not None:

--- a/test/python/api/search/test_icu_query_analyzer.py
+++ b/test/python/api/search/test_icu_query_analyzer.py
@@ -38,7 +38,7 @@ async def conn(table_factory):
     table_factory('word',
                   definition='word_id INT, word_token TEXT, type TEXT, word TEXT, info JSONB')
 
-    async with NominatimAPIAsync(environ={}) as api:
+    async with NominatimAPIAsync() as api:
         async with api.begin() as conn:
             yield conn
 

--- a/test/python/api/search/test_legacy_query_analyzer.py
+++ b/test/python/api/search/test_legacy_query_analyzer.py
@@ -72,7 +72,7 @@ async def conn(table_factory, temp_db_cursor):
     temp_db_cursor.execute("""CREATE OR REPLACE FUNCTION make_standard_name(name TEXT)
                               RETURNS TEXT AS $$ SELECT lower(name); $$ LANGUAGE SQL;""")
 
-    async with NominatimAPIAsync(environ={}) as api:
+    async with NominatimAPIAsync() as api:
         async with api.begin() as conn:
             yield conn
 

--- a/test/python/api/test_api_status.py
+++ b/test/python/api/test_api_status.py
@@ -45,7 +45,7 @@ def test_status_full(apiobj, frontend):
 def test_status_database_not_found(monkeypatch):
     monkeypatch.setenv('NOMINATIM_DATABASE_DSN', 'dbname=rgjdfkgjedkrgdfkngdfkg')
 
-    api = napi.NominatimAPI(environ={})
+    api = napi.NominatimAPI()
 
     result = api.status()
 


### PR DESCRIPTION
The Configuration object can either be instantiated to use the OS environment or be given an explicit set of configuration variables. This fixes an issue where giving an empty set of configuration variables would result in the OS environment being used.