### PR TITLE
Remove defaults and documentations for LOG_DB setting

### DIFF
--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -641,24 +641,6 @@ See also [NOMINATIM_DEFAULT_LANGUAGE](#nominatim_default_language).
 
 ### Logging Settings
 
-#### NOMINATIM_LOG_DB
-
-| Summary            |                                                     |
-| --------------     | --------------------------------------------------- |
-| **Description:**   | Log requests into the database |
-| **Format:**        | boolean |
-| **Default:**       | no |
-| **After Changes:** | run `nominatim refresh --website` |
-
-Enable logging requests into a database table with this setting. The logs
-can be found in the table `new_query_log`.
-
-When using this logging method, it is advisable to set up a job that
-regularly clears out old logging information. Nominatim will not do that
-on its own.
-
-Can be used as the same time as NOMINATIM_LOG_FILE.
-
 #### NOMINATIM_LOG_FILE
 
 | Summary            |                                                     |
@@ -681,8 +663,6 @@ Request time is the time when the request was started. The execution time is
 given in seconds and includes the entire time the query was queued and executed
 in the frontend.
 type contains the name of the endpoint used.
-
-Can be used as the same time as NOMINATIM_LOG_DB.
 
 #### NOMINATIM_DEBUG_SQL
 

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -5,7 +5,6 @@
 # Database connection string.
 # Add host, port, user etc through additional semicolon-separated attributes.
 # e.g. ;host=...;port=...;user=...;password=...
-# Changing this variable requires to run 'nominatim refresh --website'.
 NOMINATIM_DATABASE_DSN="pgsql:dbname=nominatim"
 
 # Database web user.
@@ -36,11 +35,11 @@ NOMINATIM_TOKENIZER_CONFIG=
 
 # Search in the Tiger house number data for the US.
 # Note: The tables must already exist or queries will throw errors.
-# Changing this value requires to run ./utils/setup --create-functions --setup-website.
+# Changing this value requires to run ./utils/setup --create-functions.
 NOMINATIM_USE_US_TIGER_DATA=no
 
 # Search in the auxiliary housenumber table.
-# Changing this value requires to run ./utils/setup --create-functions --setup-website.
+# Changing this value requires to run ./utils/setup --create-functions.
 NOMINATIM_USE_AUX_LOCATION_DATA=no
 
 # Proxy settings
@@ -143,8 +142,7 @@ NOMINATIM_REPLICATION_RECHECK_INTERVAL=60
 
 ### API settings
 #
-# The following settings configure the API responses. You must rerun
-# 'nominatim refresh --website' after changing any of them.
+# The following settings configure the API responses.
 
 # Send permissive CORS access headers.
 # When enabled, send CORS headers to allow access to everybody.
@@ -202,7 +200,6 @@ NOMINATIM_OUTPUT_NAMES=name:XX,name,brand,official_name:XX,short_name:XX,officia
 ### Log settings
 #
 # The following options allow to enable logging of API requests.
-# You must rerun 'nominatim refresh --website' after changing any of them.
 #
 # Enable logging of requests into a file.
 # To enable logging set this setting to the file to log to.

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -204,11 +204,6 @@ NOMINATIM_OUTPUT_NAMES=name:XX,name,brand,official_name:XX,short_name:XX,officia
 # The following options allow to enable logging of API requests.
 # You must rerun 'nominatim refresh --website' after changing any of them.
 #
-# Enable logging of requests into the DB.
-# The request will be logged into the new_query_log table.
-# You should set up a cron job that regularly clears out this table.
-NOMINATIM_LOG_DB=no
-
 # Enable logging of requests into a file.
 # To enable logging set this setting to the file to log to.
 NOMINATIM_LOG_FILE=


### PR DESCRIPTION
DB logging was never implemented in the Python frontend. Given that it is quite complex to add and that nobody seems to have noticed its absense for the better part of a year, it is not worth reimplementing it. Remove the default setting and the documentation instead.

Also cleans up the documentation in `env.defaults` and removes any mentions of website setup and refresh. We don't have this anymore with the Python frontend.

See #3775.