### PR TITLE
Add experimental Windows CI workflow

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,29 @@
+name: Windows CI (experimental)
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+    continue-on-error: true   #this is a smoke test (experimental); it won't block merges
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run CLI smoke test
+        run: python nominatim-cli.py --help


### PR DESCRIPTION
### Summary
Adds an experimental Windows GitHub Actions workflow to provide initial CI coverage for Windows (`windows-latest`).

### Motivation
Windows support would come up shortly in #3598, but there is currently no CI setup to verify behavior. This workflow gives us a reproducible way to confirm basic Windows behavior going forward.

### What this workflow does
- checks out the project
- installs Python dependencies
- runs a basic CLI startup command

### Scope
- smoke-level only
- no database setup
- no osm2pgsql
- marked experimental
- does not block merges (`continue-on-error: true`)

### Next steps
Once this runs reliably, I plan to follow with the `WindowsSelectorEventLoopPolicy`  fix  (#3598) so Windows behavior can be validated by CI.
