### PR TITLE
Tests: resolve an issue in the place-linkage name expansion test case

### DIFF
--- a/test/bdd/features/db/import/linking.feature
+++ b/test/bdd/features/db/import/linking.feature
@@ -306,11 +306,17 @@ Feature: Linking of places
         Given the places
             | osm | class    | type           | name+name                | geometry    |
             | N9  | place    | city           | Popayán                  | 9           |
-            | R1  | boundary | administrative | Perímetro Urbano Popayán | (1,2,3,4,1) |
+        Given the places
+            | osm | class    | type           | name+name                | geometry    | admin |
+            | R1  | boundary | administrative | Perímetro Urbano Popayán | (1,2,3,4,1) | 8     |
         And the relations
             | id | members  |
             | 1  | N9:label |
         When importing
+        Then placex contains
+            | object      | linked_place_id |
+            | N9:place    | R1              |
+            | R1:boundary | -               |
         Then placex contains
             | object | name+_place_name | name+_place_name:es |
             | R1     | Popayán          | Popayán             |


### PR DESCRIPTION
## Summary
This is a followup to pull request #3687 that added test coverage to illustrate how name expansion should work for linked places in a city/boundary example.

I think there is a bug in the test case -- the city and boundary don't yet seem to be linked.  To begin with, this draft pull request reactivates the test case with an extra assertion to confirm that (it is expected to fail).

If that seems reasonable then I think we may be able to add a suitable `admin` tag (administrative boundary level) to the boundary to resolve this.

## AI usage
None

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description