### PR TITLE
Avoid updates on initial filling of postcode table

### DIFF
--- a/src/nominatim_db/clicmd/args.py
+++ b/src/nominatim_db/clicmd/args.py
@@ -120,6 +120,7 @@ class NominatimArgs:
     data_object: Sequence[Tuple[str, int]]
     data_area: Sequence[Tuple[str, int]]
     ro_access: bool
+    postcode_force_reimport: bool
 
     # Arguments to 'replication'
     init: bool

--- a/src/nominatim_db/clicmd/refresh.py
+++ b/src/nominatim_db/clicmd/refresh.py
@@ -84,6 +84,10 @@ class UpdateRefresh:
                            help='Do not enable code for propagating updates')
         group.add_argument('--enable-debug-statements', action='store_true',
                            help='Enable debug warning statements in functions')
+        group = parser.add_argument_group('Arguments for postcode refresh')
+        group.add_argument('--force-reimport', action='store_true',
+                           dest='postcode_force_reimport',
+                           help='Recompute the postcodes from scratch instead of updating')
 
     def run(self, args: NominatimArgs) -> int:
         from ..tools import refresh, postcodes
@@ -96,7 +100,8 @@ class UpdateRefresh:
                 LOG.warning("Update postcodes centroid")
                 tokenizer = self._get_tokenizer(args.config)
                 postcodes.update_postcodes(args.config.get_libpq_dsn(),
-                                           args.project_dir, tokenizer)
+                                           args.project_dir, tokenizer,
+                                           force_reimport=args.postcode_force_reimport)
                 indexer = Indexer(args.config.get_libpq_dsn(), tokenizer,
                                   args.threads or 1)
                 asyncio.run(indexer.index_postcodes())

--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -177,7 +177,8 @@ class _PostcodeCollector:
         return None
 
 
-def update_postcodes(dsn: str, project_dir: Optional[Path], tokenizer: AbstractTokenizer) -> None:
+def update_postcodes(dsn: str, project_dir: Optional[Path],
+                     tokenizer: AbstractTokenizer, force_reimport: bool = False) -> None:
     """ Update the table of postcodes from the input tables
         placex and place_postcode.
     """
@@ -189,7 +190,11 @@ def update_postcodes(dsn: str, project_dir: Optional[Path], tokenizer: AbstractT
                               SET country_code = get_country_code(centroid)
                               WHERE country_code is null
                          """)
-            is_initial = _is_postcode_table_empty(conn)
+            if force_reimport:
+                conn.execute("TRUNCATE location_postcodes")
+                is_initial = True
+            else:
+                is_initial = _is_postcode_table_empty(conn)
             if is_initial:
                 conn.execute("""ALTER TABLE location_postcodes
                                 DISABLE TRIGGER location_postcodes_before_insert""")


### PR DESCRIPTION
Alternative fix for #3993.

Uses a short-cut path when the location_postcode table is empty, which doesn't check for updates. It's not much faster than the regular update path, which likely is why I didn't do it in the original implementation. Works around query planning issues by avoiding the problematic queries.

Also adds an option to recreate the postcodes from scratch.