### PR TITLE
Improve word match penalty for scripts without word boundaries

### DIFF
--- a/src/nominatim_api/search/query.py
+++ b/src/nominatim_api/search/query.py
@@ -199,8 +199,6 @@ class QueryNode:
     """
     term_normalized: str
     """ Normalised form of term ending at this node.
-        When the token resulted from a split during transliteration,
-        then this string contains the complete source term.
     """
 
     starting: List[TokenList] = dataclasses.field(default_factory=list)
@@ -391,14 +389,6 @@ class QueryStruct:
                     if t.token == token:
                         return f"[{tlist.ttype}]{t.lookup_word}"
         return 'None'
-
-    def get_transliterated_query(self) -> str:
-        """ Return a string representation of the transliterated query
-            with the character representation of the different break types.
-
-            For debugging purposes only.
-        """
-        return ''.join(''.join((n.term_lookup, n.btype)) for n in self.nodes)
 
     def extract_words(self, start: int = 0,
                       endpos: Optional[int] = None) -> Dict[str, List[TokenRange]]:


### PR DESCRIPTION
When finding matching tokens for a query, lookup is done first against the transliterated version. Then token are rematched against the normalized untransliterated version to give preference to terms where the script and spelling matches. If the transliteration process splits a word into subwords, then it becomes a bit difficult to find out what the original untransliterated part was because the ICU library doesn't tell us where in the original word the split occurred. So far, the rematching was simply done against the complete untransliterated word but that gives penalties that are wildly off.

This adds a function to guess the matching split of the untransliterated word by finding parts of the words where the transliteration fits to the transliterated subwords. This should greatly improve results for languages like Chinese and Japanese.

See also https://community.openstreetmap.org/t/nominatim-cannot-search-for-kanji-or-japanese-properly-nominatim/134630