### PR TITLE
Add generic preprocessors

### DIFF
--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -67,8 +67,9 @@ Here is an example configuration file:
 
 ``` yaml
 query-preprocessing:
+    - step: split_japanese_phrases
     - step: regex_replace
-    replacements:
+      replacements:
         - pattern: https?://[^\s]* # Filter URLs starting with http or https
           replace: ''
     - step: normalize
@@ -110,6 +111,8 @@ The following is a list of preprocessors that are shipped with Nominatim.
         members: False
         heading_level: 6
         docstring_section_style: spacy
+
+##### regex-replace
 
 ::: nominatim_api.query_preprocessing.regex_replace
     options:

--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -67,7 +67,12 @@ Here is an example configuration file:
 
 ``` yaml
 query-preprocessing:
-    - normalize
+    - step: regex_replace
+    replacements:
+        - pattern: https?://[^\s]* # Filter URLs starting with http or https
+          replace: ''
+    - step: normalize
+
 normalization:
     - ":: lower ()"
     - "ß > 'ss'" # German szet is unambiguously equal to double ss
@@ -88,8 +93,8 @@ token-analysis:
             replacements: ['ä', 'ae']
 ```
 
-The configuration file contains four sections:
-`normalization`, `transliteration`, `sanitizers` and `token-analysis`.
+The configuration file contains five sections:
+`query-preprocessing`, `normalization`, `transliteration`, `sanitizers` and `token-analysis`.
 
 #### Query preprocessing
 
@@ -105,6 +110,17 @@ The following is a list of preprocessors that are shipped with Nominatim.
         members: False
         heading_level: 6
         docstring_section_style: spacy
+
+::: nominatim_api.query_preprocessing.regex_replace
+    options:
+        members: False
+        heading_level: 6
+        docstring_section_style: spacy
+    description: 
+        This option runs any given regex pattern on the input and replaces values accordingly
+    replacements:
+        - pattern: regex pattern
+          replace: string to replace with
 
 
 #### Normalization and Transliteration

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -1,13 +1,5 @@
 query-preprocessing:
     - step: split_japanese_phrases
-    - step: regex_replace
-      replacements:
-        - pattern: \b(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3}\b # Filter for IPv4 addresses
-          replace: ''
-        - pattern: \b(?:(?:[A-Fa-f0-9]{1,4}:){1,7}|:)(?:[A-Fa-f0-9]{1,4})?\b # Filter for IPv6 addresses
-          replace: ''
-        - pattern: https?://[^\s]* # Filter URLs starting with http or https
-          replace: ''
     - step: normalize
 normalization:
     - ":: lower ()"

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -1,5 +1,13 @@
 query-preprocessing:
     - step: split_japanese_phrases
+    - step: regex_replace
+      replacements:
+        - pattern: \b(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3}\b # Filter for IPv4 addresses
+          replace: ''
+        - pattern: \b(?:(?:[A-Fa-f0-9]{1,4}:){1,7}|:)(?:[A-Fa-f0-9]{1,4})?\b # Filter for IPv6 addresses
+          replace: ''
+        - pattern: https?://[^\s]* # Filter URLs starting with http or https
+          replace: ''
     - step: normalize
 normalization:
     - ":: lower ()"

--- a/src/nominatim_api/query_preprocessing/regex_replace.py
+++ b/src/nominatim_api/query_preprocessing/regex_replace.py
@@ -5,7 +5,11 @@
 # Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
-This file replaces values based on pre-defined regex rules:
+This preprocessor replaces values in a given input based on pre-defined regex rules.
+
+Arguments:
+    pattern: Regex pattern to be applied on the input
+    replace: The string that it is to be replaced with
 """
 from typing import List
 import re
@@ -16,8 +20,10 @@ from ..search.query import Phrase
 
 
 class _GenericPreprocessing:
+    """Perform replacements to input phrases using custom regex patterns."""
 
     def __init__(self, config: QueryConfig) -> None:
+        """Initialise the _GenericPreprocessing class with patterns from the ICU config file."""
         self.config = config
 
         match_patterns = self.config.get('replacements', 'Key not found')
@@ -26,22 +32,21 @@ class _GenericPreprocessing:
             ]
 
     def split_phrase(self, phrase: Phrase) -> Phrase:
-        """
-        This function performs replacements on the given text using regex patterns.
-        """
+        """This function performs replacements on the given text using regex patterns."""
         for item in self.compiled_patterns:
             phrase.text = item[0].sub(item[1], phrase.text)
 
         return phrase
 
     def __call__(self, phrases: List[Phrase]) -> List[Phrase]:
-        """Apply regex replacements to the given addresses.
+        """
+        Return the final Phrase list.
+        Returns an empty list if there is nothing left after split_phrase.
         """
         result = [p for p in map(self.split_phrase, phrases) if p.text.strip()]
-        return result if result else []
+        return result
 
 
 def create(config: QueryConfig) -> QueryProcessingFunc:
-    """ Create a function for generic preprocessing.
-    """
+    """ Create a function for generic preprocessing."""
     return _GenericPreprocessing(config)

--- a/src/nominatim_api/query_preprocessing/regex_replace.py
+++ b/src/nominatim_api/query_preprocessing/regex_replace.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+This file replaces values based on pre-defined regex rules:
+"""
+from typing import List
+import re
+
+from .config import QueryConfig
+from .base import QueryProcessingFunc
+from ..search.query import Phrase
+
+
+class _GenericPreprocessing:
+
+    def __init__(self, config: QueryConfig) -> None:
+        self.config = config
+
+    def split_phrase(self, phrase: Phrase) -> Phrase:
+        """
+        This function performs replacements on the given text using regex patterns.
+        """
+
+        if phrase.text is None:
+            return phrase
+
+        match_patterns = self.config.get('replacements', 'Key not found')
+        for item in match_patterns:
+            phrase.text = re.sub(item['pattern'], item['replace'], phrase.text)
+
+        return phrase
+
+    def __call__(self, phrases: List[Phrase]) -> List[Phrase]:
+        """Apply regex replacements to the given addresses.
+        """
+        return [self.split_phrase(p) for p in phrases]
+
+
+def create(config: QueryConfig) -> QueryProcessingFunc:
+    """ Create a function for generic preprocessing.
+    """
+    return _GenericPreprocessing(config)

--- a/test/python/api/query_processing/test_regex_replace.py
+++ b/test/python/api/query_processing/test_regex_replace.py
@@ -46,6 +46,4 @@ def test_split_phrases(inp, outp):
     query = [qmod.Phrase(qmod.PHRASE_ANY, text) for text in inp]
 
     out = run_preprocessor_on(query)
-    expected_out = [qmod.Phrase(qmod.PHRASE_ANY, text) for text in outp]
-
-    assert out == expected_out, f"Expected {expected_out}, but got {out}"
+    assert out == [qmod.Phrase(qmod.PHRASE_ANY, text) for text in outp]

--- a/test/python/api/query_processing/test_regex_replace.py
+++ b/test/python/api/query_processing/test_regex_replace.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+'''
+Tests for replacing values in an input using custom regex.
+'''
+import pytest
+
+import nominatim_api.search.query as qmod
+from nominatim_api.query_preprocessing.config import QueryConfig
+from nominatim_api.query_preprocessing import regex_replace
+
+
+def run_preprocessor_on(query):
+    config = QueryConfig()
+    config.set_normalizer(None)
+
+    config['replacements'] = [
+        {'pattern': r'\b(?:\d{1,3}\.){3}\d{1,3}\b', 'replace': ''},  # IPv4
+        {'pattern': r'https?://\S+', 'replace': ''}  # HTTP/HTTPS URLs
+    ]
+
+    proc = regex_replace.create(config)
+    return proc(query)
+
+
+@pytest.mark.parametrize('inp,outp', [
+    (['45.67.89.101'], []),
+    (['198.51.100.23'], []),
+    (['203.0.113.255'], []),
+    (['http://www.openstreetmap.org'], []),
+    (['https://www.openstreetmap.org/edit'], []),
+    (['http://osm.org'], []),
+    (['https://www.openstreetmap.org/user/abc'], []),
+    (['https://tile.openstreetmap.org/12/2048/2048.png'], []),
+    (['Check the map at https://www.openstreetmap.org'], ['Check the map at ']),
+    (['Use 203.0.113.255 for routing'], ['Use  for routing']),
+    (['Find maps at https://osm.org and http://openstreetmap.org'], ['Find maps at  and ']),
+    (['203.0.113.255', 'Some Address'], ['Some Address']),
+    (['https://osm.org', 'Another Place'], ['Another Place']),
+])
+def test_split_phrases(inp, outp):
+    query = [qmod.Phrase(qmod.PHRASE_ANY, text) for text in inp]
+
+    out = run_preprocessor_on(query)
+    expected_out = [qmod.Phrase(qmod.PHRASE_ANY, text) for text in outp]
+
+    assert out == expected_out, f"Expected {expected_out}, but got {out}"


### PR DESCRIPTION
For now, I've added rules to filter out IPv4, IPv6 address & URLs starting with http/https in the ICU file. Most of regex_replace.py is the same as split_japanese_phrases.py.

I haven't added any tests yet. I was working using the code for the preprocessor test suite and when using QueryConfig inside a test file, the ICU-related settings (such as replacements) do not seem to be loaded. Is that supposed to happen? Are there any functions that can allow me to load the ICU file? Or is this something I'd have to make myself.