### PR TITLE
Tests: parameter-agnostic 'Indexer.has_pending' monkeypatching

### DIFF
--- a/test/python/cli/test_cli.py
+++ b/test/python/cli/test_cli.py
@@ -91,8 +91,9 @@ class TestCliWithDb:
         postcode_mock = async_mock_func_factory(nominatim_db.indexer.indexer.Indexer,
                                                 'index_postcodes')
 
+        has_pending_retvals = [True, False]
         monkeypatch.setattr(nominatim_db.indexer.indexer.Indexer, 'has_pending',
-                            [False, True].pop)
+                            lambda *args, **kwargs: has_pending_retvals.pop(0))
 
         assert self.call_nominatim('index', *params) == 0
 


### PR DESCRIPTION
## Summary
This is a pedantic/nitpicky refactor of the monkeypatching of the Indexer `has_pending` method.  Assigning the instance-method of a `list`'s `pop` method is clever, but is fragile because it requires that the runtime parameters are compatible with `list.pop`'s method signature.

By adjusting the substitute method to call an intermediate `lambda` function that accepts (and ignores) arbitrary parameters, we can allow the underyling `has_pending` method signature to change.

Discovered during an exploratory branch in #3956 that modified the signature of the `Indexer.has_pending` method.

## AI usage
None

## Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description

Edit: add context to the description to explain where this idea/suggestion originated from.
Edit: update the implementation strategy.