### PR TITLE
Add transliteration fallback using pykakasi for Japanese city name searchesAdd files via upload

### DIFF
--- a/Geocode.php
+++ b/Geocode.php
@@ -1,0 +1,53 @@
+<?php
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright
+
+namespace Nominatim\API;
+
+use Nominatim\API\SearchRequest;
+use Nominatim\Database\SearchDatabase;
+use Nominatim\Database\Place;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class Geocode
+{
+    protected $database;
+
+    public function __construct(SearchDatabase $database)
+    {
+        $this->database = $database;
+    }
+
+    public function search(SearchRequest $aRequest)
+    {
+        $aPlace = $this->database->searchPlace($aRequest);
+
+        // If original search returned no result and query looks like Japanese, try transliteration
+        if (empty($aPlace)) {
+            $query = $aRequest->getParam('q');
+
+            // Check if the query contains any Japanese character (Kanji, Hiragana, Katakana)
+            if (preg_match('/[\x{3040}-\x{30FF}\x{4E00}-\x{9FAF}]/u', $query)) {
+                // Run Python script for transliteration
+                $process = new Process(['python3', '/absolute/path/to/transliterator.py', $query]);
+                try {
+                    $process->mustRun();
+                    $romaji = trim($process->getOutput());
+
+                    // Log the transliteration attempt
+                    error_log("Fallback to Romaji: $romaji");
+
+                    // Update query and retry search
+                    $aRequest->setParam('q', $romaji);
+                    return $this->search($aRequest);
+                } catch (ProcessFailedException $e) {
+                    error_log("Transliteration failed: " . $e->getMessage());
+                }
+            }
+        }
+
+        return $aPlace;
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -75,3 +75,28 @@ used in the search, use the [OSM Forum](https://community.openstreetmap.org/).
 For questions, community help and discussions around the software and
 your own installation of Nominatim, use the
 [Github discussions forum](https://github.com/osm-search/Nominatim/discussions).
+
+
+## 🆕 Transliteration Fallback (Japanese Support)
+
+This patch introduces a transliteration fallback to improve search for Japanese place names. It uses a Python script (`transliteration.py`) with the `pykakasi` library to convert Japanese Kanji/Kana into Romaji.
+
+### How It Works
+
+- If a search query using Kanji (e.g., `仙台`) fails, the input is transliterated (e.g., to `Sendai`).
+- Nominatim retries the search with the transliterated version.
+
+### Usage
+
+Install the required Python library:
+
+pip install pykakasi
+Run the script:
+python transliteration.py 仙台
+
+# Output: sendai
+
+Author
+Harshita Manocha (GitHub: harshitam21)
+
+

--- a/transliteration.py
+++ b/transliteration.py
@@ -1,0 +1,18 @@
+
+import sys
+from pykakasi import kakasi
+
+def transliterate(text):
+    kks = kakasi()
+    kks.setMode("H", "a")  # Hiragana to ascii
+    kks.setMode("K", "a")  # Katakana to ascii
+    kks.setMode("J", "a")  # Kanji to ascii
+    kks.setMode("r", "Hepburn")
+    converter = kks.getConverter()
+    result = converter.do(text)
+    return result
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        text = sys.argv[1]
+        print(transliterate(text))


### PR DESCRIPTION
### Summary

This pull request introduces a transliteration fallback mechanism to improve city name searches in Japanese using the Nominatim API.

### Details

- A new Python script (`transliteration.py`) has been added.
- It uses `pykakasi` to convert Japanese Kanji/Kana to Romaji.
- If a search with Kanji fails (e.g., `仙台`), the fallback transliteration returns `Sendai`.

### Usage

pip install pykakasi python transliteration.py 仙台


### Author

Harshita Manocha (GitHub: harshitam21)
