### PR TITLE
Ignore survey:* tags

### DIFF
--- a/lib-lua/themes/nominatim/presets.lua
+++ b/lib-lua/themes/nominatim/presets.lua
@@ -362,7 +362,7 @@ module.IGNORE_KEYS.metatags = {'note', 'note:*', 'source', 'source:*', '*source'
                                'tiger:cfcc', 'tiger:reviewed', 'nysgissam:*',
                                'NHD:*', 'nhd:*', 'gnis:*', 'geobase:*', 'yh:*',
                                'osak:*', 'naptan:*', 'CLC:*', 'import', 'it:fvg:*',
-                               'lacounty:*', 'ref:linz:*',
+                               'lacounty:*', 'ref:linz:*', 'survey:*',
                                'ref:bygningsnr', 'ref:ruian:*', 'building:ruian:type',
                                'type',
                                'is_in:postcode'}


### PR DESCRIPTION
`survey:date` has become a tag that is quite frequently added to POIs. It's just a meta tag telling about the latest update and can be dropped by default.