### PR TITLE
reduce default DB pool size

### DIFF
--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -169,10 +169,10 @@ NOMINATIM_POLYGON_OUTPUT_MAX_TYPES=1
 # under <endpoint>.php
 NOMINATIM_SERVE_LEGACY_URLS=yes
 
-# Maximum number of connection a single API object can use. (Python API only)
+# Maximum number of DB connections a single API object can use.
 # When running Nominatim as a server, then this is the maximum number
 # of connections _per worker_.
-NOMINATIM_API_POOL_SIZE=10
+NOMINATIM_API_POOL_SIZE=5
 
 # Timeout is seconds after which a single query to the database is cancelled.
 # The user receives a 503 response, when a query times out.


### PR DESCRIPTION
The number of parallel DB connections that a single API object can handle is determined by the amount of time the query spends in Python. A single API object is still single-threaded and uses only one CPU for executing the Python part.

The original value of 10 threads is far too optimistic about how fast Python is. Reduce to a value of 5, which worked out okay in production.