### PR TITLE
cli: add --layer option to search command

### DIFF
--- a/src/nominatim_db/clicmd/api.py
+++ b/src/nominatim_db/clicmd/api.py
@@ -104,7 +104,7 @@ def _get_locales(args: NominatimArgs, config: Configuration) -> napi.Locales:
     return napi.Locales()
 
 
-def _get_layers(args: NominatimArgs, default: napi.DataLayer) -> Optional[napi.DataLayer]:
+def _get_layers(args: NominatimArgs, default: Optional[napi.DataLayer]) -> Optional[napi.DataLayer]:
     """ Get the list of selected layers as a DataLayer enum.
     """
     if not args.layers:


### PR DESCRIPTION
## Summary
This pull request adds support for the `--layer` option to the Nominatim CLI `search` command.  
The underlying API already supports layer filtering; this change exposes that functionality in the CLI and brings feature parity with the reverse search command.

## AI usage
AI assistance was used to help analyze the existing codebase and draft the pull request description.  
All code changes were written, reviewed, and validated.

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description

#3937 