### PR TITLE
Fix README: update Nominatim API server module path

### DIFF
--- a/packaging/nominatim-api/README.md
+++ b/packaging/nominatim-api/README.md
@@ -23,7 +23,7 @@ an ASGI-capable server like uvicorn. To install them from pypi run:
 You need to have a Nominatim database imported with the 'nominatim-db'
 package. Go to the project directory, then run uvicorn as:
 
-    uvicorn --factory nominatim.server.falcon.server:run_wsgi
+    uvicorn --factory nominatim_api.server.falcon.server:run_wsgi
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
This pull request fixes an outdated example command in `README.md`.

The documented `uvicorn` command referenced an old server module path. The server module has since been renamed to:

```
nominatim_api.server.falcon.server
```

The README has been updated to use the correct module path so that users following the documentation do not encounter import errors.

### After the fix
<img width="900" height="111" alt="image" src="https://github.com/user-attachments/assets/87eb357e-9aad-4f4f-8d8e-f02e06ce5058" />

## AI usage
AI assistance was used to help draft and refine the pull request description and documentation wording.  
No source code logic was generated or modified by AI.

## Contributor guidelines (mandatory)

- [x] I have adhered to the coding style
- [x] I have tested the proposed changes (documentation-only change; verified updated command resolves correctly)
- [x] I have disclosed above any use of AI to generate code, documentation, or the pull request description

