### PR TITLE
Remove support for deprecated gazetteer osm2pgsql output

### DIFF
--- a/docs/customize/Import-Styles.md
+++ b/docs/customize/Import-Styles.md
@@ -556,16 +556,6 @@ the Nominatim topic.
     ```
     Discarding country-level boundaries when running under themepark.
 
-## osm2pgsql gazetteer output
-
-Nominatim still allows you to configure the gazetteer output to remain
-backwards compatible with older imports. It will be automatically used
-when the style file name ends in `.style`. For documentation of the
-old import style, please refer to the documentation of older releases
-of Nominatim. Do not use the gazetteer output for new imports. There is no
-guarantee that new versions of Nominatim are fully compatible with the
-gazetteer output.
-
 ## Changing the style of existing databases
 
 There is usually no issue changing the style of a database that is already

--- a/docs/develop/Database-Layout.md
+++ b/docs/develop/Database-Layout.md
@@ -3,8 +3,7 @@
 ### Import tables
 
 OSM data is initially imported using [osm2pgsql](https://osm2pgsql.org).
-Nominatim uses its own data output style 'gazetteer', which differs from the
-output style created for map rendering.
+Nominatim uses a custom flex style to create the initial import tables.
 
 The import process creates the following tables:
 
@@ -14,7 +13,7 @@ The `planet_osm_*` tables are the usual backing tables for OSM data. Note
 that Nominatim uses them to look up special relations and to find nodes on
 ways.
 
-The gazetteer style produces a single table `place` as output with the following
+The osm2pgsql import produces a single table `place` as output with the following
 columns:
 
  * `osm_type` - kind of OSM object (**N** - node, **W** - way, **R** - relation)

--- a/docs/develop/overview.md
+++ b/docs/develop/overview.md
@@ -9,7 +9,7 @@ the address computation and the search frontend.
 The __data import__ stage reads the raw OSM data and extracts all information
 that is useful for geocoding. This part is done by osm2pgsql, the same tool
 that can also be used to import a rendering database. It uses the special
-gazetteer output plugin in `osm2pgsql/src/output-gazetter.[ch]pp`. The result of
+flex output style defined in the directory `/lib-lua`. The result of
 the import can be found in the database table `place`.
 
 The __address computation__ or __indexing__ stage takes the data from `place`

--- a/src/nominatim_db/tools/exec_utils.py
+++ b/src/nominatim_db/tools/exec_utils.py
@@ -37,21 +37,17 @@ def run_osm2pgsql(options: Mapping[str, Any]) -> None:
            '--style', str(options['osm2pgsql_style'])
            ]
 
-    if str(options['osm2pgsql_style']).endswith('.lua'):
-        env['LUA_PATH'] = ';'.join((str(options['osm2pgsql_style_path'] / '?.lua'),
-                                    os.environ.get('LUA_PATH', ';')))
-        env['THEMEPARK_PATH'] = str(options['osm2pgsql_style_path'] / 'themes')
-        if 'THEMEPARK_PATH' in os.environ:
-            env['THEMEPARK_PATH'] += ':' + os.environ['THEMEPARK_PATH']
-        cmd.extend(('--output', 'flex'))
+    env['LUA_PATH'] = ';'.join((str(options['osm2pgsql_style_path'] / '?.lua'),
+                                os.environ.get('LUA_PATH', ';')))
+    env['THEMEPARK_PATH'] = str(options['osm2pgsql_style_path'] / 'themes')
+    if 'THEMEPARK_PATH' in os.environ:
+        env['THEMEPARK_PATH'] += ':' + os.environ['THEMEPARK_PATH']
+    cmd.extend(('--output', 'flex'))
 
-        for flavour in ('data', 'index'):
-            if options['tablespaces'][f"main_{flavour}"]:
-                env[f"NOMINATIM_TABLESPACE_PLACE_{flavour.upper()}"] = \
-                    options['tablespaces'][f"main_{flavour}"]
-    else:
-        cmd.extend(('--output', 'gazetteer', '--hstore', '--latlon'))
-        cmd.extend(_mk_tablespace_options('main', options))
+    for flavour in ('data', 'index'):
+        if options['tablespaces'][f"main_{flavour}"]:
+            env[f"NOMINATIM_TABLESPACE_PLACE_{flavour.upper()}"] = \
+                options['tablespaces'][f"main_{flavour}"]
 
     if options['flatnode_file']:
         cmd.extend(('--flat-nodes', options['flatnode_file']))

--- a/test/python/tools/conftest.py
+++ b/test/python/tools/conftest.py
@@ -26,7 +26,8 @@ fi
 
     return dict(osm2pgsql=str(osm2pgsql_exec),
                 osm2pgsql_cache=10,
-                osm2pgsql_style='style.file',
+                osm2pgsql_style='style.lua',
+                osm2pgsql_style_path=tmp_path,
                 threads=1,
                 dsn='dbname=' + temp_db,
                 flatnode_file='',

--- a/test/python/tools/test_add_osm_data.py
+++ b/test/python/tools/test_add_osm_data.py
@@ -37,7 +37,7 @@ def test_import_osm_file_simple(dsn, table_factory, osm2pgsql_options, capfd):
     captured = capfd.readouterr()
 
     assert '--append' in captured.out
-    assert '--output gazetteer' in captured.out
+    assert '--output flex' in captured.out
     assert f'--style {osm2pgsql_options["osm2pgsql_style"]}' in captured.out
     assert f'--number-processes {osm2pgsql_options["threads"]}' in captured.out
     assert f'--cache {osm2pgsql_options["osm2pgsql_cache"]}' in captured.out
@@ -57,7 +57,7 @@ def test_import_osm_object_main_api(dsn, osm2pgsql_options, monkeypatch,
     assert get_url_mock.url.startswith(url)
 
     assert '--append' in captured.out
-    assert '--output gazetteer' in captured.out
+    assert '--output flex' in captured.out
     assert f'--style {osm2pgsql_options["osm2pgsql_style"]}' in captured.out
     assert f'--number-processes {osm2pgsql_options["threads"]}' in captured.out
     assert f'--cache {osm2pgsql_options["osm2pgsql_cache"]}' in captured.out

--- a/test/python/tools/test_database_import.py
+++ b/test/python/tools/test_database_import.py
@@ -83,7 +83,7 @@ def test_import_osm_data_simple(table_factory, osm2pgsql_options, capfd):
     captured = capfd.readouterr()
 
     assert '--create' in captured.out
-    assert '--output gazetteer' in captured.out
+    assert '--output flex' in captured.out
     assert f'--style {osm2pgsql_options["osm2pgsql_style"]}' in captured.out
     assert f'--number-processes {osm2pgsql_options["threads"]}' in captured.out
     assert f'--cache {osm2pgsql_options["osm2pgsql_cache"]}' in captured.out


### PR DESCRIPTION
Using the old "gazetteer" style for importing data with osm2pgsql has been deprecated since [4.3.0](https://github.com/osm-search/Nominatim/releases/tag/v4.3.0) which came out in September 2023. The release announcement even said that it would be removed in version 5. Somehow that slipped off of the list.

On the osm2pgsql side, the import hasn't been working since 1.11 because of incompatible changes to command line parsing. In version 2.0 the gazetteer has been removed completely.

If you still have a custom gazetteer style, it can still be used with Nominatim <=5.1 and osm2pgsql <= 1.10. You should port your changes to the new lua-base format as soon as possible though.