### PR TITLE
Align limits for deferring delete and reindexing on insert

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -732,7 +732,7 @@ BEGIN
   IF NEW.rank_address between 2 and 27 THEN
     IF (ST_GeometryType(NEW.geometry) in ('ST_Polygon','ST_MultiPolygon') AND ST_IsValid(NEW.geometry)) THEN
       -- Performance: We just can't handle re-indexing for country level changes
-      IF (NEW.rank_address < 26 and st_area(NEW.geometry) < 1)
+      IF (NEW.rank_address < 26 and st_area(NEW.geometry) <= 2)
          OR (NEW.rank_address >= 26 and st_area(NEW.geometry) < 0.01)
       THEN
         -- mark items within the geometry for re-indexing


### PR DESCRIPTION
Nominatim has a mechanism where it refuses to delete large boundary areas when they disappear, assuming that this is rather a mapping accident than a willful delete. It also has a mechanism to recompute all addresses inside a boundary area when it is indexed to take the new boundary into account but only up to a certain area size. When the limits for these two mechanisms are not aligned, we can arrive at the situation where a boundary area is deemed small enough to be deleted when it breaks but too small to trigger reindexing when the boundary is repaired.

This should avoid incidents in the future, like the ones where states in various countries have disappeared from addresses recently, e.g. [[1]](https://community.openstreetmap.org/t/how-to-add-state-data-to-connecticut-counties-planning-regions/132677) or #3640.