### PR TITLE
Add full parsing of postcodes in query

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1809,7 +1809,8 @@ us:
     languages: en
     names: !include country-names/us.yaml
     postcode:
-      pattern: "ddddd"
+      pattern: "(ddddd)(?:-dddd)?"
+      output: \1
 
 
 # Uruguay (Uruguay)

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -298,12 +298,12 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
 
 
 def _dump_word_tokens(query: qmod.QueryStruct) -> Iterator[List[Any]]:
-    yield ['type', 'token', 'word_token', 'lookup_word', 'penalty', 'count', 'info']
-    for node in query.nodes:
+    yield ['type', 'from', 'to', 'token', 'word_token', 'lookup_word', 'penalty', 'count', 'info']
+    for i, node in enumerate(query.nodes):
         for tlist in node.starting:
             for token in tlist.tokens:
                 t = cast(ICUToken, token)
-                yield [tlist.ttype, t.token, t.word_token or '',
+                yield [tlist.ttype, str(i), str(tlist.end), t.token, t.word_token or '',
                        t.lookup_word or '', t.penalty, t.count, t.info]
 
 

--- a/src/nominatim_api/search/postcode_parser.py
+++ b/src/nominatim_api/search/postcode_parser.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Handling of arbitrary postcode tokens in tokenized query string.
+"""
+from typing import Tuple, Set
+import re
+from collections import defaultdict
+
+import yaml
+
+from ..config import Configuration
+from . import query as qmod
+
+
+class PostcodeParser:
+    """ Pattern-based parser for postcodes in tokenized queries.
+
+        The postcode patterns are read from the country configuration.
+        The parser does currently not return country restrictions.
+    """
+
+    def __init__(self, config: Configuration) -> None:
+        # skip over includes here to avoid loading the complete country name data
+        yaml.add_constructor('!include', lambda loader, node: [],
+                             Loader=yaml.SafeLoader)
+        cdata = yaml.safe_load(config.find_config_file('country_settings.yaml')
+                                     .read_text(encoding='utf-8'))
+
+        unique_patterns = defaultdict(set)
+        for cc, data in cdata.items():
+            if data.get('postcode'):
+                pat = data['postcode']['pattern']
+                out = data['postcode'].get('output')
+                unique_patterns[pat.replace('d', '[0-9]').replace('l', '[a-z]')].add(out)
+
+        self.global_pattern = re.compile(
+                '(?:' +
+                '|'.join(f"(?:{k})" for k in unique_patterns)
+                + ')[:, >]')
+
+        self.local_patterns = [(re.compile(f"(?:{k})[:, >]"), v)
+                               for k, v in unique_patterns.items()]
+
+    def parse(self, query: qmod.QueryStruct) -> Set[Tuple[int, int, str]]:
+        """ Parse postcodes in the given list of query tokens taking into
+            account the list of breaks from the nodes.
+
+            The result is a sequence of tuples with
+            [start node id, end node id, postcode token]
+        """
+        nodes = query.nodes
+        outcodes = set()
+
+        for i in range(query.num_token_slots()):
+            if nodes[i].btype in '<,: ' and nodes[i + 1].btype != '`':
+                word = nodes[i + 1].term_normalized + nodes[i + 1].btype
+                if word[-1] in ' -' and nodes[i + 2].btype != '`':
+                    word += nodes[i + 2].term_normalized + nodes[i + 2].btype
+                    if word[-1] in ' -' and nodes[i + 3].btype != '`':
+                        word += nodes[i + 3].term_normalized + nodes[i + 3].btype
+
+                # Use global pattern to check for presence of any postocde.
+                m = self.global_pattern.match(word)
+                if m:
+                    # If there was a match, check against each pattern separately
+                    # because multiple patterns might be machting at the end.
+                    for pattern, info in self.local_patterns:
+                        lm = pattern.match(word)
+                        if lm:
+                            trange = (i, i + sum(c in ' ,-:>' for c in lm.group(0)))
+                            for out in info:
+                                if out:
+                                    outcodes.add((*trange, lm.expand(out).upper()))
+                                else:
+                                    outcodes.add((*trange, lm.group(0)[:-1].upper()))
+        return outcodes

--- a/src/nominatim_api/search/postcode_parser.py
+++ b/src/nominatim_api/search/postcode_parser.py
@@ -7,7 +7,7 @@
 """
 Handling of arbitrary postcode tokens in tokenized query string.
 """
-from typing import Tuple, Set
+from typing import Tuple, Set, Dict, List
 import re
 from collections import defaultdict
 
@@ -31,20 +31,21 @@ class PostcodeParser:
         cdata = yaml.safe_load(config.find_config_file('country_settings.yaml')
                                      .read_text(encoding='utf-8'))
 
-        unique_patterns = defaultdict(set)
+        unique_patterns: Dict[str, Dict[str, List[str]]] = {}
         for cc, data in cdata.items():
             if data.get('postcode'):
-                pat = data['postcode']['pattern']
+                pat = data['postcode']['pattern'].replace('d', '[0-9]').replace('l', '[a-z]')
                 out = data['postcode'].get('output')
-                unique_patterns[pat.replace('d', '[0-9]').replace('l', '[a-z]')].add(out)
+                if pat not in unique_patterns:
+                    unique_patterns[pat] = defaultdict(list)
+                unique_patterns[pat][out].append(cc)
 
         self.global_pattern = re.compile(
-                '(?:' +
-                '|'.join(f"(?:{k})" for k in unique_patterns)
-                + ')[:, >]')
+                '(?:(?P<cc>[a-z][a-z])(?P<space>[ -]?))?(?P<pc>(?:(?:'
+                + ')|(?:'.join(unique_patterns) + '))[:, >].*)')
 
-        self.local_patterns = [(re.compile(f"(?:{k})[:, >]"), v)
-                               for k, v in unique_patterns.items()]
+        self.local_patterns = [(re.compile(f"{pat}[:, >]"), list(info.items()))
+                               for pat, info in unique_patterns.items()]
 
     def parse(self, query: qmod.QueryStruct) -> Set[Tuple[int, int, str]]:
         """ Parse postcodes in the given list of query tokens taking into
@@ -64,18 +65,22 @@ class PostcodeParser:
                     if word[-1] in ' -' and nodes[i + 3].btype != '`':
                         word += nodes[i + 3].term_normalized + nodes[i + 3].btype
 
-                # Use global pattern to check for presence of any postocde.
-                m = self.global_pattern.match(word)
+                # Use global pattern to check for presence of any postcode.
+                m = self.global_pattern.fullmatch(word)
                 if m:
                     # If there was a match, check against each pattern separately
                     # because multiple patterns might be machting at the end.
+                    cc = m.group('cc')
+                    pc_word = m.group('pc')
+                    cc_spaces = len(m.group('space') or '')
                     for pattern, info in self.local_patterns:
-                        lm = pattern.match(word)
+                        lm = pattern.match(pc_word)
                         if lm:
-                            trange = (i, i + sum(c in ' ,-:>' for c in lm.group(0)))
-                            for out in info:
-                                if out:
-                                    outcodes.add((*trange, lm.expand(out).upper()))
-                                else:
-                                    outcodes.add((*trange, lm.group(0)[:-1].upper()))
+                            trange = (i, i + cc_spaces + sum(c in ' ,-:>' for c in lm.group(0)))
+                            for out, out_ccs in info:
+                                if cc is None or cc in out_ccs:
+                                    if out:
+                                        outcodes.add((*trange, lm.expand(out).upper()))
+                                    else:
+                                        outcodes.add((*trange, lm.group(0)[:-1].upper()))
         return outcodes

--- a/test/bdd/api/search/postcode.feature
+++ b/test/bdd/api/search/postcode.feature
@@ -3,9 +3,8 @@
 Feature: Searches with postcodes
     Various searches involving postcodes
 
-    @Fail
     Scenario: US 5+4 ZIP codes are shortened to 5 ZIP codes if not found
-        When sending json search query "36067 1111, us" with address
+        When sending json search query "36067-1111, us" with address
         Then result addresses contain
             | postcode |
             | 36067    |

--- a/test/bdd/db/import/postcodes.feature
+++ b/test/bdd/db/import/postcodes.feature
@@ -170,7 +170,7 @@ Feature: Import of postcodes
             | object | postcode |
             | W93    | 11200    |
 
-    Scenario: Postcodes are added to the postcode and word table
+    Scenario: Postcodes are added to the postcode
         Given the places
            | osm | class | type  | addr+postcode | addr+housenumber | geometry |
            | N34 | place | house | 01982         | 111              |country:de |
@@ -178,7 +178,6 @@ Feature: Import of postcodes
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | de      | 01982    | country:de |
-        And there are word tokens for postcodes 01982
 
 
     @Fail
@@ -195,7 +194,7 @@ Feature: Import of postcodes
          | E45 2    | gb      | 23          | 5 |
          | Y45      | gb      | 21          | 5 |
 
-    Scenario: Postcodes outside all countries are not added to the postcode and word table
+    Scenario: Postcodes outside all countries are not added to the postcode table
         Given the places
             | osm | class | type  | addr+postcode | addr+housenumber | addr+place  | geometry  |
             | N34 | place | house | 01982         | 111              | Null Island | 0 0.00001 |
@@ -205,7 +204,6 @@ Feature: Import of postcodes
         When importing
         Then location_postcode contains exactly
             | country | postcode | geometry |
-        And there are no word tokens for postcodes 01982
         When sending search query "111, 01982 Null Island"
         Then results contain
             | osm | display_name |

--- a/test/bdd/db/update/postcode.feature
+++ b/test/bdd/db/update/postcode.feature
@@ -2,7 +2,7 @@
 Feature: Update of postcode
     Tests for updating of data related to postcodes
 
-    Scenario: A new postcode appears in the postcode and word table
+    Scenario: A new postcode appears in the postcode table
         Given the places
            | osm | class | type  | addr+postcode | addr+housenumber | geometry |
            | N34 | place | house | 01982         | 111              |country:de |
@@ -18,9 +18,8 @@ Feature: Update of postcode
            | country | postcode | geometry |
            | de      | 01982    | country:de |
            | ch      | 4567     | country:ch |
-        And there are word tokens for postcodes 01982,4567
 
-     Scenario: When the last postcode is deleted, it is deleted from postcode and word
+     Scenario: When the last postcode is deleted, it is deleted from postcode
         Given the places
            | osm | class | type  | addr+postcode | addr+housenumber | geometry |
            | N34 | place | house | 01982         | 111              |country:de |
@@ -31,10 +30,8 @@ Feature: Update of postcode
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | ch      | 4567     | country:ch |
-        And there are word tokens for postcodes 4567
-        And there are no word tokens for postcodes 01982
 
-     Scenario: A postcode is not deleted from postcode and word when it exist in another country
+     Scenario: A postcode is not deleted from postcode when it exist in another country
         Given the places
            | osm | class | type  | addr+postcode | addr+housenumber | geometry |
            | N34 | place | house | 01982         | 111              |country:de |
@@ -45,7 +42,6 @@ Feature: Update of postcode
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | fr      | 01982    | country:fr |
-        And there are word tokens for postcodes 01982
 
      Scenario: Updating a postcode is reflected in postcode table
         Given the places
@@ -59,7 +55,6 @@ Feature: Update of postcode
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | de      | 20453    | country:de |
-        And there are word tokens for postcodes 20453
 
      Scenario: When changing from a postcode type, the entry appears in placex
         When importing
@@ -80,7 +75,6 @@ Feature: Update of postcode
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | de      | 20453    | country:de |
-        And there are word tokens for postcodes 20453
 
      Scenario: When changing to a postcode type, the entry disappears from placex
         When importing
@@ -101,7 +95,6 @@ Feature: Update of postcode
         Then location_postcode contains exactly
            | country | postcode | geometry |
            | de      | 01982    | country:de |
-        And there are word tokens for postcodes 01982
 
     Scenario: When a parent is deleted, the postcode gets a new parent
         Given the grid with origin DE

--- a/test/python/api/search/test_api_search_query.py
+++ b/test/python/api/search/test_api_search_query.py
@@ -21,6 +21,9 @@ def mktoken(tid: int):
     return MyToken(penalty=3.0, token=tid, count=1, addr_count=1,
                    lookup_word='foo')
 
+@pytest.fixture
+def qnode():
+    return query.QueryNode(query.BREAK_PHRASE, query.PHRASE_ANY, 0.0 ,'', '')
 
 @pytest.mark.parametrize('ptype,ttype', [(query.PHRASE_ANY, 'W'),
                                          (query.PHRASE_AMENITY, 'Q'),
@@ -37,27 +40,24 @@ def test_phrase_incompatible(ptype):
     assert not query._phrase_compatible_with(ptype, query.TOKEN_PARTIAL, True)
 
 
-def test_query_node_empty():
-    qn = query.QueryNode(query.BREAK_PHRASE, query.PHRASE_ANY)
-
-    assert not qn.has_tokens(3, query.TOKEN_PARTIAL)
-    assert qn.get_tokens(3, query.TOKEN_WORD) is None
+def test_query_node_empty(qnode):
+    assert not qnode.has_tokens(3, query.TOKEN_PARTIAL)
+    assert qnode.get_tokens(3, query.TOKEN_WORD) is None
 
 
-def test_query_node_with_content():
-    qn = query.QueryNode(query.BREAK_PHRASE, query.PHRASE_ANY)
-    qn.starting.append(query.TokenList(2, query.TOKEN_PARTIAL, [mktoken(100), mktoken(101)]))
-    qn.starting.append(query.TokenList(2, query.TOKEN_WORD, [mktoken(1000)]))
+def test_query_node_with_content(qnode):
+    qnode.starting.append(query.TokenList(2, query.TOKEN_PARTIAL, [mktoken(100), mktoken(101)]))
+    qnode.starting.append(query.TokenList(2, query.TOKEN_WORD, [mktoken(1000)]))
 
-    assert not qn.has_tokens(3, query.TOKEN_PARTIAL)
-    assert not qn.has_tokens(2, query.TOKEN_COUNTRY)
-    assert qn.has_tokens(2, query.TOKEN_PARTIAL)
-    assert qn.has_tokens(2, query.TOKEN_WORD)
+    assert not qnode.has_tokens(3, query.TOKEN_PARTIAL)
+    assert not qnode.has_tokens(2, query.TOKEN_COUNTRY)
+    assert qnode.has_tokens(2, query.TOKEN_PARTIAL)
+    assert qnode.has_tokens(2, query.TOKEN_WORD)
 
-    assert qn.get_tokens(3, query.TOKEN_PARTIAL) is None
-    assert qn.get_tokens(2, query.TOKEN_COUNTRY) is None
-    assert len(qn.get_tokens(2, query.TOKEN_PARTIAL)) == 2
-    assert len(qn.get_tokens(2, query.TOKEN_WORD)) == 1
+    assert qnode.get_tokens(3, query.TOKEN_PARTIAL) is None
+    assert qnode.get_tokens(2, query.TOKEN_COUNTRY) is None
+    assert len(qnode.get_tokens(2, query.TOKEN_PARTIAL)) == 2
+    assert len(qnode.get_tokens(2, query.TOKEN_WORD)) == 1
 
 
 def test_query_struct_empty():

--- a/test/python/api/search/test_icu_query_analyzer.py
+++ b/test/python/api/search/test_icu_query_analyzer.py
@@ -102,12 +102,11 @@ async def test_splitting_in_transliteration(conn):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('term,order', [('23456', ['P', 'H', 'W', 'w']),
-                                        ('3', ['H', 'P', 'W', 'w'])
+                                        ('3', ['H', 'W', 'w'])
                                        ])
 async def test_penalty_postcodes_and_housenumbers(conn, term, order):
     ana = await tok.create_query_analyzer(conn)
 
-    await add_word(conn, 1, term, 'P', None)
     await add_word(conn, 2, term, 'H', term)
     await add_word(conn, 3, term, 'w', term)
     await add_word(conn, 4, term, 'W', term)
@@ -179,8 +178,10 @@ async def test_add_unknown_housenumbers(conn):
     assert query.nodes[1].starting[0].ttype == qmod.TOKEN_HOUSENUMBER
     assert len(query.nodes[1].starting[0].tokens) == 1
     assert query.nodes[1].starting[0].tokens[0].token == 1
-    assert not query.nodes[2].starting
-    assert not query.nodes[3].starting
+    assert query.nodes[2].has_tokens(3, qmod.TOKEN_POSTCODE)
+    assert not query.nodes[2].has_tokens(3, qmod.TOKEN_HOUSENUMBER)
+    assert not query.nodes[2].has_tokens(4, qmod.TOKEN_HOUSENUMBER)
+    assert not query.nodes[3].has_tokens(4, qmod.TOKEN_HOUSENUMBER)
 
 
 @pytest.mark.asyncio

--- a/test/python/api/search/test_postcode_parser.py
+++ b/test/python/api/search/test_postcode_parser.py
@@ -1,0 +1,133 @@
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Test for parsing of postcodes in queries.
+"""
+import re
+from itertools import zip_longest
+
+import pytest
+
+from nominatim_api.search.postcode_parser import PostcodeParser
+from nominatim_api.search.query import QueryStruct, PHRASE_ANY
+
+@pytest.fixture
+def pc_config(project_env):
+    country_file = project_env.project_dir / 'country_settings.yaml'
+    country_file.write_text(r"""
+ab:
+  postcode:
+    pattern: "ddddd ll"
+ba:
+  postcode:
+    pattern: "ddddd"
+de:
+  postcode:
+    pattern: "ddddd"
+gr:
+  postcode:
+    pattern: "(ddd) ?(dd)"
+    output: \1 \2
+in:
+  postcode:
+    pattern: "(ddd) ?(ddd)"
+    output: \1\2
+mc:
+  postcode:
+    pattern: "980dd"
+mz:
+  postcode:
+    pattern: "(dddd)(?:-dd)?"
+bn:
+  postcode:
+    pattern: "(ll) ?(dddd)"
+    output: \1\2
+ky:
+  postcode:
+    pattern: "(d)-(dddd)"
+    output: KY\1-\2
+    """)
+
+    return project_env
+
+def mk_query(inp):
+    query = QueryStruct([])
+    phrase_split = re.split(r"([ ,:'-])", inp)
+
+    for word, breakchar in zip_longest(*[iter(phrase_split)]*2, fillvalue='>'):
+        query.add_node(breakchar, PHRASE_ANY, 0.1, word, word)
+
+    return query
+
+
+@pytest.mark.parametrize('query,pos', [('45325 Berlin', 0),
+                                       ('45325:Berlin', 0),
+                                       ('45325,Berlin', 0),
+                                       ('Berlin 45325', 1),
+                                       ('Berlin,45325', 1),
+                                       ('Berlin:45325', 1),
+                                       ('Hansastr,45325 Berlin', 1),
+                                       ('Hansastr 45325 Berlin', 1)])
+def test_simple_postcode(pc_config, query, pos):
+    parser = PostcodeParser(pc_config)
+
+    result = parser.parse(mk_query(query))
+
+    assert result == {(pos, pos + 1, '45325'), (pos, pos + 1, '453 25')}
+
+def test_contained_postcode(pc_config):
+    parser = PostcodeParser(pc_config)
+
+    assert parser.parse(mk_query('12345 dx')) == {(0, 1, '12345'), (0, 1, '123 45'),
+                                                  (0, 2, '12345 DX')}
+
+
+
+@pytest.mark.parametrize('query,frm,to', [('345987', 0, 1), ('345 987', 0, 2),
+                                          ('Aina 345 987', 1, 3),
+                                          ('Aina 23 345 987 ff', 2, 4)])
+def test_postcode_with_space(pc_config, query, frm, to):
+    parser = PostcodeParser(pc_config)
+
+    result = parser.parse(mk_query(query))
+
+    assert result == {(frm, to, '345987')}
+
+def test_overlapping_postcode(pc_config):
+    parser = PostcodeParser(pc_config)
+
+    assert parser.parse(mk_query('123 456 78')) == {(0, 2, '123456'), (1, 3, '456 78')}
+
+
+@pytest.mark.parametrize('query', ['45325-Berlin', "45325'Berlin",
+                                   'Berlin-45325', "Berlin'45325", '45325Berlin'
+                                   '345-987', "345'987", '345,987', '345:987'])
+def test_not_a_postcode(pc_config, query):
+    parser = PostcodeParser(pc_config)
+
+    assert not parser.parse(mk_query(query))
+
+
+@pytest.mark.parametrize('query', ['ba 12233', 'ba-12233'])
+def test_postcode_with_country_prefix(pc_config, query):
+    parser = PostcodeParser(pc_config)
+
+    assert (0, 2, '12233') in parser.parse(mk_query(query))
+
+
+def test_postcode_with_joined_country_prefix(pc_config):
+    parser = PostcodeParser(pc_config)
+
+    assert parser.parse(mk_query('ba12233')) == {(0, 1, '12233')}
+
+
+def test_postcode_with_non_matching_country_prefix(pc_config):
+    parser = PostcodeParser(pc_config)
+
+    assert not parser.parse(mk_query('ky12233'))
+

--- a/test/python/api/search/test_query.py
+++ b/test/python/api/search/test_query.py
@@ -46,3 +46,20 @@ def test_token_range_unimplemented_ops():
         nq.TokenRange(1, 3) <= nq.TokenRange(10, 12)
     with pytest.raises(TypeError):
         nq.TokenRange(1, 3) >= nq.TokenRange(10, 12)
+
+
+def test_query_extract_words():
+    q = nq.QueryStruct([])
+    q.add_node(nq.BREAK_WORD, nq.PHRASE_ANY, 0.1, '12', '')
+    q.add_node(nq.BREAK_TOKEN, nq.PHRASE_ANY, 0.0, 'ab', '')
+    q.add_node(nq.BREAK_PHRASE, nq.PHRASE_ANY, 0.0, '12', '')
+    q.add_node(nq.BREAK_END, nq.PHRASE_ANY, 0.5, 'hallo', '')
+
+    words = q.extract_words(base_penalty=1.0)
+
+    assert set(words.keys()) \
+             == {'12', 'ab', 'hallo', '12 ab', 'ab 12', '12 ab 12'}
+    assert sorted(words['12']) == [nq.TokenRange(0, 1, 1.0), nq.TokenRange(2, 3, 1.0)]
+    assert words['12 ab'] == [nq.TokenRange(0, 2, 1.1)]
+    assert words['hallo'] == [nq.TokenRange(3, 4, 1.0)]
+

--- a/test/python/tokenizer/test_icu.py
+++ b/test/python/tokenizer/test_icu.py
@@ -265,37 +265,13 @@ class TestPostcodes:
                                                       'address': {'postcode': postcode}}))
 
 
-    def test_update_postcodes_from_db_empty(self, table_factory, word_table):
-        table_factory('location_postcode', 'country_code TEXT, postcode TEXT',
-                      content=(('de', '12345'), ('se', '132 34'),
-                               ('bm', 'AB23'), ('fr', '12345')))
-
-        self.analyzer.update_postcodes_from_db()
-
-        assert word_table.count() == 5
-        assert word_table.get_postcodes() == {'12345', '132 34@132 34', 'AB 23@AB 23'}
-
-
-    def test_update_postcodes_from_db_ambigious(self, table_factory, word_table):
-        table_factory('location_postcode', 'country_code TEXT, postcode TEXT',
-                      content=(('in', '123456'), ('sg', '123456')))
-
-        self.analyzer.update_postcodes_from_db()
-
-        assert word_table.count() == 3
-        assert word_table.get_postcodes() == {'123456', '123456@123 456'}
-
-
-    def test_update_postcodes_from_db_add_and_remove(self, table_factory, word_table):
-        table_factory('location_postcode', 'country_code TEXT, postcode TEXT',
-                      content=(('ch', '1234'), ('bm', 'BC 45'), ('bm', 'XX45')))
+    def test_update_postcodes_deleted(self, word_table):
         word_table.add_postcode(' 1234', '1234')
         word_table.add_postcode(' 5678', '5678')
 
         self.analyzer.update_postcodes_from_db()
 
-        assert word_table.count() == 5
-        assert word_table.get_postcodes() == {'1234', 'BC 45@BC 45', 'XX 45@XX 45'}
+        assert word_table.count() == 0
 
 
     def test_process_place_postcode_simple(self, word_table):
@@ -303,15 +279,11 @@ class TestPostcodes:
 
         assert info['postcode'] == '12345'
 
-        assert word_table.get_postcodes() == {'12345', }
-
 
     def test_process_place_postcode_with_space(self, word_table):
         info = self.process_postcode('in', '123 567')
 
         assert info['postcode'] == '123567'
-
-        assert word_table.get_postcodes() == {'123567@123 567', }
 
 
 
@@ -477,9 +449,9 @@ class TestPlaceAddress:
 
     @pytest.mark.parametrize('pcode', ['12345', 'AB 123', '34-345'])
     def test_process_place_postcode(self, word_table, pcode):
-        self.process_address(postcode=pcode)
+        info = self.process_address(postcode=pcode)
 
-        assert word_table.get_postcodes() == {pcode, }
+        assert info['postcode'] == pcode
 
 
     @pytest.mark.parametrize('hnr', ['123a', '1', '101'])


### PR DESCRIPTION
This switches postcodes from being looked up in the word table to being parsed according to the postcode patterns provided in the country configuration. For one thing, this saves us 5mio entries in the word table, for another, it makes it possible to detect postcodes that are not yet in OSM.

Most notably, it brings back the ability to handle US ZIP+ codes. These will always be shortened to 5-digit codes. Saving/finding full ZIP+ codes isn't worth the trouble right now because there are too few of them in the OSM database.

This PR also includes some minor refactoring of the data structures that save the parsed query. Query now includes the source tokens directly which previously were saved in an extra QueryPart structure. This saves us a few allocations and makes lookup significantly easier.

Fixes #3324.
Closes #1452.