### PR TITLE
Improve bounding boxes for postcodes

### DIFF
--- a/src/nominatim_api/search/db_searches.py
+++ b/src/nominatim_api/search/db_searches.py
@@ -616,6 +616,8 @@ class PostcodeSearch(AbstractSearch):
 
             for prow in await conn.execute(placex_sql, _details_to_bind_params(details)):
                 result = nres.create_from_placex_row(prow, nres.SearchResult)
+                if result is not None:
+                    result.bbox = Bbox.from_wkb(prow.bbox)
                 break
             else:
                 result = nres.create_from_postcode_row(row, nres.SearchResult)

--- a/src/nominatim_api/v1/classtypes.py
+++ b/src/nominatim_api/v1/classtypes.py
@@ -48,7 +48,12 @@ def bbox_from_result(result: Union[ReverseResult, SearchResult]) -> Bbox:
         around the centroid according to dimensions derived from the
         search rank.
     """
+    if result.category == ('place', 'postcode') and result.bbox is None:
+        return Bbox.from_point(result.centroid,
+                               0.05 - 0.012 * (result.rank_search - 21))
+
     if (result.osm_object and result.osm_object[0] == 'N') or result.bbox is None:
+
         extent = NODE_EXTENT.get(result.category, 0.00005)
         return Bbox.from_point(result.centroid, extent)
 

--- a/test/python/api/search/test_search_postcode.py
+++ b/test/python/api/search/test_search_postcode.py
@@ -59,6 +59,19 @@ def test_postcode_with_country(apiobj, frontend):
     assert results[0].place_id == 101
 
 
+def test_postcode_area(apiobj, frontend):
+    apiobj.add_postcode(place_id=100, country_code='ch', postcode='12345')
+    apiobj.add_placex(place_id=200, country_code='ch', postcode='12345',
+                      osm_type='R', osm_id=34, class_='boundary', type='postal_code',
+                      geometry='POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')
+
+    results = run_search(apiobj, frontend, 0.3, ['12345'], [0.0])
+
+    assert len(results) == 1
+    assert results[0].place_id == 200
+    assert results[0].bbox.area == 1
+
+
 class TestPostcodeSearchWithAddress:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
For postcode areas, return the actual bbox of the area. For postcode points, use rank search to adapt the size of the bounding box to the likely coverage.

Also adds a `raw` output for the CLI search commands which dumps the original search result with all available info. Can be useful for debugging and when writing your own formatters.