### PR TITLE
Remove code for setting osm2pgsql location via config.lib_dir

### DIFF
--- a/nominatim-cli.py
+++ b/nominatim-cli.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Helper script for development to run nominatim from the source directory.
@@ -15,4 +15,4 @@ sys.path.insert(1, str((Path(__file__) / '..' / 'src').resolve()))
 
 from nominatim_db import cli
 
-exit(cli.nominatim(module_dir=None, osm2pgsql_path=None))
+exit(cli.nominatim())

--- a/packaging/nominatim-db/scripts/nominatim
+++ b/packaging/nominatim-db/scripts/nominatim
@@ -2,4 +2,4 @@
 
 from nominatim_db import cli
 
-exit(cli.nominatim(osm2pgsql_path=None))
+exit(cli.nominatim())

--- a/src/nominatim_db/clicmd/args.py
+++ b/src/nominatim_db/clicmd/args.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Provides custom functions over command-line arguments.
@@ -186,7 +186,7 @@ class NominatimArgs:
             from the command line arguments. The resulting dict can be
             further customized and then used in `run_osm2pgsql()`.
         """
-        return dict(osm2pgsql=self.config.OSM2PGSQL_BINARY or self.config.lib_dir.osm2pgsql,
+        return dict(osm2pgsql=self.config.OSM2PGSQL_BINARY,
                     osm2pgsql_cache=self.osm2pgsql_cache or default_cache,
                     osm2pgsql_style=self.config.get_import_style_file(),
                     osm2pgsql_style_path=self.config.lib_dir.lua,

--- a/src/nominatim_db/config.py
+++ b/src/nominatim_db/config.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Nominatim configuration accessor.
@@ -73,7 +73,6 @@ class Configuration:
             self.project_dir = None
 
         class _LibDirs:
-            osm2pgsql: Path
             sql = paths.SQLLIB_DIR
             lua = paths.LUALIB_DIR
             data = paths.DATA_DIR

--- a/src/nominatim_db/tools/exec_utils.py
+++ b/src/nominatim_db/tools/exec_utils.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Helper functions for executing external programs.
@@ -85,7 +85,7 @@ def _mk_tablespace_options(ttype: str, options: Mapping[str, Any]) -> List[str]:
 
 
 def _find_osm2pgsql_cmd(cmdline: Optional[str]) -> str:
-    if cmdline is not None:
+    if cmdline:
         return cmdline
 
     in_path = shutil.which('osm2pgsql')

--- a/test/bdd/steps/nominatim_environment.py
+++ b/test/bdd/steps/nominatim_environment.py
@@ -257,8 +257,7 @@ class NominatimEnvironment:
         if self.website_dir is not None:
             cmdline = list(cmdline) + ['--project-dir', self.website_dir.name]
 
-        cli.nominatim(osm2pgsql_path=None,
-                      cli_args=cmdline,
+        cli.nominatim(cli_args=cmdline,
                       environ=self.test_env)
 
     def copy_from_place(self, db):

--- a/test/python/api/test_export.py
+++ b/test/python/api/test_export.py
@@ -16,8 +16,7 @@ import nominatim_db.cli
 def run_export(tmp_path, capsys):
     def _exec(args):
         cli_args = ['export', '--project-dir', str(tmp_path)] + args
-        assert 0 == nominatim_db.cli.nominatim(osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                               cli_args=cli_args)
+        assert 0 == nominatim_db.cli.nominatim(cli_args=cli_args)
         return capsys.readouterr().out.split('\r\n')
 
     return _exec

--- a/test/python/api/test_warm.py
+++ b/test/python/api/test_warm.py
@@ -29,6 +29,5 @@ def setup_database_with_context(apiobj, table_factory):
 
 @pytest.mark.parametrize('args', [['--search-only'], ['--reverse-only']])
 def test_warm_all(tmp_path, args):
-    assert 0 == nominatim_db.cli.nominatim(osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                           cli_args=['admin', '--project-dir', str(tmp_path),
+    assert 0 == nominatim_db.cli.nominatim(cli_args=['admin', '--project-dir', str(tmp_path),
                                                      '--warm'] + args)

--- a/test/python/cli/conftest.py
+++ b/test/python/cli/conftest.py
@@ -69,8 +69,7 @@ def cli_call():
         Returns a function that can be called with the desired CLI arguments.
     """
     def _call_nominatim(*args):
-        return nominatim_db.cli.nominatim(osm2pgsql_path='OSM2PGSQL NOT AVAILABLE',
-                                          cli_args=args)
+        return nominatim_db.cli.nominatim(cli_args=args)
 
     return _call_nominatim
 

--- a/test/python/cli/test_cmd_replication.py
+++ b/test/python/cli/test_cmd_replication.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2023 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for replication command of command-line interface wrapper.
@@ -100,7 +100,8 @@ class TestCliReplication:
     def test_replication_update_continuous_no_index(self):
         assert self.call_nominatim('--no-index') == 1
 
-    def test_replication_update_once_no_index(self, update_mock):
+    def test_replication_update_once_no_index(self, update_mock, monkeypatch):
+        monkeypatch.setenv('NOMINATIM_OSM2PGSQL_BINARY', 'OSM2PGSQL NOT AVAILABLE')
         assert self.call_nominatim('--once', '--no-index') == 0
 
         assert str(update_mock.last_args[1]['osm2pgsql']).endswith('OSM2PGSQL NOT AVAILABLE')

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -111,7 +111,6 @@ def table_factory(temp_db_conn):
 @pytest.fixture
 def def_config():
     cfg = Configuration(None)
-    cfg.set_libdirs(osm2pgsql=None)
     return cfg
 
 
@@ -120,7 +119,6 @@ def project_env(tmp_path):
     projdir = tmp_path / 'project'
     projdir.mkdir()
     cfg = Configuration(projdir)
-    cfg.set_libdirs(osm2pgsql=None)
     return cfg
 
 
@@ -211,7 +209,7 @@ def osmline_table(temp_db_with_extensions, table_factory):
 def sql_preprocessor_cfg(tmp_path, table_factory, temp_db_with_extensions):
     table_factory('country_name', 'partition INT', ((0, ), (1, ), (2, )))
     cfg = Configuration(None)
-    cfg.set_libdirs(osm2pgsql=None, sql=tmp_path)
+    cfg.set_libdirs(sql=tmp_path)
     return cfg
 
 


### PR DESCRIPTION
When osm2pgsql was bundled with Nominatim, the code needed to be able to report the location of the internal osm2pgsql binary. This was done via the `config.lib_dir`s. With the internal osm2pgsql gone, the only way to configure the osm2pgsql location is via the env setting.

This removes the lib_dir setting which makes programmatically calling nominatim cli quite a bit simpler.