### PR TITLE
Ignore postcode areas on reverse

### DIFF
--- a/src/nominatim_api/reverse.py
+++ b/src/nominatim_api/reverse.py
@@ -362,6 +362,8 @@ class ReverseGeocoder:
             # later only a minimum of results needs to be checked with ST_Contains.
             inner = sa.select(t, sa.literal(0.0).label('distance'))\
                       .where(t.c.rank_search.between(5, MAX_RANK_PARAM))\
+                      .where(t.c.rank_address != 5)\
+                      .where(t.c.rank_address != 11)\
                       .where(t.c.geometry.intersects(WKT_PARAM))\
                       .where(sa.func.PlacexGeometryReverseLookuppolygon())\
                       .order_by(sa.desc(t.c.rank_search))\


### PR DESCRIPTION
Postcode areas used to be excluded from reverse geocoding in the PHP frontend. This restores the behaviour.

I've considered moving them into an extra layer but that would rather degrade the layer parameter into a category search. Direct postcode reverse search isn't really useful anyways as a separate function. Simply search for the address at that point and use the returned postcode.

Closes #3538.