### PR TITLE
fix mypy typing for Starlette state object

### DIFF
--- a/src/nominatim_api/server/starlette/server.py
+++ b/src/nominatim_api/server/starlette/server.py
@@ -50,7 +50,7 @@ class ParamWrapper(ASGIAdaptor):
                              headers={'content-type': self.content_type})
 
     def create_response(self, status: int, output: str, num_results: int) -> Response:
-        self.request.state.num_results = num_results
+        setattr(self.request.state, 'num_results', num_results)
         return Response(output, status_code=status, media_type=self.content_type)
 
     def base_uri(self) -> str:
@@ -95,7 +95,7 @@ class FileLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request,
                        call_next: RequestResponseEndpoint) -> Response:
         qs = QueryStatistics()
-        request.state.query_stats = qs
+        setattr(request.state, 'query_stats', qs)
         response = await call_next(request)
 
         if response.status_code != 200 or 'start' not in qs:


### PR DESCRIPTION
## Summary
<!-- Describe the purpose of your pull request and, if present, link to existing issues. -->
The PR fixes `mypy --strict` failures in `src/nominatim_api/server/starlette/server.py` related to dynamically attached request.state attributes.
The CI was failing with : 
```
src/nominatim_api/server/starlette/server.py:53: error: StateT? has no attribute "num_results"  [attr-defined]
src/nominatim_api/server/starlette/server.py:98: error: StateT? has no attribute "query_stats"  [attr-defined]
```
The direct attribute  assignment has been replaced with `setattr` , that keeps runtime behavior unchanged while avoiding `mypy attr-defined` errors. 

Output of `make tests` : 

<img width="849" height="366" alt="image" src="https://github.com/user-attachments/assets/f85a6acd-ba4a-4ec7-87ce-9c2cfa30f7cb" />


<img width="862" height="358" alt="image" src="https://github.com/user-attachments/assets/ab762560-58ce-439f-acbf-325514439848" />

## AI usage
NIL

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
