### PR TITLE
Creating tables and indexes in autocommit mode

### DIFF
--- a/src/nominatim_db/clicmd/setup.py
+++ b/src/nominatim_db/clicmd/setup.py
@@ -122,13 +122,16 @@ class SetupAll:
 
         LOG.warning('Post-process tables')
         with connect(args.config.get_libpq_dsn()) as conn:
+            conn.autocommit = True
             await database_import.create_search_indices(conn, args.config,
                                                         drop=args.no_updates,
                                                         threads=num_threads)
             LOG.warning('Create search index for default country names.')
+            conn.autocommit = False
             country_info.create_country_names(conn, tokenizer,
                                               args.config.get_str_list('LANGUAGES'))
             if args.no_updates:
+                conn.autocommit = True
                 freeze.drop_update_tables(conn)
         tokenizer.finalize_import(args.config)
 
@@ -183,6 +186,7 @@ class SetupAll:
         from ..tools import database_import, refresh
 
         with connect(config.get_libpq_dsn()) as conn:
+            conn.autocommit = True
             LOG.warning('Create functions (1st pass)')
             refresh.create_functions(conn, config, False, False)
             LOG.warning('Create tables')


### PR DESCRIPTION
The CI tests are repeatedly running into issues where a deadlock kills the import during the stage where tables and indexes are created. From the Postgresql logs it looks like the deadlock is against the autovacuum process. According to the [documentation](https://www.postgresql.org/docs/current/routine-vacuuming.html) this shouldn't be happening unless we have a forced transaction-id-wraparound vacuum. That seems rather unlikely after having only imported a small Liechtenstein extract.

Currently the create commands all run in a single connection. It might be that multiple sequential creates create a situation where autovacuum can't cancel itself anymore. At least that is the assumption in this PR. Hard to test. Lets see if the CI failures stop.