### PR TITLE
Strip leading and trailing space markers during normalization

### DIFF
--- a/src/nominatim_api/query_preprocessing/normalize.py
+++ b/src/nominatim_api/query_preprocessing/normalize.py
@@ -27,5 +27,5 @@ def create(config: QueryConfig) -> QueryProcessingFunc:
 
     return lambda phrases: list(
         filter(lambda p: p.text,
-               (Phrase(p.ptype, cast(str, normalizer.transliterate(p.text)))
+               (Phrase(p.ptype, cast(str, normalizer.transliterate(p.text)).strip('-: '))
                 for p in phrases)))

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -244,7 +244,7 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
             standardized form search will work with. All information removed
             at this stage is inevitably lost.
         """
-        return cast(str, self.normalizer.transliterate(text))
+        return cast(str, self.normalizer.transliterate(text)).strip('-: ')
 
     def split_query(self, query: qmod.QueryStruct) -> Tuple[QueryParts, WordDict]:
         """ Transliterate the phrases and split them into tokens.

--- a/test/bdd/api/search/structured.feature
+++ b/test/bdd/api/search/structured.feature
@@ -67,3 +67,13 @@ Feature: Structured search queries
         Then result addresses contain
           | town |
           | Vaduz |
+
+    #3651
+    Scenario: Structured search with surrounding extra characters
+        When sending xml search query "" with address
+          | street             | city  | postalcode |
+          | "19 Am schrägen Weg" | "Vaduz" | "9491"  |
+        Then result addresses contain
+          | house_number | road |
+          | 19           | Am Schrägen Weg |
+


### PR DESCRIPTION
#3629 introduce two new break types. In contrast to other break types, they are kept during normalisation and only stripped in the final transliteration step. This can lead to issues when theses break types are at the beginning or end of a phrase. This makes sure they are stripped away.

Fixes #3651.