### PR TITLE
Tweak penalties for postcode searches

### DIFF
--- a/src/nominatim_api/search/db_search_builder.py
+++ b/src/nominatim_api/search/db_search_builder.py
@@ -148,7 +148,6 @@ class SearchBuilder:
                                                  [t.token for r in address
                                                   for t in self.query.get_partials_list(r)],
                                                  lookups.Restrict)]
-                penalty += 0.2
             yield dbs.PostcodeSearch(penalty, sdata)
 
     def build_housenumber_search(self, sdata: dbf.SearchData, hnrs: List[Token],

--- a/src/nominatim_api/search/db_searches.py
+++ b/src/nominatim_api/search/db_searches.py
@@ -581,9 +581,13 @@ class PostcodeSearch(AbstractSearch):
                      .where((tsearch.c.name_vector + tsearch.c.nameaddress_vector)
                             .contains(sa.type_coerce(self.lookups[0].tokens,
                                                      IntArray)))
+            # Do NOT add rerank penalties based on the address terms.
+            # The standard rerank penalty only checks the address vector
+            # while terms may appear in name and address vector. This would
+            # lead to overly high penalties.
+            # We assume that a postcode is precise enough to not require
+            # additional full name matches.
 
-        for ranking in self.rankings:
-            penalty += ranking.sql_penalty(conn.t.search_name)
         penalty += sa.case(*((t.c.postcode == v, p) for v, p in self.postcodes),
                            else_=1.0)
 


### PR DESCRIPTION
Tweaks penalties in two places:

* Removes the penalty for doing a combination of postcode+address searches as at least the combination of postcode+city is not uncommon to be searched for.
* Removes full-name match penalties completely. They didn't do the right thing because they matched only against the address part of the parent of the postcode, while the search term may also appear in the name of the parent. This kind of reranking isn't much use anyway for postcodes, as the postcode itself is very restrictive already.

Fixes #3650.