### PR TITLE
Skip nat_name in default import

### DIFF
--- a/lib-lua/themes/nominatim/presets.lua
+++ b/lib-lua/themes/nominatim/presets.lua
@@ -321,7 +321,6 @@ module.NAME_TAGS = {}
 
 module.NAME_TAGS.core = {main = {'name', 'name:*',
                                  'int_name', 'int_name:*',
-                                 'nat_name', 'nat_name:*',
                                  'reg_name', 'reg_name:*',
                                  'loc_name', 'loc_name:*',
                                  'old_name', 'old_name:*',


### PR DESCRIPTION
Follow-up to https://github.com/osm-search/Nominatim-Data-Analyser/pull/62#issuecomment-3588528173

https://taginfo.openstreetmap.org/keys/nat_name#values