### PR TITLE
Enable output of extratags for geocodejson format

### DIFF
--- a/docs/api/Output.md
+++ b/docs/api/Output.md
@@ -106,8 +106,11 @@ The following feature attributes are implemented:
  * `name` - localised name of the place
  * `housenumber`, `street`, `locality`, `district`, `postcode`, `city`,
    `county`, `state`, `country` -
-   provided when it can be determined from the address
+   provided when it can be determined from the address (only with `addressdetails=1`)
  * `admin` - list of localised names of administrative boundaries (only with `addressdetails=1`)
+ * `extra` - dictionary with additional useful tags like `website` or `maxspeed`
+   (only with `extratags=1`)
+
 
 Use `polygon_geojson` to output the full geometry of the object instead
 of the centroid.

--- a/src/nominatim_api/v1/format_json.py
+++ b/src/nominatim_api/v1/format_json.py
@@ -249,6 +249,9 @@ def format_base_geocodejson(results: Union[ReverseResults, SearchResults],
                         out.keyval(f"level{line.admin_level}", line.local_name)
             out.end_object().next()
 
+        if options.get('extratags', False):
+            out.keyval('extra', result.extratags)
+
         out.end_object().next().end_object().next()
 
         out.key('geometry').raw(result.geometry.get('geojson')


### PR DESCRIPTION
This add support for the `extratags` parameter for the geocodejson format. The data is available in the additional `extra` field. This follows the standard already [set by Photon](https://github.com/komoot/photon/pull/576) a while ago.