### PR TITLE
Reduce coordinate precision of centroids and interpolation lines

### DIFF
--- a/lib-sql/functions/interpolation.sql
+++ b/lib-sql/functions/interpolation.sql
@@ -309,7 +309,7 @@ BEGIN
         IF NEW.startnumber IS NULL THEN
             NEW.startnumber := startnumber;
             NEW.endnumber := endnumber;
-            NEW.linegeo := sectiongeo;
+            NEW.linegeo := ST_ReducePrecision(sectiongeo, 0.0000001);
             NEW.postcode := postcode;
         ELSE
           INSERT INTO location_property_osmline
@@ -317,7 +317,8 @@ BEGIN
                   startnumber, endnumber, step,
                   address, postcode, country_code,
                   geometry_sector, indexed_status)
-          VALUES (sectiongeo, NEW.partition, NEW.osm_id, NEW.parent_place_id,
+          VALUES (ST_ReducePrecision(sectiongeo, 0.0000001),
+                  NEW.partition, NEW.osm_id, NEW.parent_place_id,
                   startnumber, endnumber, NEW.step,
                   NEW.address, postcode,
                   NEW.country_code, NEW.geometry_sector, 0);

--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -780,7 +780,7 @@ BEGIN
   SELECT count(*)>0 FROM pg_tables WHERE tablename = classtable and schemaname = current_schema() INTO result;
   IF result THEN
     EXECUTE 'INSERT INTO ' || classtable::regclass || ' (place_id, centroid) VALUES ($1,$2)' 
-    USING NEW.place_id, ST_Centroid(NEW.geometry);
+    USING NEW.place_id, NEW.centroid;
   END IF;
 
 {% endif %} -- not disable_diff_updates

--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -2,7 +2,7 @@
 --
 -- This file is part of Nominatim. (https://nominatim.org)
 --
--- Copyright (C) 2022 by the Nominatim developer community.
+-- Copyright (C) 2025 by the Nominatim developer community.
 -- For a full list of authors see the git log.
 
 -- Assorted helper functions for the triggers.
@@ -14,14 +14,14 @@ DECLARE
   geom_type TEXT;
 BEGIN
   geom_type := ST_GeometryType(place);
-  IF geom_type = ' ST_Point' THEN
+  IF geom_type = 'ST_Point' THEN
     RETURN place;
   END IF;
   IF geom_type = 'ST_LineString' THEN
-    RETURN ST_LineInterpolatePoint(place, 0.5);
+    RETURN ST_ReducePrecision(ST_LineInterpolatePoint(place, 0.5), 0.0000001);
   END IF;
 
-  RETURN ST_PointOnSurface(place);
+  RETURN ST_ReducePrecision(ST_PointOnSurface(place), 0.0000001);
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/test/bdd/features/api/reverse/v1_json.feature
+++ b/test/bdd/features/api/reverse/v1_json.feature
@@ -104,7 +104,7 @@ Feature: Json output for Reverse API
           | way      | 1      |
         And the result contains
           | lon       | lat        | boundingbox!in_box |
-          | 9.5705468 | 47.1185454 | 47.118494, 47.118596, 9.570495, 9.570597 |
+          | 9.5705467 | 47.1185454 | 47.118494, 47.118596, 9.570495, 9.570597 |
         And the result contains
           | display_name |
           | 1019, Grosssteg, Sücka, Triesenberg, Oberland, 9497, Liechtenstein |

--- a/test/bdd/features/api/reverse/v1_xml.feature
+++ b/test/bdd/features/api/reverse/v1_xml.feature
@@ -70,7 +70,7 @@ Feature: XML output for Reverse API
           | way      | 1      | 30         | 30           |
         And the result contains
           | lon       | lat        | boundingbox |
-          | 9.5705468 | 47.1185454 | 47.1184954,47.1185954,9.5704968,9.5705968 |
+          | 9.5705467 | 47.1185454 | 47.1184954,47.1185954,9.5704967,9.5705967 |
         And the result contains
           | display_name |
           | 1019, Grosssteg, Sücka, Triesenberg, Oberland, 9497, Liechtenstein |


### PR DESCRIPTION
Use `ST_ReducePrecision()` to make sure all coordinates are stored with a OSM coordinate precision of 7 digits.