### PR TITLE
Adjust expected count when doing housenumber search by address

### DIFF
--- a/src/nominatim_api/search/db_search_builder.py
+++ b/src/nominatim_api/search/db_search_builder.py
@@ -177,6 +177,7 @@ class SearchBuilder:
                 sdata.lookups = partials.split_lookup(split, 'nameaddress_vector')
                 sdata.lookups.append(
                     dbf.FieldLookup('name_vector', hnr_tokens, lookups.Restrict))
+                expected_count = partials.min_count() / (5**(split - 1))
             else:
                 addr_fulls = [t.token for t in
                               self.query.get_tokens(address[0], qmod.TOKEN_WORD)]


### PR DESCRIPTION
The "expected count" is an estimate for how many results will come back for a given query. Nominatim uses it to make PostgreSQL use the most efficient index when searching. When searching for an address with address terms that deviate from its parent street, then the expected count would always give the number of house numbers in the database. Most of the time, however, such a search will be done using the address parts, which tends to be much more selective in terms of results. This change adapts the expected count in this case, improving the query planning for such cases.

Fixes #4010.