### PR TITLE
Feat: Adds layer filtering option to search cli command

### DIFF
--- a/src/nominatim_db/clicmd/api.py
+++ b/src/nominatim_db/clicmd/api.py
@@ -104,7 +104,7 @@ def _get_locales(args: NominatimArgs, config: Configuration) -> napi.Locales:
     return napi.Locales()
 
 
-def _get_layers(args: NominatimArgs, default: napi.DataLayer) -> Optional[napi.DataLayer]:
+def _get_layers(args: NominatimArgs, default: Optional[napi.DataLayer]) -> Optional[napi.DataLayer]:
     """ Get the list of selected layers as a DataLayer enum.
     """
     if not args.layers:
@@ -193,7 +193,7 @@ class APISearch:
             raise UsageError(f"Unsupported format '{args.format}'. "
                              'Use --list-formats to see supported formats.')
 
-        layers = _get_layers(args, napi.DataLayer.ADDRESS | napi.DataLayer.POI)
+        layers = _get_layers(args, None)
 
         try:
             with napi.NominatimAPI(args.project_dir) as api:
@@ -262,7 +262,7 @@ class APIReverse:
         group.add_argument('--layer', metavar='LAYER',
                            choices=[n.name.lower() for n in napi.DataLayer if n.name],
                            action='append', required=False, dest='layers',
-                           help='OSM id to lookup in format <NRW><id> (may be repeated)')
+                           help='Restrict results to one or more layers (may be repeated)')
 
         _add_api_output_arguments(parser)
         _add_list_format(parser)


### PR DESCRIPTION
## Summary
This PR adds the `--layer` parameter to the `nominatim search` CLI command, bringing feature parity with the web API.
closes #3937

### Results
<details>
<summary>e2e test results</summary>

```bash
./nominatim-cli.py search --query "monte carlo" --limit 10 | jq '.[] | {name, category, type}'
2026-01-28 12:46:14: Using project directory: /home/agasta/github/os/Nominatim
{
  "name": "Monte-Carlo",
  "category": "boundary",
  "type": "administrative"
}
{
  "name": "Monte Carlo",
  "category": "building",
  "type": "apartments"
}
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "platform"
}
{
  "name": "Monte-Carlo (Tourisme)",
  "category": "highway",
  "type": "platform"
}
{
  "name": "Monte-Carlo",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte-Carlo (Tourisme)",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte Carlo",
  "category": "amenity",
  "type": "bicycle_rental"
}
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "bus_stop"
}
(nominatim-dev-venv) 
 Wed 28 Jan - 12:46  ~/github/os/Nominatim   cli 1⚙ 4☀ 
 @agasta   ./nominatim-cli.py search --query "monte carlo" --layer poi --limit 10 | jq '.[] | {name, category, type}'
2026-01-28 12:46:24: Using project directory: /home/agasta/github/os/Nominatim
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "platform"
}
{
  "name": "Monte-Carlo (Tourisme)",
  "category": "highway",
  "type": "platform"
}
{
  "name": "Monte-Carlo",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte-Carlo (Tourisme)",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "bus_stop"
}
{
  "name": "Monte Carlo",
  "category": "amenity",
  "type": "bicycle_rental"
}
{
  "name": "Monte-Carlo (Casino)",
  "category": "highway",
  "type": "bus_stop"
}
(nominatim-dev-venv) 
 Wed 28 Jan - 12:46  ~/github/os/Nominatim   cli 1⚙ 4☀ 
 @agasta   ./nominatim-cli.py search --query "monte carlo" --layer address --limit 10 | jq '.[] | {name, category, type}'
2026-01-28 12:46:31: Using project directory: /home/agasta/github/os/Nominatim
{
  "name": "Monte-Carlo",
  "category": "boundary",
  "type": "administrative"
}
(nominatim-dev-venv)

```
</details>

## AI usage
I used ai to gather the e2e test cmds used above. As idk Monaco’s place names :(

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
