### PR TITLE
Indexer: allow 'has_pending' to consider address-rank subsets

### DIFF
--- a/src/nominatim_db/clicmd/index.py
+++ b/src/nominatim_db/clicmd/index.py
@@ -64,4 +64,4 @@ class UpdateIndex:
             if not args.boundaries_only:
                 await indexer.index_by_rank(args.minrank, args.maxrank)
                 await indexer.index_postcodes()
-            has_pending = indexer.has_pending()
+            has_pending = indexer.has_pending(args.minrank, args.maxrank)

--- a/test/python/cli/test_cmd_index.py
+++ b/test/python/cli/test_cmd_index.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2025 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for index command of the command-line interface wrapper.
+"""
+import pytest
+
+import nominatim_db.indexer.indexer
+
+
+class TestCliIndexWithDb:
+
+    @pytest.fixture(autouse=True)
+    def setup_cli_call(self, cli_call, cli_tokenizer_mock):
+        self.call_nominatim = cli_call
+        self.tokenizer_mock = cli_tokenizer_mock
+
+    def test_index_empty_subset(self, monkeypatch, async_mock_func_factory, placex_row):
+        placex_row(rank_address=1, indexed_status=1)
+        placex_row(rank_address=20, indexed_status=1)
+
+        mocks = [
+            async_mock_func_factory(nominatim_db.indexer.indexer.Indexer, 'index_boundaries'),
+            async_mock_func_factory(nominatim_db.indexer.indexer.Indexer, 'index_by_rank'),
+            async_mock_func_factory(nominatim_db.indexer.indexer.Indexer, 'index_postcodes'),
+        ]
+
+        def _reject_repeat_call(*args, **kwargs):
+            assert False, "Did not expect multiple Indexer.has_pending invocations"
+
+        has_pending_calls = [nominatim_db.indexer.indexer.Indexer.has_pending, _reject_repeat_call]
+        monkeypatch.setattr(nominatim_db.indexer.indexer.Indexer, 'has_pending',
+                            lambda *args, **kwargs: has_pending_calls.pop(0)(*args, **kwargs))
+
+        assert self.call_nominatim('index', '--minrank', '5', '--maxrank', '10') == 0
+
+        for mock in mocks:
+            assert mock.called == 1, "Mock '{}' not called".format(mock.func_name)


### PR DESCRIPTION
## Summary
The `Indexer.has_pending` method hasn't been aware of min/max rank options supplied during CLI indexing -- and this means that in some cases the indexer will run continuously because it still thinks that there are places requiring reindexing, despite those being outside the min/max request range.

This pull request enables the method to check within subsets of the places by rank address number.

Note: A supporting PostgreSQL database index is available for this, named [`idx_placex_rank_address_sector`](https://github.com/osm-search/Nominatim/blob/cd2f6e458b7f4ce634bd16747788f1603ed265bc/lib-sql/tables.sql#L187-L189) -- it is defined over the columns `rank_address, geometry_sector` and is a [partial index](https://www.postgresql.org/docs/18/indexes-partial.html) for places that have a non-zero `indexed_status`.

Resolves #3969.

## AI usage
None

## Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description

Edit: simplify pull request description.