### PR TITLE
Fall back to using the OSM grid country table when no countries are found in the OSM data

### DIFF
--- a/test/bdd/api/reverse/queries.feature
+++ b/test/bdd/api/reverse/queries.feature
@@ -10,13 +10,17 @@ Feature: Reverse geocoding
     Examples:
      | lat      | lon |
      | 0.0      | 0.0 |
-     | -34.830  | -56.105 |
-     | 45.174   | -103.072 |
-     | 21.156   | -12.2744 |
      | 91.3     | 0.4    |
      | -700     | 0.4    |
      | 0.2      | 324.44 |
      | 0.2      | -180.4 |
+
+
+    Scenario: Unknown countries fall back to default country grid
+        When sending v1/reverse at 45.174,-103.072
+        Then results contain
+          | category | type    | display_name |
+          | place    | country | United States |
 
 
     @Tiger


### PR DESCRIPTION
Reverse now falls back to returning country data from the default `country_name` and `country_osm_grid` tables when it cannot find the country polygon in placex. This is similar to what is search is doing when looking up countries that are not imported.

Fixes #3595.

