### PR TITLE
Refactor of linked-place name-expansion code

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -87,7 +87,6 @@ BEGIN
     -- Add all names from the place nodes that deviate from the name
     -- in the relation with the prefix '_place_'. Deviation means that
     -- either the value is different or a given key is missing completely
-
     SELECT hstore(array_agg('_place_' || key), array_agg(value))
       INTO extra_names
       FROM each(location.name)


### PR DESCRIPTION
## Summary
I think the place-name expansion logic for linked places in `placex_indexing_prepare` is a good candidate for some refactoring, and I'd like to do that before attempting a fix for #2714.

## AI usage
None

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description