### PR TITLE
fix: Windows asyncio deprecation Python 3.16+

### DIFF
--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -10,8 +10,8 @@ import asyncio
 from pathlib import Path
 
 if sys.platform == 'win32':
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
+    loop = asyncio.SelectorEventLoop()
+    asyncio.set_event_loop(loop)    
 import psycopg
 from psycopg import sql as pysql
 import pytest


### PR DESCRIPTION
## Summary
<!-- Describe the purpose of your pull request and, if present, link to existing issues. -->
fix: Windows asyncio deprecation Python 3.16+

Replace deprecated WindowsSelectorEventLoopPolicy with SelectorEventLoop
Refs: https://docs.python.org/3.14/library/asyncio-policy.html
Fixes #3598 (Windows CI warning from #3923)
## AI usage
<!-- Please list where and to what extent AI was used. -->
Just to understand the codebase, manual changes only

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->
Doesnt violate any

- [ -] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [ ] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [ ] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
