### PR TITLE
Force installation of async requirement for SQLAlchemy

### DIFF
--- a/packaging/nominatim-api/pyproject.toml
+++ b/packaging/nominatim-api/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "async-timeout",
     "python-dotenv",
     "pyYAML>=5.1",
-    "SQLAlchemy>=1.4.31",
+    "SQLAlchemy[asyncio]>=1.4.31",
     "psycopg",
     "PyICU"
 ]


### PR DESCRIPTION
SQLAlchemy 2.1+ won't install greenlet anymore automatically, so make the asyncio version part of the requirements.