### PR TITLE
[Small fix] Add documentation to install extras for mkdocstrings

### DIFF
--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -69,9 +69,9 @@ To set up the virtual environment with all necessary packages run:
 ```sh
 virtualenv ~/nominatim-dev-venv
 ~/nominatim-dev-venv/bin/pip install\
-    psutil psycopg[binary] PyICU SQLAlchemy \
+    psutil 'psycopg[binary]' PyICU SQLAlchemy \
     python-dotenv jinja2 pyYAML behave \
-    mkdocs mkdocstrings mkdocs-gen-files pytest pytest-asyncio flake8 \
+    mkdocs 'mkdocstrings[python]' mkdocs-gen-files pytest pytest-asyncio flake8 \
     types-jinja2 types-markupsafe types-psutil types-psycopg2 \
     types-pygments types-pyyaml types-requests types-ujson \
     types-urllib3 typing-extensions unicorn falcon starlette \


### PR DESCRIPTION
Currently the developer docs ask the user to install `mkdocstrings` when trying to build the documentation. This package does not include handlers and will result in an error that looks something like this:

`ModuleNotFoundError: No module named 'mkdocstrings_handlers'`

In order to also install the handlers, we need to add extras. I've done this by replacing `mkdocstrings` with `mkdocstrings[python]`. Moreover, I've added quotation marks wherever needed as zsh errors out without them (bash for some reason does not).