### PR TITLE
fix: specify utf-8 encoding for tiger data extraction

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -182,7 +182,6 @@ jobs:
 
             - name: Set UTF-8 encoding
               run: |
-                  echo "PYTHONUTF8=1" >> $env:GITHUB_ENV
                   [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
             - name: Install PyICU from wheel

--- a/src/nominatim_db/tools/tiger_data.py
+++ b/src/nominatim_db/tools/tiger_data.py
@@ -71,7 +71,7 @@ class TigerInput:
         if self.tar_handle is not None:
             extracted = self.tar_handle.extractfile(fname)
             assert extracted is not None
-            return io.TextIOWrapper(extracted)
+            return io.TextIOWrapper(extracted, encoding='utf-8')
 
         return open(cast(str, fname), encoding='utf-8')
 


### PR DESCRIPTION
Hi @lonvia,

As a follow-up to the open points discussed in PR #3923 regarding the `UnicodeDecodeError` on Windows runners I scanned the codebase for missing encoding declarations in text-mode file operations.

It turns out that the `io.TextIOWrapper` in `src/nominatim_db/tools/tiger_data.py` was falling back to the default system encoding which defaults to `CP1252` on Windows, causing the extraction to fail on UTF-8 data. 

I added the explicit `encoding='utf-8'` parameter to ensure cross-platform consistency and remove the need for environment-level workarounds like `PYTHONUTF8=1` for this specific module.

Let me know if there are any other specific areas you'd like me to look into!