### PR TITLE
Apply request timeouts while waiting for a connection

### DIFF
--- a/packaging/nominatim-api/pyproject.toml
+++ b/packaging/nominatim-api/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "async-timeout",
     "python-dotenv",
     "pyYAML>=5.1",
     "SQLAlchemy>=1.4.31",

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -175,12 +175,15 @@ NOMINATIM_SERVE_LEGACY_URLS=yes
 NOMINATIM_API_POOL_SIZE=5
 
 # Timeout is seconds after which a single query to the database is cancelled.
-# The user receives a 503 response, when a query times out.
+# The caller receives a TimeoutError (or HTTP 503), when a query times out.
 # When empty, then timeouts are disabled.
 NOMINATIM_QUERY_TIMEOUT=10
 
-# Maximum time a single request is allowed to take. When the timeout is
-# exceeded, the available results are returned.
+# Maximum time a single request is allowed to take. If the timeout is exceeded
+# before the request is able to obtain a database connection from the
+# connection pool, a TimeoutError (or HTTP 503) is thrown. If the timeout
+# is exceeded while the search is ongoing, all results already found will
+# be returned.
 # When empty, then timeouts are disabled.
 NOMINATIM_REQUEST_TIMEOUT=60
 

--- a/src/nominatim_api/core.py
+++ b/src/nominatim_api/core.py
@@ -62,6 +62,8 @@ class NominatimAPIAsync:
         self.config = Configuration(project_dir, environ)
         self.query_timeout = self.config.get_int('QUERY_TIMEOUT') \
             if self.config.QUERY_TIMEOUT else None
+        self.request_timeout = self.config.get_int('REQUEST_TIMEOUT') \
+            if self.config.REQUEST_TIMEOUT else None
         self.reverse_restrict_to_country_area = self.config.get_bool('SEARCH_WITHIN_COUNTRIES')
         self.server_version = 0
 
@@ -252,8 +254,7 @@ class NominatimAPIAsync:
         async with self.begin() as conn:
             conn.set_query_timeout(self.query_timeout)
             geocoder = nsearch.ForwardGeocoder(conn, ntyp.SearchDetails.from_kwargs(params),
-                                               self.config.get_int('REQUEST_TIMEOUT')
-                                               if self.config.REQUEST_TIMEOUT else None)
+                                               self.request_timeout)
             phrases = [nsearch.Phrase(nsearch.PHRASE_ANY, p.strip()) for p in query.split(',')]
             return await geocoder.lookup(phrases)
 
@@ -309,9 +310,7 @@ class NominatimAPIAsync:
                 if amenity:
                     details.layers |= ntyp.DataLayer.POI
 
-            geocoder = nsearch.ForwardGeocoder(conn, details,
-                                               self.config.get_int('REQUEST_TIMEOUT')
-                                               if self.config.REQUEST_TIMEOUT else None)
+            geocoder = nsearch.ForwardGeocoder(conn, details, self.request_timeout)
             return await geocoder.lookup(phrases)
 
     async def search_category(self, categories: List[Tuple[str, str]],
@@ -334,9 +333,7 @@ class NominatimAPIAsync:
                 if details.keywords:
                     await nsearch.make_query_analyzer(conn)
 
-            geocoder = nsearch.ForwardGeocoder(conn, details,
-                                               self.config.get_int('REQUEST_TIMEOUT')
-                                               if self.config.REQUEST_TIMEOUT else None)
+            geocoder = nsearch.ForwardGeocoder(conn, details, self.request_timeout)
             return await geocoder.lookup_pois(categories, phrases)
 
 

--- a/src/nominatim_api/timeout.py
+++ b/src/nominatim_api/timeout.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Helpers for handling of timeouts for request.
+"""
+from typing import Union, Optional
+import asyncio
+
+
+class Timeout:
+    """ A class that provides helper functions to ensure a given timeout
+        is respected. Can only be used from coroutines.
+    """
+    def __init__(self, timeout: Optional[Union[int, float]]) -> None:
+        self.abs = None if timeout is None else asyncio.get_running_loop().time() + timeout
+
+    def is_elapsed(self) -> bool:
+        """ Check if the timeout has already passed.
+        """
+        return (self.abs is not None) and (asyncio.get_running_loop().time() >= self.abs)

--- a/test/python/api/test_timeout.py
+++ b/test/python/api/test_timeout.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for timeout helper
+"""
+import asyncio
+
+import pytest
+
+from nominatim_api.timeout import Timeout
+
+
+@pytest.mark.asyncio
+async def test_timeout_none():
+    timeout = Timeout(None)
+
+    assert timeout.abs is None
+    assert not timeout.is_elapsed()
+
+
+@pytest.mark.asyncio
+async def test_timeout_should_not_be_elapsed_after_creation():
+    assert not Timeout(2).is_elapsed()
+
+
+@pytest.mark.asyncio
+async def test_timeout_elapse():
+    timeout = Timeout(0.5)
+
+    assert timeout.abs is not None
+    await asyncio.sleep(0.5)
+    assert timeout.is_elapsed()


### PR DESCRIPTION
`NOMINATIM_REQUEST_TIMEOUT` allows to restrict the maximum runtime of a query. Until now it only applied to the actual processing part of the query. Before that part starts, the client has to get a database connection from the connection pool. When a server gets overloaded and the request queue gets overly full, then it can take a long time before a connection is available. This can easily lead to situations where Nominatim only gets to process queries where the client has long given up waiting for a response.

This PR changes the meaning of the parameter and also applies it to the time spent waiting for a connection. If the timeout hits before a connection is available a `TimeoutError` (or HTTP 503) is returned. If the timeout then hits later while the query is being processed, the available requests will be returned as before.