### PR TITLE
Prefer leisure=nature_reserve as main tag over boundary=protected_area

### DIFF
--- a/lib-lua/themes/nominatim/presets.lua
+++ b/lib-lua/themes/nominatim/presets.lua
@@ -117,6 +117,7 @@ module.MAIN_TAGS.all_boundaries = {
     boundary = {'named',
                 place = 'delete',
                 land_area = 'delete',
+                protected_area = 'fallback',
                 postal_code = 'always'},
     landuse = 'fallback',
     place = 'always'
@@ -198,7 +199,7 @@ module.MAIN_TAGS_POIS = function (group)
                 no = group},
     landuse = {cemetery = 'always'},
     leisure = {'always',
-               nature_reserve = 'fallback',
+               nature_reserve = 'named',
                swimming_pool = 'named',
                garden = 'named',
                common = 'named',


### PR DESCRIPTION
`leisure=nature_reserve` designates protected areas which are of interest for human recreation and may thus have more relevance. Also means that we'll catch entrances for these features.

Closes #3872.