### PR TITLE
Adjust place ranks for Saudi-Arabia

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -216,6 +216,14 @@
       }
   }
 },
+{ "countries" : ["sa"],
+  "tags" : {
+      "place" : {
+          "province" : 12,
+          "municipality" : 18
+      }
+  }
+},
 { "countries" : ["sk"],
   "tags" : {
       "boundary" : {


### PR DESCRIPTION
Saudi-Arabia is consistently using `place=province` for sub-state divisions and `place=municipality` for city boroughs. Adjust the rank levels accordingly.