### PR TITLE
docs: Added missing code span for search API parameter value

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -212,7 +212,7 @@ other layers.
 The featureType allows to have a more fine-grained selection for places
 from the address layer. Results can be restricted to places that make up
 the 'state', 'country' or 'city' part of an address. A featureType of
-settlement selects any human inhabited feature from 'state' down to
+`settlement` selects any human inhabited feature from 'state' down to
 'neighbourhood'.
 
 When featureType is set, then results are automatically restricted


### PR DESCRIPTION
Thanks for maintaining this project!

In the search API docs, all possible API parameter enum values are formatted as code spans (using backticks), except for one. I fixed this.