### PR TITLE
Better hint to user if database import didnt finish

### DIFF
--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -92,7 +92,7 @@ but executes against the code in the source tree. For example:
 ```
 me@machine:~$ cd Nominatim
 me@machine:~Nominatim$ ./nominatim-cli.py --version
-Nominatim version 4.4.99-1
+Nominatim version 5.1.0-0
 ```
 
 Make sure you have activated the virtual environment holding all

--- a/test/python/tools/test_check_database.py
+++ b/test/python/tools/test_check_database.py
@@ -31,6 +31,10 @@ def test_check_connection_bad(def_config):
     assert chkdb.check_connection(badconn, def_config) == chkdb.CheckState.FATAL
 
 
+def test_check_database_version_not_found(property_table, temp_db_conn, def_config):
+    assert chkdb.check_database_version(temp_db_conn, def_config) == chkdb.CheckState.FATAL
+
+
 def test_check_database_version_good(property_table, temp_db_conn, def_config):
     property_table.set('database_version',
                        str(nominatim_db.version.NOMINATIM_VERSION))


### PR DESCRIPTION
Improve error message for when the database import hasn't finished (when `nominatim_properties` table is created, but the `database_version` record hasn't been written yet). For https://github.com/osm-search/Nominatim/issues/3794