### PR TITLE
chore: update no,nb,nn country-names translation

### DIFF
--- a/settings/country-names/ad.yaml
+++ b/settings/country-names/ad.yaml
@@ -97,7 +97,6 @@ name:
     na: Andorra
     ne: एण्डोरा
     nl: Andorra
-    nn: Andorra
     "no": Andorra
     nv: Andówa
     oc: Andòrra

--- a/settings/country-names/ae.yaml
+++ b/settings/country-names/ae.yaml
@@ -74,6 +74,7 @@ name:
     mt: Emirati Għarab Magħquda
     my: အာရပ်စော်ဘွားများပြည်ထောင်စုနိုင်ငံ
     na: Emireitit Arabiya
+    nb: De forente arabiske emirater
     ne: संयुक्त अरब इमिरेट्स
     nl: Verenigde Arabische Emiraten
     nn: Dei sameinte arabiske emirata

--- a/settings/country-names/af.yaml
+++ b/settings/country-names/af.yaml
@@ -96,7 +96,6 @@ name:
     na: Apeganitan
     ne: अफगानिस्तान
     nl: Afghanistan
-    nn: Afghanistan
     "no": Afghanistan
     oc: Afganistan
     om: Afgaanistaan

--- a/settings/country-names/ag.yaml
+++ b/settings/country-names/ag.yaml
@@ -86,10 +86,8 @@ name:
     mt: Antigwa u Barbuda
     my: အင်တီဂွါနှင့် ဘာဘူဒါ
     na: Antigua me Barbuda
-    nb: Antigua og Barbuda
     ne: एन्टिगुआ र बर्बुडा
     nl: Antigua en Barbuda
-    nn: Antigua og Barbuda
     "no": Antigua og Barbuda
     nv: Antíígwa dóó Hashkʼaan Bikéyah Yázhí
     oc: Antigua e Barbuda

--- a/settings/country-names/ai.yaml
+++ b/settings/country-names/ai.yaml
@@ -50,7 +50,6 @@ name:
     ms: Anguilla
     ne: एन्गुला
     nl: Anguilla
-    nn: Anguilla
     "no": Anguilla
     oc: Anguilla
     pa: ਐਂਗੁਈਲਾ

--- a/settings/country-names/al.yaml
+++ b/settings/country-names/al.yaml
@@ -101,7 +101,6 @@ name:
     na: Arbainiya
     ne: अल्बानिया
     nl: Albanië
-    nn: Albania
     "no": Albania
     nv: Dziłigaii Bikéyah
     oc: Albania

--- a/settings/country-names/am.yaml
+++ b/settings/country-names/am.yaml
@@ -99,7 +99,6 @@ name:
     na: Arminiya
     ne: आर्मेनिया
     nl: Armenië
-    nn: Armenia
     "no": Armenia
     nv: Aooméénii Bikéyah
     oc: Armenia

--- a/settings/country-names/ao.yaml
+++ b/settings/country-names/ao.yaml
@@ -90,7 +90,6 @@ name:
     na: Angora
     ne: अंगोला
     nl: Angola
-    nn: Angola
     "no": Angola
     nv: Angóola
     ny: Angola

--- a/settings/country-names/ar.yaml
+++ b/settings/country-names/ar.yaml
@@ -99,7 +99,6 @@ name:
     na: Ardjentina
     ne: अर्जेन्टिना
     nl: Argentinië
-    nn: Argentina
     "no": Argentina
     nv: Béésh Łigaii Bikéyah
     oc: Argentina

--- a/settings/country-names/at.yaml
+++ b/settings/country-names/at.yaml
@@ -93,6 +93,7 @@ name:
     mt: Awstrija
     my: သြစတြီးယားနိုင်ငံ
     na: Oteriya
+    nb: Østerrike
     ne: अष्ट्रीया
     nl: Oostenrijk
     nn: Austerrike

--- a/settings/country-names/au.yaml
+++ b/settings/country-names/au.yaml
@@ -94,7 +94,6 @@ name:
     na: Otereiriya
     ne: अष्ट्रेलिया
     nl: Australië
-    nn: Australia
     "no": Australia
     nv: Nahatʼeʼiitsoh Bikéyah
     oc: Austràlia

--- a/settings/country-names/az.yaml
+++ b/settings/country-names/az.yaml
@@ -96,10 +96,8 @@ name:
     mt: Ażerbajġan
     my: အဇာဘိုင်ဂျန်နိုင်ငံ
     na: Aderbaidjan
-    nb: Aserbajdsjan
     ne: अजरबैजान
     nl: Azerbeidzjan
-    nn: Aserbajdsjan
     "no": Aserbajdsjan
     nv: Azééwii Bikéyah
     ny: Azerbaijan

--- a/settings/country-names/ba.yaml
+++ b/settings/country-names/ba.yaml
@@ -94,7 +94,6 @@ name:
     na: Boteniya me Erdegobina
     ne: बोस्निया र हर्जगोभिना
     nl: Bosnië en Herzegovina
-    nn: Bosnia-Hercegovina
     "no": Bosnia-Hercegovina
     nv: Bosna dóó Hetsog Bikéyah
     oc: Bòsnia e Ercegovina

--- a/settings/country-names/bb.yaml
+++ b/settings/country-names/bb.yaml
@@ -77,7 +77,6 @@ name:
     na: Barbadot
     ne: बार्बाडोस
     nl: Barbados
-    nn: Barbados
     "no": Barbados
     oc: Barbados
     om: Baarbeedoos

--- a/settings/country-names/bd.yaml
+++ b/settings/country-names/bd.yaml
@@ -29,6 +29,7 @@ name:
     lt: Bangladešas
     lv: Bangladeša
     mn: Бангладеш
+    "no": Bangladesh
     pl: Bangladesz
     pt: Bangladesh
     ru: Бангладеш

--- a/settings/country-names/be.yaml
+++ b/settings/country-names/be.yaml
@@ -95,10 +95,8 @@ name:
     mt: Belġju
     my: ဘယ်လ်ဂျီယမ်နိုင်ငံ
     na: Berdjiyum
-    nb: Belgia
     ne: बेल्जियम
     nl: België
-    nn: Belgia
     "no": Belgia
     oc: Belgica
     om: Beeljiyeem

--- a/settings/country-names/bf.yaml
+++ b/settings/country-names/bf.yaml
@@ -88,7 +88,6 @@ name:
     na: Burkinabato
     ne: बुर्किना फासो
     nl: Burkina Faso
-    nn: Burkina Faso
     "no": Burkina Faso
     oc: Burkina Faso
     om: Burkinaa Faasoo

--- a/settings/country-names/bg.yaml
+++ b/settings/country-names/bg.yaml
@@ -93,7 +93,6 @@ name:
     na: Borgeriya
     ne: बुल्गेरिया
     nl: Bulgarije
-    nn: Bulgaria
     "no": Bulgaria
     nv: Bálgaa Bikéyah
     oc: Bulgaria

--- a/settings/country-names/bh.yaml
+++ b/settings/country-names/bh.yaml
@@ -91,7 +91,6 @@ name:
     na: Bahrain
     ne: बहराइन
     nl: Bahrein
-    nn: Bahrain
     "no": Bahrain
     oc: Bahrayn
     om: Baahireen

--- a/settings/country-names/bi.yaml
+++ b/settings/country-names/bi.yaml
@@ -88,7 +88,6 @@ name:
     na: Burundi
     ne: बुरूण्डी
     nl: Burundi
-    nn: Burundi
     "no": Burundi
     oc: Burundi
     om: Buruundii

--- a/settings/country-names/bj.yaml
+++ b/settings/country-names/bj.yaml
@@ -91,7 +91,6 @@ name:
     na: Benin
     ne: बेनिन
     nl: Benin
-    nn: Benin
     "no": Benin
     oc: Benin
     om: Beeniin

--- a/settings/country-names/bm.yaml
+++ b/settings/country-names/bm.yaml
@@ -25,6 +25,7 @@ name:
     lv: Bermudu salas
     mk: Бермуда
     mn: Бермудын Арал
+    "no": Bermuda
     oc: Bermudas
     pl: Bermudy
     pt: Bermudas

--- a/settings/country-names/bn.yaml
+++ b/settings/country-names/bn.yaml
@@ -91,7 +91,6 @@ name:
     na: Brunei
     ne: ब्रुनेई
     nl: Brunei
-    nn: Brunei
     "no": Brunei
     ny: Brunei
     oc: Brunei

--- a/settings/country-names/bo.yaml
+++ b/settings/country-names/bo.yaml
@@ -94,7 +94,6 @@ name:
     na: Boribiya
     ne: बोलिभिया
     nl: Bolivia
-    nn: Bolivia
     "no": Bolivia
     nv: Bolíbiya
     oc: Bolívia

--- a/settings/country-names/br.yaml
+++ b/settings/country-names/br.yaml
@@ -99,7 +99,6 @@ name:
     na: Bradir
     ne: ब्राजिल
     nl: Brazilië
-    nn: Brasil
     "no": Brasil
     nv: Bwazííl
     oc: Brasil

--- a/settings/country-names/bs.yaml
+++ b/settings/country-names/bs.yaml
@@ -85,7 +85,6 @@ name:
     na: Bahamat
     ne: बहामस
     nl: Bahama's
-    nn: Bahamas
     "no": Bahamas
     oc: Las Bahamas
     om: Bahamaas

--- a/settings/country-names/bt.yaml
+++ b/settings/country-names/bt.yaml
@@ -92,7 +92,6 @@ name:
     na: Butan
     ne: भूटान
     nl: Bhutan
-    nn: Bhutan
     "no": Bhutan
     nv: Bikéyah
     oc: Botan

--- a/settings/country-names/bw.yaml
+++ b/settings/country-names/bw.yaml
@@ -90,7 +90,6 @@ name:
     na: Botwana
     ne: बोत्स्वाना
     nl: Botswana
