### PR TITLE
Move Github actions to Unbuntu-22 image

### DIFF
--- a/.github/actions/setup-postgresql/action.yml
+++ b/.github/actions/setup-postgresql/action.yml
@@ -11,10 +11,8 @@ runs:
     steps:
         - name: Remove existing PostgreSQL
           run: |
+              sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
               sudo apt-get purge -yq postgresql*
-              sudo apt install curl ca-certificates gnupg
-              curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
-              sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
               sudo apt-get update -qq
 
           shell: bash

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,10 +37,10 @@ jobs:
         needs: create-archive
         strategy:
             matrix:
-                flavour: ["ubuntu-20", "ubuntu-24"]
+                flavour: ["ubuntu-22", "ubuntu-24"]
                 include:
-                    - flavour: ubuntu-20
-                      ubuntu: 20
+                    - flavour: ubuntu-22
+                      ubuntu: 22
                       postgresql: 12
                       lua: '5.1'
                       dependencies: pip
@@ -81,7 +81,7 @@ jobs:
                   sudo make install
                   cd ../..
                   rm -rf osm2pgsql-build
-              if: matrix.ubuntu == '20'
+              if: matrix.ubuntu == '22'
               env:
                   LUA_VERSION: ${{ matrix.lua }}
 


### PR DESCRIPTION
Github actions will remove the Ubuntu-20 image soon. We don't support Ubuntu 20.04 anymore anyway, so just move over to Ubuntu 22.04.

Also changes PostgreSQL installation to use the nice little script by Debian for adding the PostgreSQL apt repository.