### PR TITLE
Localize() + Results refactor

### DIFF
--- a/src/nominatim_api/localization.py
+++ b/src/nominatim_api/localization.py
@@ -9,6 +9,7 @@ Helper functions for localizing names of results.
 """
 from typing import Mapping, List, Optional
 from .config import Configuration
+from .results import AddressLines, BaseResultT
 
 import re
 
@@ -96,3 +97,24 @@ class Locales:
                 languages.append(parts[0])
 
         return Locales(languages)
+
+    def localize(self, lines: AddressLines) -> None:
+        """ Sets the local name of address parts according to the chosen
+            locale.
+
+            Only address parts that are marked as isaddress are localized.
+
+            AddressLines should be modified in place.
+        """
+        for line in lines:
+            if line.isaddress and line.names:
+                line.local_name = self.display_name(line.names)
+
+    def localize_results(self, results: List[BaseResultT]) -> None:
+        """ Set the local name of results according to the chosen
+            locale.
+        """
+        for result in results:
+            result.locale_name = self.display_name(result.names)
+            if result.address_rows:
+                self.localize(result.address_rows)

--- a/src/nominatim_api/types.py
+++ b/src/nominatim_api/types.py
@@ -17,7 +17,6 @@ from struct import unpack
 from binascii import unhexlify
 
 from .errors import UsageError
-from .localization import Locales
 
 
 @dataclasses.dataclass
@@ -409,9 +408,6 @@ class LookupDetails:
     """ Simplification factor for a geometry in degrees WGS. A factor of
         0.0 means the original geometry is kept. The higher the value, the
         more the geometry gets simplified.
-    """
-    locales: Locales = Locales()
-    """ Preferred languages for localization of results.
     """
 
     @classmethod

--- a/src/nominatim_db/clicmd/export.py
+++ b/src/nominatim_db/clicmd/export.py
@@ -151,9 +151,11 @@ async def dump_results(conn: napi.SearchConnection,
                        results: List[ReverseResult],
                        writer: 'csv.DictWriter[str]',
                        lang: Optional[str]) -> None:
-    locale = napi.Locales([lang] if lang else None)
     await add_result_details(conn, results,
-                             LookupDetails(address_details=True, locales=locale))
+                             LookupDetails(address_details=True))
+
+    locale = napi.Locales([lang] if lang else None)
+    locale.localize_results(results)
 
     for result in results:
         data = {'placeid': result.place_id,

--- a/test/python/api/test_api_details.py
+++ b/test/python/api/test_api_details.py
@@ -34,6 +34,7 @@ def test_lookup_in_placex(apiobj, frontend, idobj):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(idobj)
+    napi.Locales().localize_results([result])
 
     assert result is not None
 
@@ -83,6 +84,7 @@ def test_lookup_in_placex_minimal_info(apiobj, frontend):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(napi.PlaceID(332))
+    napi.Locales().localize_results([result])
 
     assert result is not None
 
@@ -149,6 +151,7 @@ def test_lookup_placex_with_address_details(apiobj, frontend):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(napi.PlaceID(332), address_details=True)
+    napi.Locales().localize_results([result])
 
     assert result.address_rows == [
                napi.AddressLine(place_id=332, osm_object=('W', 4),
@@ -350,6 +353,7 @@ def test_lookup_osmline_with_address_details(apiobj, frontend):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(napi.PlaceID(9000), address_details=True)
+    napi.Locales().localize_results([result])
 
     assert result.address_rows == [
                napi.AddressLine(place_id=332, osm_object=('W', 4),
@@ -450,6 +454,7 @@ def test_lookup_tiger_with_address_details(apiobj, frontend):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(napi.PlaceID(9000), address_details=True)
+    napi.Locales().localize_results([result])
 
     assert result.address_rows == [
                napi.AddressLine(place_id=332, osm_object=('W', 4),
@@ -545,6 +550,7 @@ def test_lookup_postcode_with_address_details(apiobj, frontend):
 
     api = frontend(apiobj, options={'details'})
     result = api.details(napi.PlaceID(9000), address_details=True)
+    napi.Locales().localize_results([result])
 
     assert result.address_rows == [
                napi.AddressLine(place_id=9000, osm_object=None,

--- a/test/python/api/test_result_formatting_v1.py
+++ b/test/python/api/test_result_formatting_v1.py
@@ -119,7 +119,7 @@ def test_search_details_full():
                   country_code='ll',
                   indexed_date=import_date
                   )
-    search.localize(napi.Locales())
+    napi.Locales().localize_results([search])
 
     result = v1_format.format_result(search, 'json', {})
 

--- a/test/python/api/test_result_formatting_v1_reverse.py
+++ b/test/python/api/test_result_formatting_v1_reverse.py
@@ -102,11 +102,10 @@ def test_format_reverse_with_address(fmt):
                                                     rank_address=10,
                                                     distance=0.0)
                                  ]))
-    reverse.localize(napi.Locales())
+    napi.Locales().localize_results([reverse])
 
     raw = v1_format.format_result(napi.ReverseResults([reverse]), fmt,
                                   {'addressdetails': True})
-
     if fmt == 'xml':
         root = ET.fromstring(raw)
         assert root.find('addressparts').find('county').text == 'Hello'
@@ -165,7 +164,7 @@ def test_format_reverse_geocodejson_special_parts():
                                                     distance=0.0)
                                  ]))
 
-    reverse.localize(napi.Locales())
+    napi.Locales().localize_results([reverse])
 
     raw = v1_format.format_result(napi.ReverseResults([reverse]), 'geocodejson',
                                   {'addressdetails': True})

--- a/test/python/cli/test_cmd_api.py
+++ b/test/python/cli/test_cmd_api.py
@@ -74,8 +74,7 @@ class TestCliReverseCall:
                                     napi.Point(1.0, -3.0),
                                     names={'name': 'Name', 'name:fr': 'Nom'},
                                     extratags={'extra': 'Extra'},
-                                    locale_name='Name',
-                                    display_name='Name')
+                                    locale_name='Name')
 
         monkeypatch.setattr(napi.NominatimAPI, 'reverse',
                             lambda *args, **kwargs: result)
@@ -122,8 +121,7 @@ class TestCliLookupCall:
                                    napi.Point(1.0, -3.0),
                                    names={'name': 'Name', 'name:fr': 'Nom'},
                                    extratags={'extra': 'Extra'},
-                                   locale_name='Name',
-                                   display_name='Name')
+                                   locale_name='Name')
 
         monkeypatch.setattr(napi.NominatimAPI, 'lookup',
                             lambda *args, **kwargs: napi.SearchResults([result]))
@@ -150,8 +148,7 @@ def test_search(cli_call, tmp_path, capsys, monkeypatch, endpoint, params):
                                napi.Point(1.0, -3.0),
                                names={'name': 'Name', 'name:fr': 'Nom'},
                                extratags={'extra': 'Extra'},
-                               locale_name='Name',
-                               display_name='Name')
+                               locale_name='Name')
 
     monkeypatch.setattr(napi.NominatimAPI, endpoint,
                         lambda *args, **kwargs: napi.SearchResults([result]))


### PR DESCRIPTION
First pass at restructuring localize and the locales class! 

- Reformatted Addresslines to now explicitly subclass List[AddressLine], making it a strongly-typed list of AddressLine objects. 
- Created a Formatter class in charge of localization and removed localize from add_result_details, manually creating a new Formatter object instead. This calls localize explicitly after every add_result_details call. 
- Changed display_name to be a property of BaseResults instead of a field. This meant that I had to remove the display_name as keyword from tests as well. 