### PR TITLE
Change postcode update function to work without a project directory

### DIFF
--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Functions for importing, updating and otherwise maintaining the table
@@ -64,11 +64,15 @@ class _PostcodeCollector:
             if normalized:
                 self.collected[normalized] += (x, y)
 
-    def commit(self, conn: Connection, analyzer: AbstractAnalyzer, project_dir: Path) -> None:
-        """ Update postcodes for the country from the postcodes selected so far
-            as well as any externally supplied postcodes.
+    def commit(self, conn: Connection, analyzer: AbstractAnalyzer,
+               project_dir: Optional[Path]) -> None:
+        """ Update postcodes for the country from the postcodes selected so far.
+
+            When 'project_dir' is set, then any postcode files found in this
+            directory are taken into account as well.
         """
-        self._update_from_external(analyzer, project_dir)
+        if project_dir is not None:
+            self._update_from_external(analyzer, project_dir)
         to_add, to_delete, to_update = self._compute_changes(conn)
 
         LOG.info("Processing country '%s' (%s added, %s deleted, %s updated).",
@@ -170,7 +174,7 @@ class _PostcodeCollector:
         return None
 
 
-def update_postcodes(dsn: str, project_dir: Path, tokenizer: AbstractTokenizer) -> None:
+def update_postcodes(dsn: str, project_dir: Optional[Path], tokenizer: AbstractTokenizer) -> None:
     """ Update the table of artificial postcodes.
 
         Computes artificial postcode centroids from the placex table,

--- a/test/bdd/test_db.py
+++ b/test/bdd/test_db.py
@@ -11,7 +11,6 @@ These tests check the Nominatim import chain after the osm2pgsql import.
 """
 import asyncio
 import re
-from pathlib import Path
 
 import psycopg
 
@@ -130,7 +129,7 @@ def do_import(db_conn, def_config):
     create_table_triggers(db_conn, def_config)
     asyncio.run(load_data(def_config.get_libpq_dsn(), 1))
     tokenizer = tokenizer_factory.get_tokenizer_for_db(def_config)
-    update_postcodes(def_config.get_libpq_dsn(), Path('/xxxx'), tokenizer)
+    update_postcodes(def_config.get_libpq_dsn(), None, tokenizer)
     cli.nominatim(['index', '-q'], def_config.environ)
 
     return _collect_place_ids(db_conn)


### PR DESCRIPTION
The project directory is only needed when external postcode files are needed. When no directory is given, loading of external postcodes can simply be skipped. Computing postcodes from the internal OSM data will still work.