-    nn: Botswana
     "no": Botswana
     nv: Tswana Dineʼé Bikéyah
     oc: Botswana

--- a/settings/country-names/by.yaml
+++ b/settings/country-names/by.yaml
@@ -83,8 +83,7 @@ name:
     na: Berarut
     ne: बेलारुस
     nl: Wit-Rusland
-    nn: Kviterussland
-    "no": Hviterussland
+    "no": Belarus
     oc: Bielorussia
     or: ବେଲାଋଷ
     os: Белорусси

--- a/settings/country-names/bz.yaml
+++ b/settings/country-names/bz.yaml
@@ -85,7 +85,6 @@ name:
     na: Berij
     ne: बेलिज
     nl: Belize
-    nn: Belize
     "no": Belize
     oc: Belize
     om: Beliiz

--- a/settings/country-names/ca.yaml
+++ b/settings/country-names/ca.yaml
@@ -94,7 +94,6 @@ name:
     na: Kanada
     ne: क्यानाडा
     nl: Canada
-    nn: Canada
     "no": Canada
     nv: Deeteel Bikéyah
     oc: Canadà

--- a/settings/country-names/cd.yaml
+++ b/settings/country-names/cd.yaml
@@ -74,7 +74,6 @@ name:
     na: Ripubrikit Engame Kongo
     ne: प्रजातान्त्रिक गणतन्त्र कंगो
     nl: Democratische Republiek Congo
-    nn: Den demokratiske republikken Kongo
     "no": Den demokratiske republikken Kongo
     nv: Kéyah Káango Shádiʼááhjí Siʼánígíí
     oc: Republica Democratica de Còngo

--- a/settings/country-names/cf.yaml
+++ b/settings/country-names/cf.yaml
@@ -72,6 +72,7 @@ name:
     mt: Repubblika Ċentru-Afrikana
     my: ဗဟိုအာဖရိကသမ္မတနိုင်ငံ
     na: Ripubrikin Aprika Yugaga
+    nb: Den sentralafrikanske republikk
     ne: मध्य अफ्रिकी गणतन्त्र
     nl: Centraal-Afrikaanse Republiek
     nn: Den sentralafrikanske republikken

--- a/settings/country-names/cg.yaml
+++ b/settings/country-names/cg.yaml
@@ -70,7 +70,6 @@ name:
     na: Ripubrikin Kongo
     ne: कङ्गो
     nl: Congo-Brazzaville
-    nn: Kongo-Brazzaville
     "no": Republikken Kongo
     nv: Kéyah Káango Náhookǫsjí Siʼánígíí
     oc: Republica de Còngo

--- a/settings/country-names/ch.yaml
+++ b/settings/country-names/ch.yaml
@@ -84,7 +84,6 @@ name:
     na: Switzerland
     ne: स्विजरल्याण्ड
     nl: Zwitserland
-    nn: Sveits
     "no": Sveits
     nv: Swis Bikéyah
     oc: Soïssa

--- a/settings/country-names/ci.yaml
+++ b/settings/country-names/ci.yaml
@@ -75,6 +75,7 @@ name:
     mt: Kosta tal-Avorju
     my: အိုင်ဗရီကို့စ်နိုင်ငံ
     na: Aibori Kot
+    nb: Elfenbenskysten
     ne: आइभरी कोस्ट
     nl: Ivoorkust
     nn: Elfenbeinskysten

--- a/settings/country-names/ck.yaml
+++ b/settings/country-names/ck.yaml
@@ -79,6 +79,7 @@ name:
     ms: Kepulauan Cook
     mt: Gżejjer Cook
     my: ကွတ် ကျွန်းစု
+    nb: Cookøyene
     ne: कुक टापु
     nl: Cookeilanden
     nn: Cookøyane

--- a/settings/country-names/cl.yaml
+++ b/settings/country-names/cl.yaml
@@ -103,7 +103,6 @@ name:
     na: Tsire
     ne: चिली
     nl: Chili
-    nn: Chile
     "no": Chile
     nv: Chíilii
     ny: Chile

--- a/settings/country-names/cm.yaml
+++ b/settings/country-names/cm.yaml
@@ -79,7 +79,6 @@ name:
     na: Kamerun
     ne: क्यामेरून
     nl: Kameroen
-    nn: Kamerun
     "no": Kamerun
     nv: Táłtłʼááh Chʼosh Daadánígíí Bitooh
     oc: Cameron

--- a/settings/country-names/cn.yaml
+++ b/settings/country-names/cn.yaml
@@ -101,10 +101,8 @@ name:
     mt: Ċina
     my: တရုတ်
     na: Tsiene
-    nb: Kina
     ne: चीन
     nl: China
-    nn: Kina
     "no": Kina
     nv: Tsiiʼyishbizhí Dineʼé Bikéyah
     ny: China

--- a/settings/country-names/co.yaml
+++ b/settings/country-names/co.yaml
@@ -82,7 +82,6 @@ name:
     na: Korombiya
     ne: कोलम्बिया
     nl: Colombia
-    nn: Colombia
     "no": Colombia
     nv: Kolámbiya
     oc: Colómbia

--- a/settings/country-names/cr.yaml
+++ b/settings/country-names/cr.yaml
@@ -81,7 +81,6 @@ name:
     na: Kosta Rika
     ne: कोस्टारिका
     nl: Costa Rica
-    nn: Costa Rica
     "no": Costa Rica
     oc: Còsta Rica
     om: Kostaa Rikaa

--- a/settings/country-names/cu.yaml
+++ b/settings/country-names/cu.yaml
@@ -78,7 +78,6 @@ name:
     na: Kiuba
     ne: क्युबा
     nl: Cuba
-    nn: Cuba
     "no": Cuba
     nv: Kyóoba
     oc: Cuba

--- a/settings/country-names/cv.yaml
+++ b/settings/country-names/cv.yaml
@@ -36,6 +36,7 @@ name:
     mk: Зелен ’Рт
     mn: Кабо-Верде
     nl: Kaapverdië
+    "no": Kapp Verde
     pl: Republika Zielonego Przylądka
     pt: Cabo Verde
     ru: Кабо-Верде

--- a/settings/country-names/cy.yaml
+++ b/settings/country-names/cy.yaml
@@ -77,10 +77,8 @@ name:
     mt: Ċipru
     my: ဆိုက်ပရပ်စ်နိုင်ငံ
     na: Taiprus
-    nb: Kypros
     ne: साइप्रस
     nl: Cyprus
-    nn: Kypros
     "no": Kypros
     nv: Béésh Łichíiʼii Bikéyah
     oc: Chipre

--- a/settings/country-names/cz.yaml
+++ b/settings/country-names/cz.yaml
@@ -93,7 +93,6 @@ name:
     na: Ripubrikin Tsiek
     ne: चेक गणतन्त्र
     nl: Tsjechië
-    nn: Tsjekkia
     "no": Tsjekkia
     nv: Chek Bikéyah
     oc: Republica Chèca

--- a/settings/country-names/de.yaml
+++ b/settings/country-names/de.yaml
@@ -99,7 +99,6 @@ name:
     na: Djermani
     ne: जर्मनी
     nl: Duitsland
-    nn: Tyskland
     "no": Tyskland
     nv: Béésh Bichʼahii Bikéyah
     oc: Alemanha

--- a/settings/country-names/dj.yaml
+++ b/settings/country-names/dj.yaml
@@ -74,7 +74,6 @@ name:
     na: Djibuti
     ne: जिबुटी
     nl: Djibouti
-    nn: Djibouti
     "no": Djibouti
     nv: Jibótii
     oc: Jiboti

--- a/settings/country-names/dk.yaml
+++ b/settings/country-names/dk.yaml
@@ -85,7 +85,6 @@ name:
     na: Denemark
     ne: डेनमार्क
     nl: Denemarken
-    nn: Danmark
     "no": Danmark
     nv: Déinish Dineʼé Bikéyah
     oc: Danemarc

--- a/settings/country-names/dm.yaml
+++ b/settings/country-names/dm.yaml
@@ -28,6 +28,7 @@ name:
     lv: Dominika
     mn: Доминика
     nl: Dominica
+    "no": Dominica
     pl: Dominika
     pt: Dominica
     ru: Доминика

--- a/settings/country-names/do.yaml
+++ b/settings/country-names/do.yaml
@@ -69,6 +69,7 @@ name:
     mt: Repubblika Dominikana
     my: ဒိုမီနီကန်သမ္မတနိုင်ငံ
     na: Ripubrikin Dominika
+    nb: Den dominikanske republikk
     ne: डोमिनिकन गणतन्त्र
     nl: Dominicaanse Republiek
     nn: Den dominikanske republikken

--- a/settings/country-names/dz.yaml
+++ b/settings/country-names/dz.yaml
@@ -93,7 +93,6 @@ name:
     na: Ardjiriya
     ne: अल्जेरिया
     nl: Algerije
-    nn: Algerie
     "no": Algerie
     nv: Aljííya
     ny: Algeria

--- a/settings/country-names/ec.yaml
+++ b/settings/country-names/ec.yaml
@@ -77,7 +77,6 @@ name:
     na: Ekwador
     ne: इक्वेडर
     nl: Ecuador
-    nn: Ecuador
     "no": Ecuador
     nv: Kéyah Nahasdzáán Ałníiʼgi Siʼánígíí
     oc: Eqüator

--- a/settings/country-names/ee.yaml
+++ b/settings/country-names/ee.yaml
@@ -85,7 +85,6 @@ name:
     na: Etoniya
     ne: इस्टोनिया
     nl: Estland
-    nn: Estland
     "no": Estland
     nv: Ééstii Bikéyah
     oc: Estònia

