### PR TITLE
Reduce area for geometry rank for very small countries

### DIFF
--- a/lib-sql/functions/ranking.sql
+++ b/lib-sql/functions/ranking.sql
@@ -88,6 +88,10 @@ BEGIN
     area := area / 3;
   ELSIF country_code IN ('bo', 'ar', 'sd', 'mn', 'in', 'et', 'cd', 'mz', 'ly', 'cl', 'zm') THEN
     area := area / 2;
+  ELSIF country_code IN ('sg', 'ws', 'st', 'kn') THEN
+    area := area * 5;
+  ELSIF country_code IN ('dm', 'mt', 'lc', 'gg', 'sc', 'nr') THEN
+    area := area * 20;
   END IF;
 
   IF area > 1 THEN


### PR DESCRIPTION
This is a bit of a quick hack to avoid that non-addressable places get address terms from administrative areas that are much smaller than themselves. See #3771.