### PR TITLE
Clean up word transition penalty assignment for searches

### DIFF
--- a/src/nominatim_api/search/db_search_builder.py
+++ b/src/nominatim_api/search/db_search_builder.py
@@ -301,14 +301,14 @@ class SearchBuilder:
         ranks: List[dbf.RankedTokens] = []
 
         while todo:
-            neglen, pos, rank = heapq.heappop(todo)
+            _, pos, rank = heapq.heappop(todo)
             # partial node
             partial = self.query.nodes[pos].partial
             if partial is not None:
                 if pos + 1 < trange.end:
                     penalty = rank.penalty + partial.penalty \
                               + self.query.nodes[pos + 1].word_break_penalty
-                    heapq.heappush(todo, (neglen - 1, pos + 1,
+                    heapq.heappush(todo, (-(pos + 1), pos + 1,
                                    dbf.RankedTokens(penalty, rank.tokens)))
                 else:
                     ranks.append(dbf.RankedTokens(rank.penalty + partial.penalty,
@@ -321,7 +321,7 @@ class SearchBuilder:
                                      + self.query.get_in_word_penalty(
                                             qmod.TokenRange(pos, tlist.end))
                         for t in tlist.tokens:
-                            heapq.heappush(todo, (neglen - 1, tlist.end,
+                            heapq.heappush(todo, (-tlist.end, tlist.end,
                                                   rank.with_token(t, chgpenalty)))
                     elif tlist.end == trange.end:
                         ranks.extend(rank.with_token(t, 0.0) for t in tlist.tokens)

--- a/src/nominatim_api/search/db_search_builder.py
+++ b/src/nominatim_api/search/db_search_builder.py
@@ -287,7 +287,7 @@ class SearchBuilder:
                  for t in name_fulls]
         ranks.sort(key=lambda r: r.penalty)
         # Fallback, sum of penalty for partials
-        default = sum(t.penalty for t in self.query.iter_partials(trange))
+        default = sum(t.penalty for t in self.query.iter_partials(trange)) + 0.2
         default += sum(n.word_break_penalty
                        for n in self.query.nodes[trange.start + 1:trange.end])
         return dbf.FieldRanking(db_field, default, ranks)
@@ -329,7 +329,7 @@ class SearchBuilder:
             if len(ranks) >= 10:
                 # Too many variants, bail out and only add
                 # Worst-case Fallback: sum of penalty of partials
-                default = sum(t.penalty for t in self.query.iter_partials(trange))
+                default = sum(t.penalty for t in self.query.iter_partials(trange)) + 0.2
                 default += sum(n.word_break_penalty
                                for n in self.query.nodes[trange.start + 1:trange.end])
                 ranks.append(dbf.RankedTokens(rank.penalty + default, []))

--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -83,7 +83,7 @@ class ForwardGeocoder:
         min_ranking = searches[0].penalty + 2.0
         prev_penalty = 0.0
         for i, search in enumerate(searches):
-            if search.penalty > prev_penalty and (search.penalty > min_ranking or i > 20):
+            if search.penalty > prev_penalty and (search.penalty > min_ranking or i > 15):
                 break
             log().table_dump(f"{i + 1}. Search", _dump_searches([search], query))
             log().var_dump('Params', self.params)

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -47,6 +47,7 @@ PENALTY_BREAK = {
      qmod.BREAK_TOKEN: 0.4
 }
 
+
 @dataclasses.dataclass
 class ICUToken(qmod.Token):
     """ Specialised token for ICU tokenizer.
@@ -232,9 +233,7 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                 if trans:
                     for term in trans.split(' '):
                         if term:
-                            query.add_node(qmod.BREAK_TOKEN, phrase.ptype,
-                                           PENALTY_IN_TOKEN_BREAK[qmod.BREAK_TOKEN],
-                                           term, word)
+                            query.add_node(qmod.BREAK_TOKEN, phrase.ptype, term, word)
                     query.nodes[-1].btype = breakchar
 
         query.nodes[-1].btype = qmod.BREAK_END

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -42,7 +42,7 @@ PENALTY_BREAK = {
      qmod.BREAK_END: -0.5,
      qmod.BREAK_PHRASE: -0.5,
      qmod.BREAK_SOFT_PHRASE: -0.5,
-     qmod.BREAK_WORD: 0.0,
+     qmod.BREAK_WORD: 0.1,
      qmod.BREAK_PART: 0.2,
      qmod.BREAK_TOKEN: 0.4
 }

--- a/src/nominatim_api/search/query.py
+++ b/src/nominatim_api/search/query.py
@@ -134,7 +134,6 @@ class TokenRange:
     """
     start: int
     end: int
-    penalty: Optional[float] = None
 
     def __lt__(self, other: 'TokenRange') -> bool:
         return self.end <= other.start

--- a/src/nominatim_api/search/token_assignment.py
+++ b/src/nominatim_api/search/token_assignment.py
@@ -23,16 +23,6 @@ class TypedRange:
     trange: qmod.TokenRange
 
 
-PENALTY_TOKENCHANGE = {
-    qmod.BREAK_START: 0.0,
-    qmod.BREAK_END: 0.0,
-    qmod.BREAK_PHRASE: 0.0,
-    qmod.BREAK_SOFT_PHRASE: 0.0,
-    qmod.BREAK_WORD: 0.1,
-    qmod.BREAK_PART: 0.2,
-    qmod.BREAK_TOKEN: 0.4
-}
-
 TypedRangeSeq = List[TypedRange]
 
 

--- a/test/python/api/search/test_postcode_parser.py
+++ b/test/python/api/search/test_postcode_parser.py
@@ -68,7 +68,7 @@ def mk_query(inp):
     phrase_split = re.split(r"([ ,:'-])", inp)
 
     for word, breakchar in zip_longest(*[iter(phrase_split)]*2, fillvalue='>'):
-        query.add_node(breakchar, PHRASE_ANY, 0.1, word, word)
+        query.add_node(breakchar, PHRASE_ANY, word, word)
 
     return query
 
@@ -153,9 +153,9 @@ def test_postcode_inside_postcode_phrase(pc_config):
 
     query = QueryStruct([])
     query.nodes[-1].ptype = PHRASE_STREET
-    query.add_node(',', PHRASE_STREET, 0.1, '12345', '12345')
-    query.add_node(',', PHRASE_POSTCODE, 0.1, 'xz', 'xz')
-    query.add_node('>', PHRASE_POSTCODE, 0.1, '4444', '4444')
+    query.add_node(',', PHRASE_STREET, '12345', '12345')
+    query.add_node(',', PHRASE_POSTCODE, 'xz', 'xz')
+    query.add_node('>', PHRASE_POSTCODE, '4444', '4444')
 
     assert parser.parse(query) == {(2, 3, '4444')}
 
@@ -165,7 +165,7 @@ def test_partial_postcode_in_postcode_phrase(pc_config):
 
     query = QueryStruct([])
     query.nodes[-1].ptype = PHRASE_POSTCODE
-    query.add_node(' ', PHRASE_POSTCODE, 0.1, '2224', '2224')
-    query.add_node('>', PHRASE_POSTCODE, 0.1, '12345', '12345')
+    query.add_node(' ', PHRASE_POSTCODE, '2224', '2224')
+    query.add_node('>', PHRASE_POSTCODE, '12345', '12345')
 
     assert not parser.parse(query)

--- a/test/python/api/search/test_query.py
+++ b/test/python/api/search/test_query.py
@@ -51,15 +51,15 @@ def test_token_range_unimplemented_ops():
 
 def test_query_extract_words():
     q = nq.QueryStruct([])
-    q.add_node(nq.BREAK_WORD, nq.PHRASE_ANY, 0.1, '12', '')
-    q.add_node(nq.BREAK_TOKEN, nq.PHRASE_ANY, 0.0, 'ab', '')
-    q.add_node(nq.BREAK_PHRASE, nq.PHRASE_ANY, 0.0, '12', '')
-    q.add_node(nq.BREAK_END, nq.PHRASE_ANY, 0.5, 'hallo', '')
+    q.add_node(nq.BREAK_WORD, nq.PHRASE_ANY, '12', '')
+    q.add_node(nq.BREAK_TOKEN, nq.PHRASE_ANY, 'ab', '')
+    q.add_node(nq.BREAK_PHRASE, nq.PHRASE_ANY, '12', '')
+    q.add_node(nq.BREAK_END, nq.PHRASE_ANY, 'hallo', '')
 
-    words = q.extract_words(base_penalty=1.0)
+    words = q.extract_words()
 
     assert set(words.keys()) \
         == {'12', 'ab', 'hallo', '12 ab', 'ab 12', '12 ab 12'}
-    assert sorted(words['12']) == [nq.TokenRange(0, 1, 1.0), nq.TokenRange(2, 3, 1.0)]
-    assert words['12 ab'] == [nq.TokenRange(0, 2, 1.1)]
-    assert words['hallo'] == [nq.TokenRange(3, 4, 1.0)]
+    assert sorted(words['12']) == [nq.TokenRange(0, 1), nq.TokenRange(2, 3)]
+    assert words['12 ab'] == [nq.TokenRange(0, 2)]
+    assert words['hallo'] == [nq.TokenRange(3, 4)]

--- a/test/python/api/search/test_token_assignment.py
+++ b/test/python/api/search/test_token_assignment.py
@@ -12,8 +12,8 @@ import pytest
 from nominatim_api.search.query import QueryStruct, Phrase, TokenRange, Token
 import nominatim_api.search.query as qmod
 from nominatim_api.search.token_assignment import (yield_token_assignments,
-                                                   TokenAssignment,
-                                                   PENALTY_TOKENCHANGE)
+                                                   TokenAssignment)
+from nominatim_api.search.icu_tokenizer import PENALTY_BREAK
 
 
 class MyToken(Token):
@@ -28,6 +28,7 @@ def make_query(*args):
 
     for btype, ptype, _ in args[1:]:
         q.add_node(btype, ptype)
+        q.nodes[-1].penalty = PENALTY_BREAK[btype]
     q.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)
 
     for start, t in enumerate(args):
@@ -94,7 +95,7 @@ def test_multiple_simple_words(btype):
                    (btype, qmod.PHRASE_ANY, [(2, qmod.TOKEN_PARTIAL)]),
                    (btype, qmod.PHRASE_ANY, [(3, qmod.TOKEN_PARTIAL)]))
 
-    penalty = PENALTY_TOKENCHANGE[btype]
+    penalty = PENALTY_BREAK[btype]
 
     check_assignments(yield_token_assignments(q),
                       TokenAssignment(name=TokenRange(0, 3)),


### PR DESCRIPTION
The code has been a bit inconsistent about where and when to add penalties for transitions between tokens. The result being that assignment was handled inconsistently, leading to overall penalties that are not completely comparable. This PR changes two things:

1. Introduce one simple penalty value for QueryNodes. A positive value means that a penalty is added when a word ends at the node. A negative value means that the inverse penalty is added, when a word crosses the node. Setting the node penalty is now the sole responsibility of the tokenizer when it creates the Query structure.
2. Remove all transition penalties from the Token penalty. The Token penalty now only describes penalties given for the token at hand. This penalty may still be position-dependent. Transition penalties are assigned during token assignment using the node penalties from the QueryNodes.

The more conistent assignment leads to better query ordering, so that it is now save to reduce the maximum number of SQL queries per search to 15.

The change also fixes an issue with the ranking for address parts. This now has a preference for long full words over short ones and partials.