### PR TITLE
Replace custom Almost with stdlib math.isclose

### DIFF
--- a/test/bdd/steps/check_functions.py
+++ b/test/bdd/steps/check_functions.py
@@ -11,17 +11,6 @@ import json
 import math
 import re
 
-class Almost:
-    """ Compares a float value with a certain jitter.
-    """
-    def __init__(self, value, offset=0.00001):
-        self.value = value
-        self.offset = offset
-
-    def __eq__(self, other):
-        return abs(other - self.value) < self.offset
-
-
 OSM_TYPE = {'N' : 'node', 'W' : 'way', 'R' : 'relation',
             'n' : 'node', 'w' : 'way', 'r' : 'relation',
             'node' : 'n', 'way' : 'w', 'relation' : 'r'}

--- a/test/bdd/steps/http_responses.py
+++ b/test/bdd/steps/http_responses.py
@@ -11,7 +11,7 @@ import re
 import json
 import xml.etree.ElementTree as ET
 
-from check_functions import Almost, OsmType, Field, check_for_attributes
+from check_functions import OsmType, Field, check_for_attributes
 
 
 class GenericResponse:

--- a/test/bdd/steps/table_compare.py
+++ b/test/bdd/steps/table_compare.py
@@ -7,13 +7,12 @@
 """
 Functions to facilitate accessing and comparing the content of DB tables.
 """
+import math
 import re
 import json
 
 import psycopg
 from psycopg import sql as pysql
-
-from steps.check_functions import Almost
 
 ID_REGEX = re.compile(r"(?P<typ>[NRW])(?P<oid>\d+)(:(?P<cls>\w+))?")
 
@@ -166,7 +165,7 @@ class DBRow:
         else:
             x, y = self.context.osm.grid_node(int(expected))
 
-        return Almost(float(x)) == self.db_row['cx'] and Almost(float(y)) == self.db_row['cy']
+        return math.isclose(float(x), self.db_row['cx']) and math.isclose(float(y), self.db_row['cy'])
 
     def _has_geometry(self, expected):
         geom = self.context.osm.parse_geometry(expected)


### PR DESCRIPTION
`math.isclose` has per default relative tolerance of 10e-9, so if it matters, I can change it to the absolute tolerance of 0.00001 as it was used in the original code.  