### PR TITLE
Some minor tweaks to postcode parsing in query

### DIFF
--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -193,10 +193,12 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
 
         self.add_extra_tokens(query)
         for start, end, pc in self.postcode_parser.parse(query):
+            term = ' '.join(n.term_lookup for n in query.nodes[start + 1:end + 1])
             query.add_token(qmod.TokenRange(start, end),
                             qmod.TOKEN_POSTCODE,
                             ICUToken(penalty=0.1, token=0, count=1, addr_count=1,
-                                     lookup_word=pc, word_token=pc, info=None))
+                                     lookup_word=pc, word_token=term,
+                                     info=None))
         self.rerank_tokens(query)
 
         log().table_dump('Word tokens', _dump_word_tokens(query))

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -269,10 +269,10 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
         """
         for i, node, tlist in query.iter_token_lists():
             if tlist.ttype == qmod.TOKEN_POSTCODE:
+                tlen = len(cast(ICUToken, tlist.tokens[0]).word_token)
                 for repl in node.starting:
                     if repl.end == tlist.end and repl.ttype != qmod.TOKEN_POSTCODE \
-                       and (repl.ttype != qmod.TOKEN_HOUSENUMBER
-                            or len(tlist.tokens[0].lookup_word) > 4):
+                       and (repl.ttype != qmod.TOKEN_HOUSENUMBER or tlen > 4):
                         repl.add_penalty(0.39)
             elif (tlist.ttype == qmod.TOKEN_HOUSENUMBER
                   and len(tlist.tokens[0].lookup_word) <= 3):

--- a/src/nominatim_api/search/token_assignment.py
+++ b/src/nominatim_api/search/token_assignment.py
@@ -269,10 +269,8 @@ class _TokenSequence:
             # <address>,<postcode> should give preference to address search
             if base.postcode.start == 0:
                 penalty = self.penalty
-                self.direction = -1  # name searches are only possible backwards
             else:
                 penalty = self.penalty + 0.1
-                self.direction = 1  # name searches are only possible forwards
             yield dataclasses.replace(base, penalty=penalty)
 
     def _get_assignments_address_forward(self, base: TokenAssignment,
@@ -281,6 +279,11 @@ class _TokenSequence:
             left-to-right reading.
         """
         first = base.address[0]
+
+        # The postcode must come after the name.
+        if base.postcode and base.postcode < first:
+            log().var_dump('skip forward', (base.postcode, first))
+            return
 
         log().comment('first word = name')
         yield dataclasses.replace(base, penalty=self.penalty,
@@ -317,7 +320,12 @@ class _TokenSequence:
         """
         last = base.address[-1]
 
-        if self.direction == -1 or len(base.address) > 1:
+        # The postcode must come before the name for backward direction.
+        if base.postcode and base.postcode > last:
+            log().var_dump('skip backward', (base.postcode, last))
+            return
+
+        if self.direction == -1 or len(base.address) > 1 or base.postcode:
             log().comment('last word = name')
             yield dataclasses.replace(base, penalty=self.penalty,
                                       name=last, address=base.address[:-1])

--- a/src/nominatim_api/search/token_assignment.py
+++ b/src/nominatim_api/search/token_assignment.py
@@ -271,6 +271,7 @@ class _TokenSequence:
                 penalty = self.penalty
             else:
                 penalty = self.penalty + 0.1
+            penalty += 0.1 * max(0, len(base.address) - 1)
             yield dataclasses.replace(base, penalty=penalty)
 
     def _get_assignments_address_forward(self, base: TokenAssignment,


### PR DESCRIPTION
* fix allowable postcode placement in query: the postcode must be part of the address and not come before the name
* fix content of `word_token` for postcodes, that must be the transliterated query item
* when penalizing tokens of other type, use transliterated query as a base for comparison
* penalize postcode searches with multiple name qualifiers