### PR TITLE
Exclude address searches with country from direction penalty

### DIFF
--- a/src/nominatim_api/search/token_assignment.py
+++ b/src/nominatim_api/search/token_assignment.py
@@ -287,7 +287,7 @@ class _TokenSequence:
             return
 
         penalty = self.penalty
-        if self.direction == 1 and query.dir_penalty > 0:
+        if not base.country and self.direction == 1 and query.dir_penalty > 0:
             penalty += query.dir_penalty
 
         log().comment('first word = name')
@@ -332,7 +332,7 @@ class _TokenSequence:
             return
 
         penalty = self.penalty
-        if self.direction == -1 and query.dir_penalty < 0:
+        if not base.country and self.direction == -1 and query.dir_penalty < 0:
             penalty -= query.dir_penalty
 
         if self.direction == -1 or len(base.address) > 1 or base.postcode:


### PR DESCRIPTION
Countries are not adequately represented by partial term counts, so the guess at a direction may be wrong especially with shorter queries. So do not add the direction penalty when a country restriction is present.

See also #3730.