### PR TITLE
Fixup: add single-quote escaping within debug message

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -1240,7 +1240,7 @@ BEGIN
        LIMIT 1
     LOOP
       IF location.osm_id = NEW.osm_id THEN
-        {% if debug %}RAISE WARNING 'Updating names for country '%' with: %', NEW.country_code, NEW.name;{% endif %}
+        {% if debug %}RAISE WARNING 'Updating names for country ''%'' with: %', NEW.country_code, NEW.name;{% endif %}
         UPDATE country_name SET derived_name = NEW.name WHERE country_code = NEW.country_code;
       END IF;
     END LOOP;


### PR DESCRIPTION
## Summary
A single-quoting fixup for one of the SQL scripts, to resolve a problem noticed during:

```sh
$ nominatim refresh --functions --verbose --enable-debug-statements
```

...as attempted while trying to figure out (which I now have) why my functions weren't being recreated during BDD tests (the answer was in the documentation: use `pytest --nominatim-purge`).

## AI usage
None

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description