--- a/settings/country-names/eg.yaml
+++ b/settings/country-names/eg.yaml
@@ -97,7 +97,6 @@ name:
     na: Idjipt
     ne: मिश्र
     nl: Egypte
-    nn: Egypt
     "no": Egypt
     nv: Ííjip
     oc: Egipte

--- a/settings/country-names/eh.yaml
+++ b/settings/country-names/eh.yaml
@@ -10,7 +10,10 @@ name:
     fr: République arabe sahraouie démocratique
     it: Repubblica Araba Democratica dei Sahrawi
     lt: Sacharos Arabų Demokratinė Respublika
+    nb: Den saharawiske arabiske demokratiske republikk
     nl: Arabische Democratische Republiek Sahara
+    nn: Den saharawiske arabiske demokratiske republikken
+    "no": Den saharawiske arabiske demokratiske republikk
     pt: República Árabe Saaraui Democrática
     ru: Сахарская Арабская Демократическая Республика
     ur: صحراوی عرب عوامی جمہوریہ

--- a/settings/country-names/er.yaml
+++ b/settings/country-names/er.yaml
@@ -77,7 +77,6 @@ name:
     na: Eritrea
     ne: एरिट्रिया
     nl: Eritrea
-    nn: Eritrea
     "no": Eritrea
     oc: Eritrèa
     om: Eritrea

--- a/settings/country-names/es.yaml
+++ b/settings/country-names/es.yaml
@@ -88,10 +88,8 @@ name:
     mt: Spanja
     my: စပိန်နိုင်ငံ
     na: Pain
-    nb: Spania
     ne: स्पेन
     nl: Spanje
-    nn: Spania
     "no": Spania
     nv: Dibé Diníí Bikéyah
     oc: Espanha

--- a/settings/country-names/et.yaml
+++ b/settings/country-names/et.yaml
@@ -92,7 +92,6 @@ name:
     na: Itiyopiya
     ne: इथियोपिया
     nl: Ethiopië
-    nn: Etiopia
     "no": Etiopia
     nv: Iithiyópya
     oc: Etiopia

--- a/settings/country-names/fi.yaml
+++ b/settings/country-names/fi.yaml
@@ -92,7 +92,6 @@ name:
     na: Finland
     ne: फिनल्याण्ड
     nl: Finland
-    nn: Finland
     "no": Finland
     nv: Nahoditsʼǫʼłání
     oc: Finlàndia

--- a/settings/country-names/fj.yaml
+++ b/settings/country-names/fj.yaml
@@ -73,7 +73,6 @@ name:
     na: Bidji
     ne: फिजी
     nl: Fiji
-    nn: Fiji
     "no": Fiji
     nv: Fííjii
     oc: Fiji

--- a/settings/country-names/fk.yaml
+++ b/settings/country-names/fk.yaml
@@ -68,6 +68,7 @@ name:
     ms: Kepulauan Falkland (Islas Malvinas)
     mt: Falkland Islands
     my: ဖောက်ကလန် ကျွန်းစု
+    nb: Falklandsøyene
     ne: फक्ल्याण्ड टापुहरू (इज्लास माल्भिनास)
     nl: Falklandeilanden
     nn: Falklandsøyane

--- a/settings/country-names/fm.yaml
+++ b/settings/country-names/fm.yaml
@@ -31,7 +31,7 @@ name:
     lv: Mikronēzija
     mn: Микронези
     nl: Micronesia
-    "no": Mikronesia
+    "no": Mikronesiaføderasjonen
     oc: Estats Federats de Micronesia
     pl: Mikronezja
     ru: Федеративные Штаты Микронезии

--- a/settings/country-names/fo.yaml
+++ b/settings/country-names/fo.yaml
@@ -63,6 +63,7 @@ name:
     mr: फेरो द्वीपसमूह
     ms: Kepulauan Faroe
     mt: Gżejjer Faroe
+    nb: Færøyene
     ne: फरोइ टापु
     nl: Faeröer
     nn: Færøyane

--- a/settings/country-names/fr.yaml
+++ b/settings/country-names/fr.yaml
@@ -96,7 +96,6 @@ name:
     na: Prant
     ne: फ्रान्स
     nl: Frankrijk
-    nn: Frankrike
     "no": Frankrike
     nv: Dáághahii Dineʼé Bikéyah
     oc: França

--- a/settings/country-names/ga.yaml
+++ b/settings/country-names/ga.yaml
@@ -77,7 +77,6 @@ name:
     na: Gabun
     ne: गाबोन
     nl: Gabon
-    nn: Gabon
     "no": Gabon
     nv: Gabǫ́ǫ́
     oc: Gabon

--- a/settings/country-names/gb.yaml
+++ b/settings/country-names/gb.yaml
@@ -98,7 +98,6 @@ name:
     na: Ingerand
     ne: संयुक्त अधिराज्य
     nl: Verenigd Koninkrijk
-    nn: Storbritannia
     "no": Storbritannia
     nv: Tótaʼ Dineʼé Bikéyah
     oc: Reialme Unit

--- a/settings/country-names/gd.yaml
+++ b/settings/country-names/gd.yaml
@@ -27,6 +27,7 @@ name:
     lv: Grenāda
     mn: Гренада
     nl: Grenada
+    "no": Grenada
     pl: Granada
     pt: Granada
     ru: Гренада

--- a/settings/country-names/ge.yaml
+++ b/settings/country-names/ge.yaml
@@ -78,7 +78,6 @@ name:
     na: Djiordjiya
     ne: जर्जिया (देश)
     nl: Georgië
-    nn: Georgia
     "no": Georgia
     nv: Jóojah (Kéyah)
     oc: Georgia (Caucàs)

--- a/settings/country-names/gg.yaml
+++ b/settings/country-names/gg.yaml
@@ -55,7 +55,6 @@ name:
     ms: Guernsey
     ne: गुर्न्जी
     nl: Guernsey
-    nn: Guernsey
     "no": Guernsey
     oc: Guernesey
     os: Гернси

--- a/settings/country-names/gh.yaml
+++ b/settings/country-names/gh.yaml
@@ -83,7 +83,6 @@ name:
     na: Gana
     ne: घाना
     nl: Ghana
-    nn: Ghana
     "no": Ghana
     nv: Gáana
     oc: Ghana

--- a/settings/country-names/gi.yaml
+++ b/settings/country-names/gi.yaml
@@ -63,7 +63,6 @@ name:
     my: ဂျီဘရော်လ်တာ
     ne: गिब्राल्टार
     nl: Gibraltar
-    nn: Gibraltar
     "no": Gibraltar
     oc: Gibartar
     or: ଜିବ୍ରାଲେଟର

--- a/settings/country-names/gl.yaml
+++ b/settings/country-names/gl.yaml
@@ -72,7 +72,6 @@ name:
     my: ဂရင်းလန်ကျွန်း
     ne: ग्रीनल्याण्ड
     nl: Groenland
-    nn: Grønland
     "no": Grønland
     nv: Haʼaʼaahjí Hakʼaz Dineʼé Bikéyah
     oc: Groenlàndia

--- a/settings/country-names/gm.yaml
+++ b/settings/country-names/gm.yaml
@@ -75,10 +75,8 @@ name:
     mt: Gambja
     my: ဂမ်ဘီယာနိုင်ငံ
     na: Gambiya
-    nb: Gambia
     ne: गाम्बिया
     nl: Gambia
-    nn: Gambia
     "no": Gambia
     nv: Géémbiya
     oc: Gàmbia

--- a/settings/country-names/gn.yaml
+++ b/settings/country-names/gn.yaml
@@ -76,7 +76,6 @@ name:
     na: Gini
     ne: गिनी
     nl: Guinee
-    nn: Guinea
     "no": Guinea
     nv: Gíní
     oc: Guinèa

--- a/settings/country-names/gq.yaml
+++ b/settings/country-names/gq.yaml
@@ -87,10 +87,8 @@ name:
     mt: Gwinea Ekwatorjali
     my: အီကွေတာဂီနီနိုင်ငံ
     na: Gini t Ekwador
-    nb: Ekvatorial-Guinea
     ne: इक्वेटोरियल गिनी
     nl: Equatoriaal Guinee
-    nn: Ekvatorial-Guinea
     "no": Ekvatorial-Guinea
     nv: Gíní Nahasdzáán Ałníiʼgi Siʼánígíí
     oc: Guinèa Eqüatoriala

--- a/settings/country-names/gr.yaml
+++ b/settings/country-names/gr.yaml
@@ -88,7 +88,6 @@ name:
     na: Grit
     ne: ग्रीस
     nl: Griekenland
-    nn: Hellas
     "no": Hellas
     nv: Gwíík Dineʼé Bikéyah
     oc: Grècia

--- a/settings/country-names/gs.yaml
+++ b/settings/country-names/gs.yaml
@@ -39,6 +39,7 @@ name:
     mk: Јужна Џорџија и Јужни Сендвички Острови
     mr: साउथ जॉर्जिया व साउथ सँडविच द्वीपसमूह
     ms: Georgia Selatan dan Kepulauan Sandwich Selatan
+    nb: Sør-Georgia og Sør-Sandwichøyene
     nl: Zuid-Georgia en de Zuidelijke Sandwicheilanden
     nn: Sør-Georgia og Sør-Sandwichøyane
     "no": Sør-Georgia og Sør-Sandwichøyene

--- a/settings/country-names/gt.yaml
+++ b/settings/country-names/gt.yaml
@@ -77,7 +77,6 @@ name:
     na: Guatemara
     ne: ग्वाटेमाला
     nl: Guatemala
-    nn: Guatemala
     "no": Guatemala
     oc: Guatemala
     os: Гватемалæ

--- a/settings/country-names/gw.yaml
+++ b/settings/country-names/gw.yaml
@@ -76,7 +76,6 @@ name:
     na: Gini-Bitau
     ne: गिनी-बिसाउ
     nl: Guinee-Bissau
