### PR TITLE
Reenable index on centroid column for location_postcodes

### DIFF
--- a/lib-sql/functions/utils.sql
+++ b/lib-sql/functions/utils.sql
@@ -153,8 +153,7 @@ BEGIN
     IF ST_GeometryType(geom) in ('ST_Polygon','ST_MultiPolygon') THEN
       SELECT min(postcode), count(*) FROM
         (SELECT postcode FROM location_postcodes
-           WHERE geom && location_postcodes.geometry -- want to use the index
-                 AND ST_Contains(geom, location_postcodes.centroid)
+           WHERE ST_Contains(geom, location_postcodes.centroid)
                  AND country_code = country
            LIMIT 2) sub
         INTO outcode, cnt;

--- a/lib-sql/tables/postcodes.sql
+++ b/lib-sql/tables/postcodes.sql
@@ -23,6 +23,8 @@ CREATE UNIQUE INDEX idx_location_postcodes_id ON location_postcodes
   USING BTREE (place_id) {{db.tablespace.search_index}};
 CREATE INDEX idx_location_postcodes_geometry ON location_postcodes
   USING GIST (geometry) {{db.tablespace.search_index}};
+CREATE INDEX idx_location_postcodes_centroid ON location_postcodes
+  USING GIST (centroid) {{db.tablespace.search_index}};
 CREATE INDEX IF NOT EXISTS idx_location_postcodes_postcode ON location_postcodes
   USING BTREE (postcode, country_code) {{db.tablespace.search_index}};
 CREATE INDEX IF NOT EXISTS idx_location_postcodes_osmid ON location_postcodes


### PR DESCRIPTION
Turns out that PostgreSQL is making quite clever usage of the centroid index to find the closest postcode for an address during query time. So reenable that index.