### PR TITLE
Add uv support for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data/country_osm_grid.sql.gz
 
 # Not committed per project policy
 uv.lock
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist
 
 .vagrant
 data/country_osm_grid.sql.gz
+
+# Not committed per project policy
+uv.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ Please see the development section of the Nominatim documentation for
 * [an architecture overview](https://nominatim.org/release-docs/develop/develop/overview/)
   and backgrounds on some of the algorithms
 * [how to set up a development environment](https://nominatim.org/release-docs/develop/develop/Development-Environment/)
+  using virtualenv or [uv](https://docs.astral.sh/uv/)
 * and background on [how tests are organised](https://nominatim.org/release-docs/develop/develop/Testing/)
 
 

--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -68,14 +68,14 @@ Create a virtual environment and install all dependencies:
 ```sh
 virtualenv ~/nominatim-dev-venv
 . ~/nominatim-dev-venv/bin/activate
-pip install --group runtime --group dev .
+pip install --group runtime --group dev
 ```
 
 To install dependencies individually:
 
 ```sh
 pip install \
-    psutil 'psycopg[binary]' PyICU SQLAlchemy \
+    psutil 'psycopg[binary]' PyICU 'SQLAlchemy[asyncio]' \
     python-dotenv jinja2 pyYAML \
     mkdocs 'mkdocstrings[python]' mkdocs-gen-files mkdocs-material \
     pytest pytest-asyncio pytest-bdd flake8 \

--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -63,20 +63,24 @@ sudo apt install build-essential libsqlite3-mod-spatialite osm2pgsql \
 
 #### Using pip
 
-Create a virtual environment and install all dependencies from the project's
-`pyproject.toml`:
+Create a virtual environment and install all dependencies:
+
 ```sh
 virtualenv ~/nominatim-dev-venv
 . ~/nominatim-dev-venv/bin/activate
-pip install --group dev .
+pip install --group runtime --group dev .
 ```
 
-This installs the two Nominatim packages (`nominatim-api`, `nominatim-db`)
-along with all development dependencies (tests, linting, type stubs, docs, serve).
+To install dependencies individually:
 
-To install runtime dependencies only:
 ```sh
-pip install .
+pip install \
+    packaging/nominatim-db packaging/nominatim-api \
+    pytest pytest-asyncio pytest-bdd flake8 mypy \
+    mkdocs mkdocstrings mkdocs-gen-files mkdocs-material \
+    osmium aiosqlite falcon starlette uvicorn \
+    types-jinja2 types-markupsafe types-psutil types-psycopg2 \
+    types-pygments types-pyyaml types-requests types-ujson types-urllib3 typing-extensions
 ```
 
 #### Using uv

--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -82,6 +82,27 @@ Now enter the virtual environment whenever you want to develop:
 . ~/nominatim-dev-venv/bin/activate
 ```
 
+### Alternative: Using uv
+
+If you prefer, you can use [uv](https://docs.astral.sh/uv/) for a faster
+development setup. Install uv following the
+[official instructions](https://docs.astral.sh/uv/getting-started/installation/),
+then from the Nominatim source directory:
+
+```sh
+uv sync
+```
+
+This creates a virtual environment and installs all Python dependencies
+automatically. To run commands in the environment:
+
+```sh
+uv run nominatim --version
+uv run pytest test/python
+uv run make lint
+```
+
+
 ### Running Nominatim during development
 
 The source code for Nominatim can be found in the `src` directory and can

--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -61,28 +61,25 @@ sudo apt install build-essential libsqlite3-mod-spatialite osm2pgsql \
                  pkg-config libicu-dev virtualenv
 ```
 
-To set up the virtual environment with all necessary packages run:
+#### Using pip
 
+Create a virtual environment and install all dependencies from the project's
+`pyproject.toml`:
 ```sh
 virtualenv ~/nominatim-dev-venv
-~/nominatim-dev-venv/bin/pip install\
-    psutil 'psycopg[binary]' PyICU SQLAlchemy \
-    python-dotenv jinja2 pyYAML \
-    mkdocs 'mkdocstrings[python]' mkdocs-gen-files mkdocs-material \
-    pytest pytest-asyncio pytest-bdd flake8 \
-    types-jinja2 types-markupsafe types-psutil types-psycopg2 \
-    types-pygments types-pyyaml types-requests types-ujson \
-    types-urllib3 typing-extensions gunicorn falcon starlette \
-    uvicorn mypy osmium aiosqlite mwparserfromhell
-```
-
-Now enter the virtual environment whenever you want to develop:
-
-```sh
 . ~/nominatim-dev-venv/bin/activate
+pip install --group dev .
 ```
 
-### Alternative: Using uv
+This installs the two Nominatim packages (`nominatim-api`, `nominatim-db`)
+along with all development dependencies (tests, linting, type stubs, docs, serve).
+
+To install runtime dependencies only:
+```sh
+pip install .
+```
+
+#### Using uv
 
 If you prefer, you can use [uv](https://docs.astral.sh/uv/) for a faster
 development setup. Install uv following the
@@ -101,7 +98,6 @@ uv run nominatim --version
 uv run pytest test/python
 uv run make lint
 ```
-
 
 ### Running Nominatim during development
 

--- a/docs/develop/Development-Environment.md
+++ b/docs/develop/Development-Environment.md
@@ -75,12 +75,14 @@ To install dependencies individually:
 
 ```sh
 pip install \
-    packaging/nominatim-db packaging/nominatim-api \
-    pytest pytest-asyncio pytest-bdd flake8 mypy \
-    mkdocs mkdocstrings mkdocs-gen-files mkdocs-material \
-    osmium aiosqlite falcon starlette uvicorn \
+    psutil 'psycopg[binary]' PyICU SQLAlchemy \
+    python-dotenv jinja2 pyYAML \
+    mkdocs 'mkdocstrings[python]' mkdocs-gen-files mkdocs-material \
+    pytest pytest-asyncio pytest-bdd flake8 \
     types-jinja2 types-markupsafe types-psutil types-psycopg2 \
-    types-pygments types-pyyaml types-requests types-ujson types-urllib3 typing-extensions
+    types-pygments types-pyyaml types-requests types-ujson \
+    types-urllib3 typing-extensions gunicorn falcon starlette \
+    uvicorn mypy osmium aiosqlite mwparserfromhell
 ```
 
 #### Using uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,19 @@
+[project]
+name = "nominatim"
+version = "5.3.0"
+requires-python = ">=3.9"
+
+dependencies = [
+    "nominatim-api",
+    "nominatim-db",
+]
+
 [tool.uv.workspace]
 members = ["packaging/*"]
+
+[tool.uv.sources]
+nominatim-api = { workspace = true }
+nominatim-db  = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -23,7 +37,7 @@ lint = [
 ]
 
 types = [
-    "mypy",
+    "mypy<=1.19.1",
     "types-jinja2",
     "types-markupsafe",
     "types-psycopg2",
@@ -45,7 +59,6 @@ docs = [
 
 serve = [
     "falcon",
-    "gunicorn",
     "starlette",
     "uvicorn",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,5 @@
-[project]
-name = "nominatim"
-version = "5.3.0"
-requires-python = ">=3.9"
-
-dependencies = [
-    "nominatim-api",
-    "nominatim-db",
-]
-
 [tool.uv.workspace]
 members = ["packaging/*"]
-
-[tool.uv.sources]
-nominatim-api = { workspace = true }
-nominatim-db  = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -48,6 +34,18 @@ types = [
     "types-ujson",
     "types-urllib3",
     "typing-extensions",
+]
+
+runtime = [
+    "psycopg != 3.3.0",
+    "async-timeout",
+    "python-dotenv",
+    "jinja2",
+    "pyYAML>=5.1",
+    "psutil",
+    "PyICU",
+    "mwparserfromhell",
+    "SQLAlchemy>=1.4.31",
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[tool.uv.workspace]
+members = ["packaging/*"]
+
+[dependency-groups]
+dev = [
+    { include-group = "test" },
+    { include-group = "lint" },
+    { include-group = "types" },
+    { include-group = "docs" },
+    { include-group = "serve" },
+]
+
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-bdd",
+    "aiosqlite",
+    "osmium",
+]
+
+lint = [
+    "flake8",
+]
+
+types = [
+    "mypy",
+    "types-jinja2",
+    "types-markupsafe",
+    "types-psycopg2",
+    "types-psutil",
+    "types-Pygments",
+    "types-PyYAML",
+    "types-requests",
+    "types-ujson",
+    "types-urllib3",
+    "typing-extensions",
+]
+
+docs = [
+    "mkdocs",
+    "mkdocstrings[python]",
+    "mkdocs-gen-files",
+    "mkdocs-material",
+]
+
+serve = [
+    "falcon",
+    "gunicorn",
+    "starlette",
+    "uvicorn",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ lint = [
 ]
 
 types = [
-    "mypy<=1.19.1",
+    "mypy",
     "types-jinja2",
     "types-markupsafe",
     "types-psycopg2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,18 +36,6 @@ types = [
     "typing-extensions",
 ]
 
-runtime = [
-    "psycopg != 3.3.0",
-    "async-timeout",
-    "python-dotenv",
-    "jinja2",
-    "pyYAML>=5.1",
-    "psutil",
-    "PyICU",
-    "mwparserfromhell",
-    "SQLAlchemy>=1.4.31",
-]
-
 docs = [
     "mkdocs",
     "mkdocstrings[python]",
@@ -59,4 +47,16 @@ serve = [
     "falcon",
     "starlette",
     "uvicorn",
+]
+
+runtime = [
+    "psycopg != 3.3.0",
+    "async-timeout",
+    "python-dotenv",
+    "jinja2",
+    "pyYAML>=5.1",
+    "psutil",
+    "PyICU",
+    "mwparserfromhell",
+    "SQLAlchemy[asyncio]>=1.4.31",
 ]


### PR DESCRIPTION
## Summary
- Add a root `pyproject.toml` with uv workspace configuration and dev dependency groups, enabling contributors to use uv as an alternative to the existing virtualenv + pip workflow.
- Add documentation for using uv in the dev environment setup.

### How it works
Contributors using uv can set up their env with a single command:
```sh
uv sync
# This installs runtime dependencies (from the package pyproject.toml files)
# and all dev tools (pytest, mypy, flake8, mkdocs, etc.) into a local .venv.

# Individual groups can be installed separately:
uv sync --group test --no-dev    # Only test dependencies
uv sync --group docs --no-dev    # Only docs dependencies
uv sync --group serve --no-dev   # Only server dependencies
```

**NOTE:** uv.lock is in .gitignore as per project policy.... each developer resolves dependencies locally. For more info refer to the thread https://github.com/osm-search/Nominatim/discussions/4044

## AI usage
None

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
