### PR TITLE
Fix typo in place_addressline table name in tests

### DIFF
--- a/test/python/tools/test_freeze.py
+++ b/test/python/tools/test_freeze.py
@@ -12,7 +12,7 @@ from nominatim_db.tools import freeze
 NOMINATIM_RUNTIME_TABLES = [
     'country_name', 'country_osm_grid',
     'location_postcode', 'location_property_osmline', 'location_property_tiger',
-    'placex', 'place_adressline',
+    'placex', 'place_addressline',
     'search_name',
     'word'
 ]


### PR DESCRIPTION
## Summary

Fix a typo in the test suite where the table name `place_adressline` was used instead of the correct `place_addressline`.

---

## What was changed

- Updated `test_freeze.py`
- Replaced `place_adressline` with `place_addressline`

---

## Why this change is needed

The rest of the codebase and the SQL schema consistently use the table name
`place_addressline`. The typo in the test could lead to failing tests or
confusion when maintaining the code.

---

## Testing

- `make lint`
- `make tests`

---

## Checklist

- [x] Single-purpose PR
- [x] Lint passes (`make lint`)
- [x] Tests pass (`make tests`)
- [x] No AI-generated code
- [x] Ready for review

---

## Affected file

- `test_freeze.py`

#3924 issue closing