### PR TITLE
Refactor: add default params to Indexer.index_boundaries

### DIFF
--- a/src/nominatim_db/indexer/indexer.py
+++ b/src/nominatim_db/indexer/indexer.py
@@ -59,7 +59,7 @@ class Indexer:
                 if await self.index_by_rank(0, 4) > 0:
                     _analyze()
 
-                if await self.index_boundaries(0, 30) > 100:
+                if await self.index_boundaries() > 100:
                     _analyze()
 
                 if await self.index_by_rank(5, 25) > 100:
@@ -74,7 +74,7 @@ class Indexer:
                 if not self.has_pending():
                     break
 
-    async def index_boundaries(self, minrank: int, maxrank: int) -> int:
+    async def index_boundaries(self, minrank: int = 0, maxrank: int = 30) -> int:
         """ Index only administrative boundaries within the given rank range.
         """
         total = 0

--- a/test/python/indexer/test_indexing.py
+++ b/test/python/indexer/test_indexing.py
@@ -247,7 +247,7 @@ async def test_index_boundaries(test_db, threads, test_tokenizer):
     assert test_db.osmline_unindexed() == 1
 
     idx = indexer.Indexer('dbname=test_nominatim_python_unittest', test_tokenizer, threads)
-    await idx.index_boundaries(0, 30)
+    await idx.index_boundaries()
 
     assert test_db.placex_unindexed() == 31
     assert test_db.osmline_unindexed() == 1


### PR DESCRIPTION
## Summary
This refactor is intended to make calls to `index_boundaries` more visually distinct from the `index_full` callsite.

This helps to distinguish between the various calls that index places within certain address rank ranges, and the functionally-distinct call to index boundaries.

NB: internally, `index_boundaries` caps `minrank` to `4`, and `maxrank` to `25`.

## AI usage
None

## Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description