-    nn: Guinea-Bissau
     "no": Guinea-Bissau
     nv: Gíní Bisó
     oc: Guinèa Bissau

--- a/settings/country-names/gy.yaml
+++ b/settings/country-names/gy.yaml
@@ -77,7 +77,6 @@ name:
     na: Guyana
     ne: गुयना
     nl: Guyana
-    nn: Guyana
     "no": Guyana
     oc: Guyana
     or: ଗାଇଓନା

--- a/settings/country-names/hn.yaml
+++ b/settings/country-names/hn.yaml
@@ -75,7 +75,6 @@ name:
     na: Ondurat
     ne: होण्डुरस
     nl: Honduras
-    nn: Honduras
     "no": Honduras
     oc: Honduras
     or: ହୋଣ୍ଡାରୁସ

--- a/settings/country-names/hr.yaml
+++ b/settings/country-names/hr.yaml
@@ -81,7 +81,6 @@ name:
     na: Kroaitsiya
     ne: क्रोएशिया
     nl: Kroatië
-    nn: Kroatia
     "no": Kroatia
     nv: Kwóóʼad Bikéyah
     oc: Croàcia

--- a/settings/country-names/ht.yaml
+++ b/settings/country-names/ht.yaml
@@ -76,7 +76,6 @@ name:
     na: Aiti
     ne: हाइटी
     nl: Haïti
-    nn: Haiti
     "no": Haiti
     nv: Héítii
     oc: Haití (estat)

--- a/settings/country-names/hu.yaml
+++ b/settings/country-names/hu.yaml
@@ -86,8 +86,7 @@ name:
     na: Ungari
     ne: हंगेरी
     nl: Hongarije
-    nn: Ungarn
-    "no": Ungern
+    "no": Ungarn
     nv: Hángewii
     oc: Ongria
     or: ହଙ୍ଗେରୀ

--- a/settings/country-names/id.yaml
+++ b/settings/country-names/id.yaml
@@ -87,7 +87,6 @@ name:
     na: Indonitsiya
     ne: इण्डोनेशिया
     nl: Indonesië
-    nn: Indonesia
     "no": Indonesia
     nv: Indoníízha
     oc: Indonesia

--- a/settings/country-names/ie.yaml
+++ b/settings/country-names/ie.yaml
@@ -93,7 +93,6 @@ name:
     na: Ripubrikit Airerand
     ne: आइरल्याण्ड
     nl: Ierland
-    nn: Irland
     "no": Irland
     nv: Bitsiighaʼ Łichííʼí Bikéyah
     oc: Republica d'Irlanda

--- a/settings/country-names/il.yaml
+++ b/settings/country-names/il.yaml
@@ -86,7 +86,6 @@ name:
     na: Iteraer
     ne: इजरायल
     nl: Israël
-    nn: Israel
     "no": Israel
     nv: Ízrel Bikéyah
     oc: Israèl

--- a/settings/country-names/im.yaml
+++ b/settings/country-names/im.yaml
@@ -56,7 +56,6 @@ name:
     mr: आईल ऑफ मान
     ms: Isle of Man
     nl: Eiland Man
-    nn: Isle of Man
     "no": Man
     oc: Illa de Man
     os: Мэн

--- a/settings/country-names/in.yaml
+++ b/settings/country-names/in.yaml
@@ -26,6 +26,7 @@ name:
     lt: Indija
     lv: Indija
     mn: Энэтхэг
+    "no": India
     pl: Indie
     ru: Индия
     sl: Indija

--- a/settings/country-names/io.yaml
+++ b/settings/country-names/io.yaml
@@ -67,7 +67,6 @@ name:
     my: ဗြိတိသျှ အိန္ဒြိယ သမုဒ္ဒရာ ပိုင်နက်
     ne: बेलायती हिन्द महासागर क्षेत्र
     nl: Brits Territorium in de Indische Oceaan
-    nn: Britiske område i Det indiske hav
     "no": Det britiske territoriet i Indiahavet
     or: ବ୍ରିଟିଶ୍ ଭାରତୀୟ ସାମୁଦ୍ରିକ କ୍ଷେତ୍ର
     pl: Brytyjskie Terytorium Oceanu Indyjskiego

--- a/settings/country-names/iq.yaml
+++ b/settings/country-names/iq.yaml
@@ -76,10 +76,8 @@ name:
     mt: Iraq
     my: အီရတ်နိုင်ငံ
     na: Irak
-    nb: Irak
     ne: ईराक
     nl: Irak
-    nn: Irak
     "no": Irak
     nv: Iiwááʼ
     oc: Iraq

--- a/settings/country-names/ir.yaml
+++ b/settings/country-names/ir.yaml
@@ -82,7 +82,6 @@ name:
     na: Iran
     ne: इरान
     nl: Iran
-    nn: Iran
     "no": Iran
     nv: Iiwą́ą́
     oc: Iran

--- a/settings/country-names/is.yaml
+++ b/settings/country-names/is.yaml
@@ -86,10 +86,8 @@ name:
     mt: Iżlanda
     my: အိုက်စလန်နိုင်ငံ
     na: Aiterand
-    nb: Island
     ne: आइसल्याण्ड
     nl: IJsland
-    nn: Island
     "no": Island
     nv: Tin Bikéyah
     oc: Islàndia

--- a/settings/country-names/it.yaml
+++ b/settings/country-names/it.yaml
@@ -93,7 +93,6 @@ name:
     na: Itari
     ne: इटाली
     nl: Italië
-    nn: Italia
     "no": Italia
     nv: Ídelii
     oc: Itàlia

--- a/settings/country-names/je.yaml
+++ b/settings/country-names/je.yaml
@@ -51,7 +51,6 @@ name:
     ms: Jersey
     ne: जर्सी
     nl: Jersey
-    nn: Jersey
     "no": Jersey
     oc: Jersei
     os: Джерси

--- a/settings/country-names/jm.yaml
+++ b/settings/country-names/jm.yaml
@@ -30,6 +30,7 @@ name:
     lv: Jamaika
     mn: Ямайка
     nl: Jamaica
+    "no": Jamaica
     oc: Jamaica
     pl: Jamajka
     pt: Jamaica

--- a/settings/country-names/jo.yaml
+++ b/settings/country-names/jo.yaml
@@ -75,7 +75,6 @@ name:
     my: ဂျော်ဒန်နိုင်ငံ
     na: Djordan
     nl: Jordanië
-    nn: Jordan
     "no": Jordan
     nv: Jóoʼdan
     oc: Jordania

--- a/settings/country-names/jp.yaml
+++ b/settings/country-names/jp.yaml
@@ -92,7 +92,6 @@ name:
     na: Djapan
     ne: जापान
     nl: Japan
-    nn: Japan
     "no": Japan
     nv: Binaʼadaałtzózí Dinéʼiʼ Bikéyah
     oc: Japon

--- a/settings/country-names/ke.yaml
+++ b/settings/country-names/ke.yaml
@@ -81,7 +81,6 @@ name:
     my: ကင်ညာနိုင်ငံ
     na: Keniya
     nl: Kenia
-    nn: Kenya
     "no": Kenya
     nv: Kénya
     oc: Kenya

--- a/settings/country-names/kg.yaml
+++ b/settings/country-names/kg.yaml
@@ -75,7 +75,6 @@ name:
     my: ကာဂျစ္စတန်နိုင်ငံ
     na: Kirgitan
     nl: Kirgizië
-    nn: Kirgisistan
     "no": Kirgisistan
     nv: Kíígiz Bikéyah
     oc: Quirguizstan

--- a/settings/country-names/kh.yaml
+++ b/settings/country-names/kh.yaml
@@ -79,7 +79,6 @@ name:
     my: ကမ္ဘောဒီးယားနိုင်ငံ
     na: Kambodja
     nl: Cambodja
-    nn: Kambodsja
     "no": Kambodsja
     oc: Cambòtja
     or: କମ୍ବୋଡ଼ିଆ

--- a/settings/country-names/ki.yaml
+++ b/settings/country-names/ki.yaml
@@ -19,6 +19,7 @@ name:
     lt: Kiribatis
     lv: Kiribati
     mn: Кирибати
+    "no": Kiribati
     pl: Kiribati
     ru: Кирибати
     sv: Kiribati

--- a/settings/country-names/km.yaml
+++ b/settings/country-names/km.yaml
@@ -35,7 +35,10 @@ name:
     lv: Komoru salas
     mk: Комори
     mn: Коморын арлууд
+    nb: Komorene
     nl: Comoren
+    nn: Komorane
+    "no": Komorene
     pl: Komory
     ps: قمرټاپوګان
     pt: Comores

--- a/settings/country-names/kn.yaml
+++ b/settings/country-names/kn.yaml
@@ -34,6 +34,7 @@ name:
     mk: Свети Кристифер и Невис
     mn: Сент-Киттс ба Невис
     nl: Saint Kitts en Nevis
+    "no": Saint Kitts og Nevis
     pl: Saint Kitts i Nevis
     pt: São Cristóvão e Nevis
     ru: Сент-Китс и Невис

--- a/settings/country-names/kp.yaml
+++ b/settings/country-names/kp.yaml
@@ -87,7 +87,6 @@ name:
     na: Ripubrikit Engame Korea
     ne: उत्तर कोरिया
     nl: Noord-Korea
-    nn: Nord-Korea
     "no": Nord-Korea
     nv: Kolíya Bikéyah Náhookǫsjí Siʼánígíí
     oc: Corèa del Nòrd

--- a/settings/country-names/kr.yaml
+++ b/settings/country-names/kr.yaml
@@ -86,7 +86,6 @@ name:
     na: Ripubrikin Korea
     ne: दक्षिण कोरिया
     nl: Zuid-Korea
