### PR TITLE
Fix flaky test around postcode word match penalties

### DIFF
--- a/test/python/api/search/test_icu_query_analyzer.py
+++ b/test/python/api/search/test_icu_query_analyzer.py
@@ -116,8 +116,10 @@ async def test_penalty_postcodes_and_housenumbers(conn, term, order):
 
     assert query.num_token_slots() == 1
 
-    torder = [(tl.tokens[0].penalty, tl.ttype) for tl in query.nodes[0].starting]
+    torder = [(min(t.penalty for t in tl.tokens), tl.ttype) for tl in query.nodes[0].starting]
     torder.sort()
+
+    print(torder)
 
     assert [t[1] for t in torder] == order
 


### PR DESCRIPTION
Different postcode formats from different countries can have different rematch penalties. Since we are now doubling the rematch penalty for non-words, this causes different orders for the test when just looking at the penalty of whatever the first postcode is.