### PR TITLE
docs: fix incorrect search viewbox values order

### DIFF
--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -235,7 +235,7 @@ cause the search to return other, less accurate, matches (if possible).
 
 | Parameter | Value | Default |
 |-----------| ----- | ------- |
-| viewbox   | `<x1>,<y1>,<x2>,<y2>` | _unset_ |
+| viewbox   | `<x1>,<x2>,<y1>,<y2>` | _unset_ |
 
 Boost parameter which focuses the search on the given area.
 Any two corner points of the box are accepted as long as they make a proper


### PR DESCRIPTION
Hey, I believe the order of the coordinates for the viewbox search param were wrong in the docs. I didn't bother checking the code, but:

previous doc order: https://nominatim.openstreetmap.org/search?q=Bern&format=jsonv2&viewbox=45.8179579,5.9558318,47.8084544,10.4922941&bounded=1 

--> Doesn't find Bern in Switzerland's bounding box.

 correct order: https://nominatim.openstreetmap.org/search?q=Bern&format=jsonv2&viewbox=45.8179579,47.8084544,5.9558318,10.4922941&bounded=1

--> Correctly finds Bern in Switzerland's bounding box.

It also makes more sense because it matches the boundingbox attribute's order too.

Cheers.