### PR TITLE
Improve centroid computation for line strings

### DIFF
--- a/lib-sql/functions/interpolation.sql
+++ b/lib-sql/functions/interpolation.sql
@@ -121,6 +121,8 @@ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION osmline_insert()
   RETURNS TRIGGER
   AS $$
+DECLARE
+  centroid GEOMETRY;
 BEGIN
   NEW.place_id := nextval('seq_place');
   NEW.indexed_date := now();
@@ -135,10 +137,11 @@ BEGIN
       END IF;
 
       NEW.indexed_status := 1; --STATUS_NEW
-      NEW.country_code := lower(get_country_code(NEW.linegeo));
+      centroid := get_center_point(NEW.linegeo);
+      NEW.country_code := lower(get_country_code(centroid));
 
       NEW.partition := get_partition(NEW.country_code);
-      NEW.geometry_sector := geometry_sector(NEW.partition, NEW.linegeo);
+      NEW.geometry_sector := geometry_sector(NEW.partition, centroid);
   END IF;
 
   RETURN NEW;

--- a/lib-sql/functions/interpolation.sql
+++ b/lib-sql/functions/interpolation.sql
@@ -176,8 +176,8 @@ BEGIN
   END IF;
 
   NEW.parent_place_id := get_interpolation_parent(NEW.token_info, NEW.partition,
-                                                 ST_PointOnSurface(NEW.linegeo),
-                                                 NEW.linegeo);
+                                                  get_center_point(NEW.linegeo),
+                                                  NEW.linegeo);
 
   -- Cannot find a parent street. We will not be able to display a reliable
   -- address, so drop entire interpolation.

--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -668,7 +668,7 @@ BEGIN
   NEW.place_id := nextval('seq_place');
   NEW.indexed_status := 1; --STATUS_NEW
 
-  NEW.centroid := ST_PointOnSurface(NEW.geometry);
+  NEW.centroid := get_center_point(NEW.geometry);
   NEW.country_code := lower(get_country_code(NEW.centroid));
 
   NEW.partition := get_partition(NEW.country_code);
@@ -870,7 +870,7 @@ BEGIN
   END IF;
 
   -- Compute a preliminary centroid.
-  NEW.centroid := ST_PointOnSurface(NEW.geometry);
+  NEW.centroid := get_center_point(NEW.geometry);
 
     -- recalculate country and partition
   IF NEW.rank_search = 4 AND NEW.address is not NULL AND NEW.address ? 'country' THEN

--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -27,15 +27,11 @@ $$
 LANGUAGE plpgsql IMMUTABLE;
 
 
-CREATE OR REPLACE FUNCTION geometry_sector(partition INTEGER, place geometry)
+CREATE OR REPLACE FUNCTION geometry_sector(partition INTEGER, place GEOMETRY)
   RETURNS INTEGER
   AS $$
-DECLARE
-  NEWgeometry geometry;
 BEGIN
---  RAISE WARNING '%',place;
-  NEWgeometry := ST_PointOnSurface(place);
-  RETURN (partition*1000000) + (500-ST_X(NEWgeometry)::integer)*1000 + (500-ST_Y(NEWgeometry)::integer);
+  RETURN (partition*1000000) + (500-ST_X(place)::INTEGER)*1000 + (500-ST_Y(place)::INTEGER);
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE;
@@ -179,16 +175,13 @@ $$
 LANGUAGE plpgsql STABLE;
 
 
-CREATE OR REPLACE FUNCTION get_country_code(place geometry)
+CREATE OR REPLACE FUNCTION get_country_code(place_centre geometry)
   RETURNS TEXT
   AS $$
 DECLARE
-  place_centre GEOMETRY;
   nearcountry RECORD;
   countries TEXT[];
 BEGIN
-  place_centre := ST_PointOnSurface(place);
-
 -- RAISE WARNING 'get_country_code, start: %', ST_AsText(place_centre);
 
   -- Try for a OSM polygon

--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -7,6 +7,26 @@
 
 -- Assorted helper functions for the triggers.
 
+CREATE OR REPLACE FUNCTION get_center_point(place GEOMETRY)
+  RETURNS GEOMETRY
+  AS $$
+DECLARE
+  geom_type TEXT;
+BEGIN
+  geom_type := ST_GeometryType(place);
+  IF geom_type = ' ST_Point' THEN
+    RETURN place;
+  END IF;
+  IF geom_type = 'ST_LineString' THEN
+    RETURN ST_LineInterpolatePoint(place, 0.5);
+  END IF;
+
+  RETURN ST_PointOnSurface(place);
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE;
+
+
 CREATE OR REPLACE FUNCTION geometry_sector(partition INTEGER, place geometry)
   RETURNS INTEGER
   AS $$
@@ -19,6 +39,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE;
+
 
 
 CREATE OR REPLACE FUNCTION array_merge(a INTEGER[], b INTEGER[])


### PR DESCRIPTION
When computing the centroid for line objects (streets etc.) use ST_LineInterpolatePoint instead of ST_PointOnSurface.

ST_PointOnSurface always returns one of the vertices of a line. That' s nice and efficient but means that a two-point line will have the centroid at one of the ends. That's less then ideal for further computations where the centroid is used.

Also removes two places where the centroid was recomputed instead of using the already computed one.

Fixes #3572.