### PR TITLE
Reverse: only return housenumbers near street

### DIFF
--- a/test/bdd/features/db/query/reverse.feature
+++ b/test/bdd/features/db/query/reverse.feature
@@ -9,13 +9,32 @@ Feature: Reverse searches
         And the places
           | osm | class   | type       | geometry    |
           | W1  | aeroway | terminal   | (1,2,3,4,1) |
-          | N1  | amenity | restaurant | 9           |
+          | N9  | amenity | restaurant | 9           |
         When importing
         And reverse geocoding 1.0001,1.0001
         Then the result contains
          | object |
-         | N1  |
+         | N9  |
         When reverse geocoding 1.0003,1.0001
         Then the result contains
          | object |
          | W1  |
+
+
+    Scenario: Find closest housenumber for street matches
+        Given the 0.0001 grid with origin 1,1
+          |    | 1 |   |    |
+          |    |   | 2 |    |
+          | 10 |   |   | 11 |
+        And the places
+          | osm | class   | type     | name        | geometry |
+          | W1  | highway | service  | Goose Drive | 10,11    |
+          | N2  | tourism | art_work | Beauty      | 2        |
+        And the places
+          | osm | class | type  | housenr | geometry |
+          | N1  | place | house | 23      | 1        |
+        When importing
+        When reverse geocoding 1.0002,1.0002
+        Then the result contains
+          | object |
+          | N1 |


### PR DESCRIPTION
Follow-up to #3899.

Example issue: [this reverse search](https://nominatim.openstreetmap.org/ui/reverse.html?lat=51.05026602111971&lon=13.724781274904673&zoom=18) returns the nearby artwork instead of the nearby housenumber.