-    nn: Sør-Korea
     "no": Sør-Korea
     nv: Kolíya Bikéyah Shádiʼááhjí Siʼánígíí
     oc: Corèa del Sud

--- a/settings/country-names/kw.yaml
+++ b/settings/country-names/kw.yaml
@@ -75,7 +75,6 @@ name:
     na: Kuwait
     ne: कुवेत
     nl: Koeweit
-    nn: Kuwait
     "no": Kuwait
     nv: Kóóweiʼ
     oc: Kowait

--- a/settings/country-names/ky.yaml
+++ b/settings/country-names/ky.yaml
@@ -67,6 +67,7 @@ name:
     mr: केमन बेटे
     mt: Gżejjer Kajmani
     my: ကေမန် ကျွန်းစု
+    nb: Caymanøyene
     ne: केयमान टापु
     nl: Kaaimaneilanden
     nn: Caymanøyane

--- a/settings/country-names/kz.yaml
+++ b/settings/country-names/kz.yaml
@@ -84,7 +84,6 @@ name:
     my: ကာဇက်စတန်နိုင်ငံ
     na: Kadaketan
     nl: Kazachstan
-    nn: Kasakhstan
     "no": Kasakhstan
     nv: Kʼazah Bikéyah
     oc: Cazacstan

--- a/settings/country-names/la.yaml
+++ b/settings/country-names/la.yaml
@@ -76,7 +76,6 @@ name:
     my: လာအိုနိုင်ငံ
     na: Raot
     nl: Laos
-    nn: Laos
     "no": Laos
     nv: Lááʼos
     oc: Laos

--- a/settings/country-names/lb.yaml
+++ b/settings/country-names/lb.yaml
@@ -76,9 +76,7 @@ name:
     mt: Libanu
     my: လက်ဘနွန်နိုင်ငံ
     na: Ribanon
-    nb: Libanon
     nl: Libanon
-    nn: Libanon
     "no": Libanon
     nv: Łíbanoo
     oc: Liban

--- a/settings/country-names/lc.yaml
+++ b/settings/country-names/lc.yaml
@@ -29,6 +29,7 @@ name:
     lv: Sentlūsija
     mn: Сент Люсиа
     nl: Saint Lucia
+    "no": Saint Lucia
     pl: Saint Lucia
     pt: Santa Lúcia
     ru: Сент-Люсия

--- a/settings/country-names/li.yaml
+++ b/settings/country-names/li.yaml
@@ -31,6 +31,7 @@ name:
     mk: Лихтенштајн
     mn: Лихтенштейн
     nl: Liechtenstein
+    "no": Liechtenstein
     pl: Liechtenstein
     ru: Лихтенштейн
     se: Liechtenstein

--- a/settings/country-names/lk.yaml
+++ b/settings/country-names/lk.yaml
@@ -77,7 +77,6 @@ name:
     na: Sri Lanka
     ne: श्रीलंका
     nl: Sri Lanka
-    nn: Sri Lanka
     "no": Sri Lanka
     nv: Swii Lankʼa
     oc: Sri Lanka

--- a/settings/country-names/lr.yaml
+++ b/settings/country-names/lr.yaml
@@ -74,7 +74,6 @@ name:
     mt: Liberja
     my: လိုက်ဘေးရီးယားနိုင်ငံ
     nl: Liberia
-    nn: Liberia
     "no": Liberia
     oc: Libèria
     or: ଲାଇବେରିଆ

--- a/settings/country-names/ls.yaml
+++ b/settings/country-names/ls.yaml
@@ -74,7 +74,6 @@ name:
     my: လီဆိုသိုနိုင်ငံ
     na: Resoto
     nl: Lesotho
-    nn: Lesotho
     "no": Lesotho
     nv: Sotho Dineʼé Bikéyah
     oc: Lesotho

--- a/settings/country-names/lt.yaml
+++ b/settings/country-names/lt.yaml
@@ -92,7 +92,6 @@ name:
     na: Rituainiya
     ne: लिथुआनिया
     nl: Litouwen
-    nn: Litauen
     "no": Litauen
     nv: Łitʼoowę́ęya
     ny: Lithuania

--- a/settings/country-names/lu.yaml
+++ b/settings/country-names/lu.yaml
@@ -81,7 +81,6 @@ name:
     na: Ruketemburg
     ne: लक्जेम्बर्ग
     nl: Luxemburg
-    nn: Luxembourg
     "no": Luxembourg
     nv: Látsębooʼ
     oc: Luxemborg

--- a/settings/country-names/lv.yaml
+++ b/settings/country-names/lv.yaml
@@ -94,7 +94,6 @@ name:
     na: Ratebiya
     ne: लात्भिया
     nl: Letland
-    nn: Latvia
     "no": Latvia
     nv: Létbiiya
     oc: Letònia

--- a/settings/country-names/ly.yaml
+++ b/settings/country-names/ly.yaml
@@ -80,7 +80,6 @@ name:
     my: လစ်ဗျားနိုင်ငံ
     ne: लिबिया
     nl: Libië
-    nn: Libya
     "no": Libya
     nv: Łíbya
     oc: Libia

--- a/settings/country-names/ma.yaml
+++ b/settings/country-names/ma.yaml
@@ -75,7 +75,6 @@ name:
     mt: Marokk
     my: မော်ရိုကိုနိုင်ငံ
     nl: Marokko
-    nn: Marokko
     "no": Marokko
     nv: Moroko
     oc: Marròc

--- a/settings/country-names/mc.yaml
+++ b/settings/country-names/mc.yaml
@@ -90,7 +90,6 @@ name:
     na: Monako
     ne: मोनाको
     nl: Monaco
-    nn: Monaco
     "no": Monaco
     oc: Mónegue
     or: ମୋନାକୋ

--- a/settings/country-names/md.yaml
+++ b/settings/country-names/md.yaml
@@ -82,7 +82,6 @@ name:
     na: Mordowa
     ne: मोल्दोवा
     nl: Moldavië
-    nn: Moldova
     "no": Moldova
     oc: Moldàvia
     or: ମାଲଡୋଭା

--- a/settings/country-names/me.yaml
+++ b/settings/country-names/me.yaml
@@ -80,7 +80,6 @@ name:
     na: Montenegro
     ne: मोन्टेनेग्रो
     nl: Montenegro
-    nn: Montenegro
     "no": Montenegro
     nv: Dziłizhin Bikéyah
     oc: Montenegro

--- a/settings/country-names/mg.yaml
+++ b/settings/country-names/mg.yaml
@@ -80,7 +80,6 @@ name:
     mt: Madagaskar
     my: မဒါဂတ်စကားနိုင်ငံ
     nl: Madagaskar
-    nn: Madagaskar
     "no": Madagaskar
     nv: Madaʼgéésgáá
     oc: Madagascar

--- a/settings/country-names/mh.yaml
+++ b/settings/country-names/mh.yaml
@@ -33,7 +33,10 @@ name:
     lv: Māršala salas
     mk: Маршалски Острови
     mn: Маршаллын арлууд
+    nb: Marshalløyene
     nl: Marshalleilanden
+    nn: Marshalløyane
+    "no": Marshalløyene
     oc: Illas Marshall
     pl: Wyspy Marshalla
     pt: Ilhas Marshall

--- a/settings/country-names/mk.yaml
+++ b/settings/country-names/mk.yaml
@@ -91,7 +91,6 @@ name:
     na: Matedoniya
     ne: म्यासेडोनिया
     nl: Noord-Macedonië
-    nn: Nord-Makedonia
     "no": Nord-Makedonia
     oc: Republica de Macedònia
     or: ମାସିଡୋନିଆ

--- a/settings/country-names/ml.yaml
+++ b/settings/country-names/ml.yaml
@@ -75,7 +75,6 @@ name:
     mt: Mali
     my: မာလီနိုင်ငံ
     nl: Mali
-    nn: Mali
     "no": Mali
     oc: Mali
     or: ମାଲି

--- a/settings/country-names/mm.yaml
+++ b/settings/country-names/mm.yaml
@@ -80,7 +80,6 @@ name:
     na: Miyanmar
     ne: म्यानमार
     nl: Myanmar
-    nn: Myanmar
     "no": Myanmar
     oc: Birmania
     or: ବର୍ମା

--- a/settings/country-names/mn.yaml
+++ b/settings/country-names/mn.yaml
@@ -82,7 +82,6 @@ name:
     na: Mongoriya
     ne: मङ्गोलिया
     nl: Mongolië
-    nn: Mongolia
     "no": Mongolia
     nv: Chʼah Diʼilii Bikéyah
     oc: Mongolia

--- a/settings/country-names/mr.yaml
+++ b/settings/country-names/mr.yaml
@@ -75,7 +75,6 @@ name:
     mt: Mawritanja
     my: မော်ရီတေးနီးယားနိုင်ငံ
     nl: Mauritanië
-    nn: Mauritania
     "no": Mauritania
     nv: Moowitéínya
     oc: Mauritània

--- a/settings/country-names/ms.yaml
+++ b/settings/country-names/ms.yaml
@@ -51,7 +51,6 @@ name:
     mr: माँटसेराट
     ms: Montserrat
     nl: Montserrat
-    nn: Montserrat
     "no": Montserrat
     oc: Montserrat
     pa: ਮਾਂਟਸਰਾਤ

--- a/settings/country-names/mu.yaml
+++ b/settings/country-names/mu.yaml
@@ -60,6 +60,7 @@ name:
     my: မောရစ်ရှနိုင်ငံ
     ne: मौरिसस
     nl: Mauritius
+    "no": Mauritius
     oc: Maurici
     or: ମରିସସ
     os: Маврикий

--- a/settings/country-names/mv.yaml
+++ b/settings/country-names/mv.yaml
@@ -66,6 +66,7 @@ name:
     mr: मालदीव्ज
     ms: Maldiv
     my: မော်လဒိုက်
+    nb: Maldivene
     ne: माल्दिभ्स
     nl: Malediven
     nn: Maldivane

--- a/settings/country-names/mw.yaml
+++ b/settings/country-names/mw.yaml
@@ -75,7 +75,6 @@ name:
     mt: Malawi
     my: မာလဝီနိုင်ငံ
     nl: Malawi
-    nn: Malawi
     "no": Malawi
     nv: Malááwii
     ny: Malaŵi

--- a/settings/country-names/mx.yaml
+++ b/settings/country-names/mx.yaml
@@ -86,7 +86,6 @@ name:
     na: Meketiko
     ne: मेक्सिको
     nl: Mexico
-    nn: Mexico
     "no": Mexico
     nv: Méhigo
     oc: Mexic

--- a/settings/country-names/my.yaml
+++ b/settings/country-names/my.yaml
@@ -78,7 +78,6 @@ name:
     na: Maraidja
     ne: मलेशिया
     nl: Maleisië
-    nn: Malaysia
     "no": Malaysia
     nv: Maléízha
     oc: Malàisia

--- a/settings/country-names/mz.yaml
+++ b/settings/country-names/mz.yaml
@@ -75,7 +75,6 @@ name:
     mt: Możambik
     my: မိုဇမ်ဘစ်နိုင်ငံ
     nl: Mozambique
-    nn: Mosambik
     "no": Mosambik
     ny: Mozambique
     oc: Moçambic

--- a/settings/country-names/na.yaml
+++ b/settings/country-names/na.yaml
@@ -73,7 +73,6 @@ name:
     mt: Namibja
     my: နမီးဘီးယားနိုင်ငံ
     nl: Namibië
-    nn: Namibia
     "no": Namibia
     nv: Namííbya
     oc: Namibia

--- a/settings/country-names/ne.yaml
+++ b/settings/country-names/ne.yaml
@@ -74,7 +74,6 @@ name:
     mt: Niġer
     my: နိုင်ဂျာနိုင်ငံ
     nl: Niger
-    nn: Niger
     "no": Niger
     oc: Nigèr
     or: ନାଇଜର

--- a/settings/country-names/ng.yaml
+++ b/settings/country-names/ng.yaml
@@ -82,7 +82,6 @@ name:
     my: နိုင်ဂျီးရီးယားနိုင်ငံ
     ne: नाइजेरिया
     nl: Nigeria
-    nn: Nigeria
     "no": Nigeria
     oc: Nigèria
     or: ନାଇଜେରିଆ

--- a/settings/country-names/ni.yaml
+++ b/settings/country-names/ni.yaml
@@ -75,7 +75,6 @@ name:
     my: နီကာရာဂွါနိုင်ငံ
     ne: निकाराग्वा
     nl: Nicaragua
-    nn: Nicaragua
     "no": Nicaragua
     oc: Nicaragua
     or: ନିକାରାଗୁଆ

--- a/settings/country-names/nl.yaml
+++ b/settings/country-names/nl.yaml
@@ -87,7 +87,6 @@ name:
     na: Eben Eyong
     ne: नेदरल्याण्ड्स
     nl: Nederland
-    nn: Nederland
     "no": Nederland
     nv: Tsin Bikeeʼ Dineʼé Bikéyah
     oc: Païses Basses

--- a/settings/country-names/np.yaml
+++ b/settings/country-names/np.yaml
@@ -21,6 +21,7 @@ name:
     lv: Nepāla
     mn: Балба
     ne: नेपाल
+    "no": Nepal
     pl: Nepal
     ru: Непал
     sv: Nepal

--- a/settings/country-names/nr.yaml
+++ b/settings/country-names/nr.yaml
@@ -29,6 +29,7 @@ name:
     ml: നൗറു
     mn: Науру
     mt: Nawru
+    "no": Nauru
     pl: Nauru
     ru: Науру
     se: Nauru

--- a/settings/country-names/nu.yaml
+++ b/settings/country-names/nu.yaml
@@ -32,6 +32,7 @@ name:
     ml: നിയുവെ
     mn: Ниуэ
     mr: न्युए
+    "no": Niue
     os: Ниуэ
     pl: Niue
     ru: Ниуэ

--- a/settings/country-names/nz.yaml
+++ b/settings/country-names/nz.yaml
@@ -77,7 +77,6 @@ name:
     na: Niu Djiran
     ne: न्यू जील्याण्ड
     nl: Nieuw-Zeeland
-    nn: New Zealand
     "no": New Zealand
     oc: Nòva Zelanda
     or: ନିଉଜିଲ୍ୟାଣ୍ଡ

--- a/settings/country-names/om.yaml
+++ b/settings/country-names/om.yaml
@@ -73,7 +73,6 @@ name:
     my: အိုမန်နိုင်ငံ
     na: Oman
     nl: Oman
-    nn: Oman
     "no": Oman
     nv: Omą́ą́
     oc: Oman

--- a/settings/country-names/pa.yaml
+++ b/settings/country-names/pa.yaml
@@ -78,7 +78,6 @@ name:
     my: ပနားမားနိုင်ငံ
     ne: पानामा
     nl: Panama
-    nn: Panama
     "no": Panama
     oc: Panamà
     or: ପାନାମା

--- a/settings/country-names/pe.yaml
+++ b/settings/country-names/pe.yaml
@@ -88,7 +88,6 @@ name:
     na: Peru
     ne: पेरू
     nl: Peru
-    nn: Peru
     "no": Peru
     oc: Peró
     or: ପେରୁ

--- a/settings/country-names/pg.yaml
+++ b/settings/country-names/pg.yaml
@@ -70,7 +70,6 @@ name:
     my: ပါပူအာနယူးဂီနီနိုင်ငံ
     na: Papua New Guinea
     nl: Papoea-Nieuw-Guinea
-    nn: Papua Ny-Guinea
     "no": Papua Ny-Guinea
     nv: Páápowa Bigíní Ániidí
     oc: Papoa-Nòva Guinèa

--- a/settings/country-names/ph.yaml
+++ b/settings/country-names/ph.yaml
@@ -73,6 +73,7 @@ name:
     ms: Filipina
     my: ဖိလစ်ပိုင်နိုင်ငံ
     na: Eben Piripin
+    nb: Filippinene
     ne: फिलिपिन्स
     nl: Filipijnen
     nn: Filippinane

--- a/settings/country-names/pk.yaml
+++ b/settings/country-names/pk.yaml
@@ -82,10 +82,8 @@ name:
     mt: Pakistan
     my: ပါကစ္စတန်နိုင်ငံ
     na: Pakistan
-    nb: Pakistan
     ne: पाकिस्तान
     nl: Pakistan
-    nn: Pakistan
     "no": Pakistan
     nv: Eʼeʼaahjí Naakaii Dootłʼizhí Bikéyah
     oc: Paquistan

--- a/settings/country-names/pl.yaml
+++ b/settings/country-names/pl.yaml
@@ -92,7 +92,6 @@ name:
     na: Poran
     ne: पोल्याण्ड
     nl: Polen
-    nn: Polen
     "no": Polen
     nv: Póolish Dineʼé Bikéyah
     oc: Polonha

--- a/settings/country-names/pn.yaml
+++ b/settings/country-names/pn.yaml
@@ -30,7 +30,10 @@ name:
     mi: Pitikeina
     mk: Питкерн
     mn: Питкэрн Арлууд
+    nb: Pitcairnøyene
     nl: Pitcairneilanden
+    nn: Pitcairn
+    "no": Pitcairnøyene
     pl: Wyspy Pitcairn
     ru: Острова Питкэрн
     sl: Pitcairnovi otoki

--- a/settings/country-names/ps.yaml
+++ b/settings/country-names/ps.yaml
@@ -1,2 +1,3 @@
 name: 
     default: Palestinian Territory
+    "no": Det palestinske området

--- a/settings/country-names/pt.yaml
+++ b/settings/country-names/pt.yaml
@@ -86,7 +86,6 @@ name:
     na: Portsiugar
     ne: पोर्चुगल
     nl: Portugal
-    nn: Portugal
     "no": Portugal
     oc: Portugal
     or: ପର୍ତ୍ତୁଗାଲ

--- a/settings/country-names/pw.yaml
+++ b/settings/country-names/pw.yaml
@@ -11,6 +11,7 @@ name:
     io: Palau
     lt: Palau
     mi: Pārau
+    "no": Palau
     oc: Belau
     pl: Palau
     ru: Палау

--- a/settings/country-names/py.yaml
+++ b/settings/country-names/py.yaml
@@ -76,7 +76,6 @@ name:
     my: ပါရာဂွေးနိုင်ငံ
     ne: पाराग्वे
     nl: Paraguay
-    nn: Paraguay
     "no": Paraguay
     oc: Paraguai
     or: ପାରାଗୁଏ

--- a/settings/country-names/qa.yaml
+++ b/settings/country-names/qa.yaml
@@ -75,7 +75,6 @@ name:
     my: ကာတာနိုင်ငံ
     na: Qatar
     nl: Qatar
-    nn: Qatar
     "no": Qatar
     nv: Kʼatár
     oc: Qatar

--- a/settings/country-names/ro.yaml
+++ b/settings/country-names/ro.yaml
@@ -83,7 +83,6 @@ name:
     na: Romania
     ne: रोमानिया
     nl: Roemenië
-    nn: Romania
     "no": Romania
     nv: Wooméiniya
     oc: Romania

--- a/settings/country-names/rs.yaml
+++ b/settings/country-names/rs.yaml
@@ -80,10 +80,8 @@ name:
     mt: Serbja
     my: ဆားဘီးယားနိုင်ငံ
     na: Terbiya
-    nb: Serbia
     ne: सर्बिया
     nl: Servië
-    nn: Serbia
     "no": Serbia
     oc: Serbia
     or: ସର୍ବିଆ

--- a/settings/country-names/ru.yaml
+++ b/settings/country-names/ru.yaml
@@ -102,7 +102,6 @@ name:
     na: Ratsiya
     ne: रुस
     nl: Rusland
-    nn: Russland
     "no": Russland
     nv: Biʼééʼ Łichííʼí Bikéyah
     ny: Russia

--- a/settings/country-names/rw.yaml
+++ b/settings/country-names/rw.yaml
@@ -74,7 +74,6 @@ name:
     my: ရဝမ်ဒါနိုင်ငံ
     ne: रुवाण्डा
     nl: Rwanda
-    nn: Rwanda
     "no": Rwanda
     nv: Wánda Dineʼé Bikéyah
     oc: Rwanda

--- a/settings/country-names/sa.yaml
+++ b/settings/country-names/sa.yaml
@@ -80,7 +80,6 @@ name:
     na: Taudiarabiya
     ne: साउदी अरब
     nl: Saoedi-Arabië
-    nn: Saudi-Arabia
     "no": Saudi-Arabia
     nv: Ásáí Bikéyah Saʼoodí
     oc: Arabia Saudita

--- a/settings/country-names/sb.yaml
+++ b/settings/country-names/sb.yaml
@@ -63,6 +63,7 @@ name:
     ms: Kepulauan Solomon
     mt: Gżejjer Solomon
     my: ဆော်လမွန်အိုင်းလန်းနိုင်ငံ
+    nb: Salomonøyene
     ne: सोलोमन द्धीप
     nl: Salomonseilanden
     nn: Salomonøyane

--- a/settings/country-names/sc.yaml
+++ b/settings/country-names/sc.yaml
@@ -69,6 +69,7 @@ name:
     ms: Seychelles
     mt: Seychelles
     my: ဆေးရှဲနိုင်ငံ
+    nb: Seychellene
     nl: Seychellen
     nn: Seychellane
     "no": Seychellene

--- a/settings/country-names/sd.yaml
+++ b/settings/country-names/sd.yaml
@@ -81,7 +81,6 @@ name:
     my: ဆူဒန်နိုင်ငံ
     na: Tudan
     nl: Soedan
-    nn: Sudan
     "no": Sudan
     nv: Soodą́ą
     ny: Sudan

--- a/settings/country-names/se.yaml
+++ b/settings/country-names/se.yaml
@@ -91,7 +91,6 @@ name:
     na: Widen
     ne: स्वीडेन
     nl: Zweden
-    nn: Sverige
     "no": Sverige
     oc: Suècia
     or: ସ୍ଵିଡେନ

--- a/settings/country-names/sg.yaml
+++ b/settings/country-names/sg.yaml
@@ -82,7 +82,6 @@ name:
     na: Tsingapoar
     ne: सिंगापुर
     nl: Singapore
-    nn: Singapore
     "no": Singapore
     nv: Sį́ʼgaboo
     oc: Singapor

--- a/settings/country-names/sh.yaml
+++ b/settings/country-names/sh.yaml
@@ -15,6 +15,7 @@ name:
     lt: Šventoji Elena, Dangun Žengimo ir Tristanas da Kunja
     mk: Света Елена, Успение и Тристан да Куња
     nl: Sint-Helena, Ascension en Tristan da Cunha
+    "no": Sankt Helena, Ascension og Tristan da Cunha
     pt: Santa Helena, Ascensão e Tristão da Cunha
     ru: Острова Святой Елены, Вознесения и Тристан-да-Кунья
     sk: Svätá Helena, Ascension a Tristan da Cunha

--- a/settings/country-names/si.yaml
+++ b/settings/country-names/si.yaml
@@ -80,7 +80,6 @@ name:
     na: Tsirobeniya
     ne: स्लोभेनिया
     nl: Slovenië
-    nn: Slovenia
     "no": Slovenia
     nv: Słobíín Bikéyah
     oc: Eslovènia

--- a/settings/country-names/sk.yaml
+++ b/settings/country-names/sk.yaml
@@ -81,7 +81,6 @@ name:
     na: Slowakia
     ne: स्लोभाकिया
     nl: Slowakije
-    nn: Slovakia
     "no": Slovakia
     nv: Słóbaʼ Bikéyah
     oc: Eslovaquia

--- a/settings/country-names/sl.yaml
+++ b/settings/country-names/sl.yaml
@@ -73,7 +73,6 @@ name:
     mt: Sierra Leone
     my: ဆီရာလီယွန်နိုင်ငံ
     nl: Sierra Leone
-    nn: Sierra Leone
     "no": Sierra Leone
     nv: Náshdóítsoh Bitsiijįʼ Daditłʼooʼígíí Bidził
     oc: Sierra Leone

--- a/settings/country-names/sm.yaml
+++ b/settings/country-names/sm.yaml
@@ -27,6 +27,7 @@ name:
     mi: Hato Marino
     mn: Сан-Марино
     nl: San Marino
+    "no": San Marino
     pl: San Marino
     pt: San Marino
     ru: Сан-Марино

--- a/settings/country-names/sn.yaml
+++ b/settings/country-names/sn.yaml
@@ -77,7 +77,6 @@ name:
     my: ဆီနီဂေါနိုင်ငံ
     na: Senegal
     nl: Senegal
-    nn: Senegal
     "no": Senegal
     oc: Senegal
     or: ସେନେଗାଲ

--- a/settings/country-names/so.yaml
+++ b/settings/country-names/so.yaml
@@ -74,7 +74,6 @@ name:
     my: ဆိုမာလီယာနိုင်ငံ
     na: Tomariya
     nl: Somalië
-    nn: Somalia
     "no": Somalia
     nv: Soomáálii Bikéyah
     oc: Somalia

--- a/settings/country-names/sr.yaml
+++ b/settings/country-names/sr.yaml
@@ -74,7 +74,6 @@ name:
     mt: Surinam
     my: ဆူရာနမ်နိုင်ငံ
     nl: Suriname
-    nn: Surinam
     "no": Surinam
     nv: Sówinam
     oc: Surinam

--- a/settings/country-names/ss.yaml
+++ b/settings/country-names/ss.yaml
@@ -64,7 +64,6 @@ name:
     my: တောင်ဆူဒန်နိုင်ငံ
     na: South Sudan
     nl: Zuid-Soedan
-    nn: Sør-Sudan
     "no": Sør-Sudan
     nv: Shádiʼááhjí Soodą́ą
     oc: Sodan del Sud

--- a/settings/country-names/st.yaml
+++ b/settings/country-names/st.yaml
@@ -31,6 +31,7 @@ name:
     lt: Sao Tomė ir Prinsipė
     mn: Сан-Томе ба Принсипи
     nl: Sao Tomé en Principe
+    "no": São Tomé og Príncipe
     pl: Wyspy Świętego Tomasza i Książęca
     pt: São Tomé e Príncipe
     ru: Сан-Томе и Принсипи

--- a/settings/country-names/sv.yaml
+++ b/settings/country-names/sv.yaml
@@ -74,7 +74,6 @@ name:
     na: Ersarbador
     ne: एल साल्भादोर
     nl: El Salvador
-    nn: El Salvador
     "no": El Salvador
     oc: Lo Salvador
     or: ଏଲ ସାଲଭାଡୋର

--- a/settings/country-names/sy.yaml
+++ b/settings/country-names/sy.yaml
@@ -80,7 +80,6 @@ name:
     na: Syria
     ne: सीरिया
     nl: Syrië
-    nn: Syria
     "no": Syria
     nv: Sííwiya
     oc: Siria

--- a/settings/country-names/sz.yaml
+++ b/settings/country-names/sz.yaml
@@ -84,7 +84,6 @@ name:
     my: ဆွာဇီလန်နိုင်ငံ
     ne: स्वाजिल्याण्ड
     nl: Swaziland
-    nn: Eswatini
     "no": Eswatini
     nv: Swáazi Dineʼé Bikéyah
     oc: Swaziland

--- a/settings/country-names/tc.yaml
+++ b/settings/country-names/tc.yaml
@@ -44,6 +44,7 @@ name:
     mn: Туркс ба Кайкосын Арлууд
     mr: टर्क्स आणि कैकास द्वीपसमूह
     ms: Kepulauan Turks dan Caicos
+    nb: Turks- og Caicosøyene
     nl: Turks- en Caicoseilanden
     nn: Turks- og Caicosøyane
     "no": Turks- og Caicosøyene

--- a/settings/country-names/td.yaml
+++ b/settings/country-names/td.yaml
@@ -76,7 +76,6 @@ name:
     my: ချဒ်သမ္မတနိုင်ငံ
     na: Tsiad
     nl: Tsjaad
-    nn: Tsjad
     "no": Tsjad
     oc: Chad
     or: ଚାଡ

--- a/settings/country-names/tg.yaml
+++ b/settings/country-names/tg.yaml
@@ -75,7 +75,6 @@ name:
     my: တိုဂိုနိုင်ငံ
     na: Togo
     nl: Togo
-    nn: Togo
     "no": Togo
     nv: Tʼóogo
     oc: Tògo

--- a/settings/country-names/th.yaml
+++ b/settings/country-names/th.yaml
@@ -81,7 +81,6 @@ name:
     na: Thailand
     ne: थाइल्याण्ड
     nl: Thailand
-    nn: Thailand
     "no": Thailand
     nv: Tʼáí Bikéyah
     oc: Tailàndia

--- a/settings/country-names/tj.yaml
+++ b/settings/country-names/tj.yaml
@@ -76,7 +76,6 @@ name:
     my: တာဂျစ်ကစ္စတန်နိုင်ငံ
     na: Tadjikitan
     nl: Tadzjikistan
-    nn: Tadsjikistan
     "no": Tadsjikistan
     nv: Tʼajiʼ Bikéyah
     oc: Tatgiquistan

--- a/settings/country-names/tl.yaml
+++ b/settings/country-names/tl.yaml
@@ -30,7 +30,9 @@ name:
     lt: Rytų Timoras
     mn: Зүүн Тимор
     ms: Timor Timur
+    nb: Øst-Timor
     nl: Oost-Timor
+    nn: Aust-Timor
     "no": Øst-Timor
     pl: Timor Wschodni
     pt: Timor-Leste

--- a/settings/country-names/tm.yaml
+++ b/settings/country-names/tm.yaml
@@ -75,7 +75,6 @@ name:
     na: Turkmenistan
     ne: तुर्कमेनिस्तान
     nl: Turkmenistan
-    nn: Turkmenistan
     "no": Turkmenistan
     nv: Tʼóokmen Bikéyah
     oc: Turcmenistan

--- a/settings/country-names/tn.yaml
+++ b/settings/country-names/tn.yaml
@@ -76,7 +76,6 @@ name:
     mt: Tuneżija
     my: တူနီးရှားနိုင်ငံ
     nl: Tunesië
-    nn: Tunisia
     "no": Tunisia
     oc: Tunisia
     or: ଟ୍ୟୁନିସିଆ

--- a/settings/country-names/to.yaml
+++ b/settings/country-names/to.yaml
@@ -67,7 +67,6 @@ name:
     mt: Tonga
     my: တုံဂါနိုင်ငံ
     nl: Tonga
-    nn: Tonga
     "no": Tonga
     nv: Tʼónga
     oc: Tònga

--- a/settings/country-names/tr.yaml
+++ b/settings/country-names/tr.yaml
@@ -90,7 +90,6 @@ name:
     na: Terki
     ne: टर्की
     nl: Turkije
-    nn: Tyrkia
     "no": Tyrkia
     nv: Tʼóok Bikéyah
     oc: Turquia

--- a/settings/country-names/tt.yaml
+++ b/settings/country-names/tt.yaml
@@ -30,6 +30,7 @@ name:
     lt: Trinidadas ir Tobagas
     mn: Тринидад ба Тобаго
     nl: Trinidad en Tobago
+    "no": Trinidad og Tobago
     pl: Trynidad i Tobago
     pt: Trindade e Tobago
     ru: Тринидад и Тобаго

--- a/settings/country-names/tw.yaml
+++ b/settings/country-names/tw.yaml
@@ -85,7 +85,6 @@ name:
     my: ထိုင်ဝမ်
     ne: ताइवान
     nl: Taiwan
-    nn: Taiwan
     "no": Taiwan
     oc: Taiwan
     or: ତାଇୱାନ

--- a/settings/country-names/tz.yaml
+++ b/settings/country-names/tz.yaml
@@ -79,7 +79,6 @@ name:
     my: တန်ဇေးနီးယားနိုင်ငံ
     ne: तन्जानिया
     nl: Tanzania
-    nn: Tanzania
     "no": Tanzania
     nv: Tʼanzanííya
     ny: Tanzania

--- a/settings/country-names/ua.yaml
+++ b/settings/country-names/ua.yaml
@@ -85,7 +85,6 @@ name:
     na: Ukraine
     ne: युक्रेन
     nl: Oekraïne
-    nn: Ukraina
     "no": Ukraina
     nv: Yóókwein
     oc: Ucraïna

--- a/settings/country-names/ug.yaml
+++ b/settings/country-names/ug.yaml
@@ -77,7 +77,6 @@ name:
     mt: Uganda
     my: ယူဂန်းဒါးနိုင်ငံ
     nl: Oeganda
-    nn: Uganda
     "no": Uganda
     nv: Yogénda
     oc: Oganda

--- a/settings/country-names/uy.yaml
+++ b/settings/country-names/uy.yaml
@@ -90,7 +90,6 @@ name:
     my: ဥရုဂွေးနိုင်ငံ
     ne: उरुग्वाइ
     nl: Uruguay
-    nn: Uruguay
     "no": Uruguay
     nv: Táłtłʼááh Chʼosh Bitooh (Kéyah Dah Siʼánígíí)
     oc: Uruguai

--- a/settings/country-names/uz.yaml
+++ b/settings/country-names/uz.yaml
@@ -74,7 +74,6 @@ name:
     my: ဥဇဘက်ကစ္စတန်နိုင်ငံ
     na: Uzbekistan
     nl: Oezbekistan
-    nn: Usbekistan
     "no": Usbekistan
     nv: Ózbeʼ Bikéyah
     oc: Ozbequistan

--- a/settings/country-names/va.yaml
+++ b/settings/country-names/va.yaml
@@ -83,7 +83,6 @@ name:
     na: Batikan
     ne: भ्याटिकन सिटी
     nl: Vaticaanstad
-    nn: Vatikanstaten
     "no": Vatikanstaten
     nv: Bádikin Sídii
     oc: Vatican

--- a/settings/country-names/vc.yaml
+++ b/settings/country-names/vc.yaml
@@ -30,7 +30,10 @@ name:
     li: Saint-Vincent
     lt: Sent Vinsentas ir Grenadinai
     mn: Сент-Винсент ба Гренадин
+    nb: Saint Vincent og Grenadinene
     nl: Saint Vincent en de Grenadines
+    nn: Saint Vincent og Grenadinane
+    "no": Saint Vincent og Grenadinene
     pl: Saint Vincent i Grenadyny
     pt: São Vicente e Granadinas
     ru: Сент-Винсент и Гренадины

--- a/settings/country-names/ve.yaml
+++ b/settings/country-names/ve.yaml
@@ -80,7 +80,6 @@ name:
     my: ဗင်နီဇွဲလားနိုင်ငံ
     ne: भेनेजुएला
     nl: Venezuela
-    nn: Venezuela
     "no": Venezuela
     nv: Táłkááʼ Bighan Dineʼé Bikéyah
     oc: Veneçuèla

--- a/settings/country-names/vg.yaml
+++ b/settings/country-names/vg.yaml
@@ -30,7 +30,10 @@ name:
     lv: Britu Virdžīnu salas
     mk: Британски Девствени Острови
     mn: Виржиний Арлууд, Британийн
+    nb: De britiske jomfruøyene
     nl: Britse Maagdeneilanden
+    nn: Dei britiske Jomfruøyane
+    "no": De britiske jomfruøyene
     pl: Brytyjskie Wyspy Dziewicze
     pt: Ilhas Virgens Britânicas
     ru: Британские Виргинские острова

--- a/settings/country-names/vn.yaml
+++ b/settings/country-names/vn.yaml
@@ -91,7 +91,6 @@ name:
     na: Bitinam
     ne: भियतनाम
     nl: Vietnam
-    nn: Vietnam
     "no": Vietnam
     nv: Biʼednam
     oc: Vietnam

--- a/settings/country-names/vu.yaml
+++ b/settings/country-names/vu.yaml
@@ -45,6 +45,7 @@ name:
     my: ဗနွားတူနိုင်ငံ
     na: Banuatu
     ne: भानुअटु
+    "no": Vanuatu
     nv: Banoʼáátʼoo
     oc: Vanuatu
     or: ଭାନୁଆଟୁ

--- a/settings/country-names/xk.yaml
+++ b/settings/country-names/xk.yaml
@@ -74,7 +74,6 @@ name:
     my: ကိုဆိုဗို
     na: Kosovo
     nl: Kosovo
-    nn: Kosovo
     "no": Kosovo
     ny: Kosovo
     oc: Kosova

--- a/settings/country-names/ye.yaml
+++ b/settings/country-names/ye.yaml
@@ -79,7 +79,6 @@ name:
     na: Yemen
     ne: गणतन्त्र यमन
     nl: Jemen
-    nn: Jemen
     "no": Jemen
     nv: Shádiʼááhjí Ásáí Bikéyah
     oc: Iemèn

--- a/settings/country-names/za.yaml
+++ b/settings/country-names/za.yaml
@@ -87,7 +87,6 @@ name:
     my: တောင်အာဖရိက
     ne: दक्षिण अफ्रिका
     nl: Zuid-Afrika
-    nn: Sør-Afrika
     "no": Sør-Afrika
     nv: Kéyah Naakai Łizhinii Bikéyah Shádiʼááhjí Siʼánígíí
     ny: South Africa

--- a/settings/country-names/zm.yaml
+++ b/settings/country-names/zm.yaml
@@ -72,7 +72,6 @@ name:
     mt: Żambja
     my: ဇမ်ဘီယာနိုင်ငံ
     nl: Zambia
-    nn: Zambia
     "no": Zambia
     ny: Zambia
     oc: Zambia

--- a/settings/country-names/zw.yaml
+++ b/settings/country-names/zw.yaml
@@ -75,7 +75,6 @@ name:
     my: ဇင်ဘာဘွေနိုင်ငံ
     ne: जिम्बाब्वे
     nl: Zimbabwe
-    nn: Zimbabwe
     "no": Zimbabwe
     nv: Hooghan Tsé Bee Ádaalyaaí Bikéyah
     ny: Zimbabwe


### PR DESCRIPTION
Update and add missing translations for: 
- Norwegian (no) 
- Norwegian Bokmål (nb) 
- Norwegian Nynorsk (NN)

Also removed nn and nb values where the "no" value was matching. Ref: https://wiki.openstreetmap.org/wiki/Multilingual_names#Norway

**Development process:**
- Initial batch done by a Node.JS script I wrote to read the yamls, then call the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames API and add nb, no and nn
- Due to amount of mistakes in JS, I did a check against the norwegian lexicon https://snl.no/ for the norwegian name for listed countries.
- Finally I manually went over the changes and validated the names and made minor tweaks and adjustments.  