### PR TITLE
Enable entrance lookup for reverse and lookup

### DIFF
--- a/src/nominatim_api/v1/server_glue.py
+++ b/src/nominatim_api/v1/server_glue.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Generic part of the server implementation of the v1 API.
@@ -200,6 +200,7 @@ async def reverse_endpoint(api: NominatimAPIAsync, params: ASGIAdaptor) -> Any:
     details['max_rank'] = helpers.zoom_to_rank(params.get_int('zoom', 18))
     details['layers'] = get_layers(params)
     details['query_stats'] = params.query_stats()
+    details['entrances'] = params.get_bool('entrances', False)
 
     result = await api.reverse(coord, **details)
 
@@ -238,6 +239,7 @@ async def lookup_endpoint(api: NominatimAPIAsync, params: ASGIAdaptor) -> Any:
     debug = setup_debugging(params)
     details = parse_geometry_details(params, fmt)
     details['query_stats'] = params.query_stats()
+    details['entrances'] = params.get_bool('entrances', False)
 
     places = []
     for oid in (params.get('osm_ids') or '').split(','):

--- a/test/bdd/features/api/lookup/simple.feature
+++ b/test/bdd/features/api/lookup/simple.feature
@@ -42,6 +42,22 @@ Feature: Tests for finding places by osm_type and osm_id
         | jsonv2      | json        |
         | geojson     | geojson     |
 
+    Scenario Outline: Lookup with entrances
+        When sending v1/lookup with format <format>
+          | osm_ids    | entrances |
+          | W429210603 | 1         |
+        Then a HTTP 200 is returned
+        And the result is valid <outformat>
+        And result 0 contains in field entrances+0
+          | osm_id     | type | lat        | lon       |
+          | 6580031131 | yes  | 47.2489382 | 9.5284033 |
+
+        Examples:
+          | format | outformat |
+          | json   | json |
+          | jsonv2 | json |
+          | geojson | geojson |
+
     Scenario: Linked places return information from the linkee
         When sending v1/lookup with format geocodejson
           | osm_ids |

--- a/test/bdd/features/api/reverse/v1_params.feature
+++ b/test/bdd/features/api/reverse/v1_params.feature
@@ -167,3 +167,18 @@ Feature: v1/reverse Parameter Tests
           | json   | json |
           | jsonv2 | json |
           | xml    | xml |
+
+    Scenario Outline: Reverse with entrances
+        When sending v1/reverse with format <format>
+          | lat               | lon              | entrances | zoom |
+          | 47.24942041089678 | 9.52854573737568 | 1         | 18   |
+        Then a HTTP 200 is returned
+        And the result is valid <outformat>
+        And the result contains array field entrances where element 0 contains
+          | osm_id     | type | lat        | lon       |
+          | 6580031131 | yes  | 47.2489382 | 9.5284033 |
+
+        Examples:
+          | format | outformat |
+          | json   | json |
+          | jsonv2 | json |


### PR DESCRIPTION
Fixes an issue, where setting `entrances=1` would only enable output of entrances but not the lookup of them.

Closes #3941.