### PR TITLE
postcode import: make query planner use the index on location_postcodes

### DIFF
--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -102,6 +102,13 @@ class _PostcodeCollector:
 
         with conn.cursor() as cur:
             if to_add:
+                # postcodes_insert trigger checks for duplicates via
+                # SELECT on (postcode, country_code). On an initial import the
+                # table stats can be 0 rows, so the query planner ignores the
+                # index. All inserts in executemany are in a transaction and
+                # postgres doesn't update the table state. The 'ANALYSE' after
+                # is too late.
+                cur.execute("SET LOCAL enable_seqscan = off")
                 cur.executemany(pysql.SQL(
                     """INSERT INTO location_postcodes
                          (country_code, rank_search, postcode, centroid, geometry)
@@ -112,6 +119,7 @@ class _PostcodeCollector:
                                 pysql.Literal(_extent_to_rank(self.extent)),
                                 pysql.Literal(self.extent)),
                     to_add)
+                cur.execute("SET LOCAL enable_seqscan = on")
             if to_delete:
                 cur.execute("""DELETE FROM location_postcodes
                                WHERE country_code = %s and postcode = any(%s)


### PR DESCRIPTION
Fix for https://github.com/osm-search/Nominatim/issues/3993

## Summary

`_PostcodeCollector.commit()` (`src/nominatim_db/tools/postcodes.py`) has a loop of INSERT sql statements using Psyops' `executemany` which runs all inside a transaction. Before the loop it's possible that Postgresql query planner
sees 0 postcodes in the `location_postcodes` table and has no statistics.

Each INSERT runs a trigger (`lib-sql/functions/postcode_triggers.sql`) which checks if a postcode already exists
in the database. It runs basically `SELECT [...] FROM location_postcodes WHERE country_code = [...] AND postcode = postcode`. The index (`idx_location_postcodes_postcode`) would be ideal but Postgresql chooses a sequential
scan.

When importing one UK county I saw the INSERTs became slower over time. The "Calculate postcodes" step never
finished.

| Rows inserted | Time per INSERT | Cumulative wall time |
|---------------|----------------:|---------------------:|
| 1             | 0.5ms           | 0s                   |
| 10,000        | ~0.8ms          | 4s                   |
| 20,000        | ~1.4ms          | 16s                  |
| 40,000        | ~2.9ms          | 59s                  |
| 60,000        | ~4.3ms          | 131s                 |
| 80,000        | ~5.8ms          | 232s                 |
| 1,700,000     | ~120ms (proj.)  | ~45 hours (proj.)    |

With this PR the same import on a fresh database takes about 2 minutes
```
# https://en.wikipedia.org/wiki/Rutland
nominatim import -v --osm-file rutland-latest.osm.pbf
...
2026-02-20 21:46:51: Calculate postcodes
2026-02-20 21:46:51: Using external postcode file 'nominatim-project/gb_postcodes.csv'.
2026-02-20 21:46:58: Processing country 'gb' (1756829 added, 0 deleted).
2026-02-20 21:49:07: Indexing places
...
```

It's possible importing one UK county or Ireland was an edge case and the same issue wouldn't happen with
a full planet installation, or when importing another country.

## AI usage
AI helped me summarize the postgresql logfile and found the pattern that the individual INSERT statement
duration increases over time. It couldn't explain it though. It helped me write a test script importing the same
file with similar methods (`executemany`) but the script was always fast and no amount of tweaking made
it reproduce the issue. It advised me against the change in this PR and suggested instead to disable and
recreate the trigger during the `executemany` insert, or to drop and recreate the index. The `commit()`
runs many times, looping through countries, that wouldn't have been pragmatic.

## Contributor guidelines (mandatory)

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
