### PR TITLE
Indexer: relocate zero-ranked-address indexing

### DIFF
--- a/src/nominatim_db/indexer/indexer.py
+++ b/src/nominatim_db/indexer/indexer.py
@@ -56,7 +56,7 @@ class Indexer:
                         cur.execute('ANALYZE')
 
             while True:
-                if await self.index_by_rank(0, 4) > 0:
+                if await self.index_by_rank(1, 4) > 0:
                     _analyze()
 
                 if await self.index_boundaries() > 100:
@@ -67,6 +67,9 @@ class Indexer:
 
                 if await self.index_by_rank(26, 30) > 1000:
                     _analyze()
+
+                # Special case: rank zero depends on the previously-indexed [1..30] ranks
+                await self.index_by_rank(0, 0)
 
                 if await self.index_postcodes() > 100:
                     _analyze()
@@ -147,8 +150,11 @@ class Indexer:
                 total += await self._index(runners.RankRunner(rank, analyzer),
                                            batch=batch, total_tuples=total_tuples.get(rank, 0))
 
-            if maxrank == 30:
+            # Special case: rank zero depends on ranks [1..30]
+            if minrank == 0:
                 total += await self._index(runners.RankRunner(0, analyzer))
+
+            if maxrank == 30:
                 total += await self._index(runners.InterpolationRunner(analyzer), batch=20)
 
         return total

--- a/test/python/indexer/test_indexing.py
+++ b/test/python/indexer/test_indexing.py
@@ -226,12 +226,12 @@ async def test_index_partial_with_30(test_db, threads, test_tokenizer):
     idx = indexer.Indexer('dbname=test_nominatim_python_unittest', test_tokenizer, threads)
     await idx.index_by_rank(28, 30)
 
-    assert test_db.placex_unindexed() == 27
+    assert test_db.placex_unindexed() == 28
     assert test_db.osmline_unindexed() == 0
 
     assert test_db.scalar("""
                     SELECT count(*) FROM placex
-                      WHERE indexed_status = 0 AND rank_address between 1 and 27""") == 0
+                      WHERE indexed_status = 0 AND rank_address between 0 and 27""") == 0
 
 
 @pytest.mark.parametrize("threads", [1, 15])


### PR DESCRIPTION
## Summary
Extract the special-case handling of rank zero so that it doesn't occur automagically when rank 30 is requested/indexed.

Context / ref: https://github.com/osm-search/Nominatim/pull/3971#pullrequestreview-3772308501

NB: I considered creating a separate method called something like `index_environs` -- but with a less-urban connotation noun than `environs` -- to make this more distinctive than yet another `index_rank` call.  However: the construction of a redundant/duplicate name analyzer within that method felt inelegant, too.

## AI usage
None

## Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description