### PR TITLE
Raise minimum required Python version to 3.9

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,11 +44,13 @@ jobs:
                       postgresql: 12
                       lua: '5.1'
                       dependencies: pip
+                      python: '3.9'
                     - flavour: ubuntu-24
                       ubuntu: 24
                       postgresql: 17
                       lua: '5.3'
                       dependencies: apt
+                      python: 'builtin'
 
         runs-on: ubuntu-${{ matrix.ubuntu }}.04
 
@@ -74,6 +76,12 @@ jobs:
                      /usr/local/bin/osm2pgsql
                   key: osm2pgsql-bin-22-1
               if: matrix.ubuntu == '22'
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python }}
+              if: matrix.python != 'builtin'
 
             - name: Compile osm2pgsql
               run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -119,7 +119,7 @@ jobs:
               if: matrix.dependencies == 'pip'
 
             - name: Python static typechecking
-              run: ../venv/bin/python -m mypy --strict --python-version 3.8 src
+              run: ../venv/bin/python -m mypy --strict --python-version 3.9 src
               working-directory: Nominatim
               if: matrix.dependencies == 'pip'
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-api:
 tests: mypy lint pytest bdd
 
 mypy:
-	mypy --strict --python-version 3.8 src
+	mypy --strict --python-version 3.9 src
 
 pytest:
 	pytest test/python

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -27,7 +27,7 @@ For running Nominatim:
   * [PostgreSQL](https://www.postgresql.org) (12+ will work, 13+ strongly recommended)
   * [PostGIS](https://postgis.net) (3.0+ will work, 3.2+ strongly recommended)
   * [osm2pgsql](https://osm2pgsql.org) (1.8+)
-  * [Python 3](https://www.python.org/) (3.7+)
+  * [Python 3](https://www.python.org/) (3.9+)
 
 Furthermore the following Python libraries are required:
 

--- a/packaging/nominatim-api/pyproject.toml
+++ b/packaging/nominatim-api/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nominatim-api"
 description = "A tool for building a database of OpenStreetMap for geocoding and for searching the database. Search library."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = 'GPL-3.0-or-later'
 maintainers = [
   { name = "Sarah Hoffmann", email = "lonvia@denofr.de" },

--- a/packaging/nominatim-db/pyproject.toml
+++ b/packaging/nominatim-db/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nominatim-db"
 description = "A tool for building a database of OpenStreetMap for geocoding and for searching the database. Database backend."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = 'GPL-3.0-or-later'
 maintainers = [
   { name = "Sarah Hoffmann", email = "lonvia@denofr.de" },

--- a/src/nominatim_api/logging.py
+++ b/src/nominatim_api/logging.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2025 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Functions for specialised logging with HTML output.
@@ -106,9 +106,6 @@ class BaseLogger:
                 except TypeError:
                     return sqlstr
 
-            # Fixes an odd issue with Python 3.7 where percentages are not
-            # quoted correctly.
-            sqlstr = re.sub(r'%(?!\()', '%%', sqlstr)
             sqlstr = re.sub(r'__\[POSTCOMPILE_([^]]*)\]', r'%(\1)s', sqlstr)
             return sqlstr % params
 


### PR DESCRIPTION
Seeing more and more dependencies raise the minimum requirement to 3.9. Latest one is [mypy](https://github.com/osm-search/Nominatim/actions/runs/16287788800). Given that 3.9 is almost 5 years old and even old-stable distributions fulfill the requirements, it is easier to just raise the minimum version.

Looking forward to using [assignment expressions](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions) and [type hinting generics in standard collections](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections).