### PR TITLE
Allow any boundary to have an entrance

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -891,7 +891,7 @@ BEGIN
   NEW.centroid := get_center_point(NEW.geometry);
 
   -- Record the entrance node locations
-  IF NEW.osm_type = 'W' and (NEW.rank_search > 27 or NEW.class IN ('landuse', 'leisure')) THEN
+  IF NEW.osm_type = 'W' and (NEW.rank_search > 27 or NEW.class IN ('landuse', 'leisure', 'boundary')) THEN
     PERFORM place_update_entrances(NEW.place_id, NEW.osm_id);
   END IF;
 


### PR DESCRIPTION
There is no entrance for https://nominatim.openstreetmap.org/ui/details.html?osmtype=W&osmid=1448345146 because the search rank is less than 27 and this park is filtered out even though there is an entrance on the way. (The park is search rank 25)
More detail https://github.com/osm-search/Nominatim/issues/3872

It is also possible to set NEW.rank_search > 27 to be greater than 24, but I am not sure which option would be the most efficient. 