### PR TITLE
Refuse to link boundary and places with wikidata mismatch

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -347,6 +347,8 @@ BEGIN
         AND placex.osm_type = 'N'
         AND (placex.linked_place_id is null or placex.linked_place_id = bnd.place_id)
         AND placex.rank_search < 26 -- needed to select the right index
+        AND (NOT placex.extratags ? 'wikidata' OR NOT bnd.extratags ? 'wikidata'
+             OR placex.extratags->'wikidata' = bnd.extratags->'wikidata')
         AND ST_Covers(bnd.geometry, placex.geometry)
     LOOP
       {% if debug %}RAISE WARNING 'Found type-matching place node %', linked_placex.osm_id;{% endif %}
@@ -370,6 +372,8 @@ BEGIN
         AND placex.class = 'place'
         AND (placex.linked_place_id is null or placex.linked_place_id = bnd.place_id)
         AND placex.rank_search < 26 -- needed to select the right index
+        AND (placex.extratags->'wikidata' is null OR bnd.extratags->'wikidata' is null
+             OR placex.extratags->'wikidata' = bnd.extratags->'wikidata')
         AND ST_Covers(bnd.geometry, placex.geometry)
     LOOP
       {% if debug %}RAISE WARNING 'Found matching place node %', linked_placex.osm_id;{% endif %}

--- a/test/bdd/features/db/import/linking.feature
+++ b/test/bdd/features/db/import/linking.feature
@@ -297,6 +297,40 @@ Feature: Linking of places
          | R1         | LabelPlace |
 
 
+    Scenario: Boundaries and places do not link by name when wikidata mismatches
+        Given the 0.05 grid
+         | 1 |   | 2 |
+         |   | 9 |   |
+         | 4 |   | 3 |
+        Given the places
+         | osm | class    | type           | extra+wikidata | name | admin | geometry    |
+         | R1  | boundary | administrative | Q34            | Foo  | 8     | (1,2,3,4,1) |
+        And the places
+         | osm | class    | type           | extra+wikidata | name |
+         | N9  | place    | city           | Q35            | Foo  |
+        When importing
+        Then placex contains
+         | object     | linked_place_id |
+         | N9         | - |
+
+
+    Scenario: Boundaries and places link by name when wikidata matches
+        Given the 0.05 grid
+         | 1 |   | 2 |
+         |   | 9 |   |
+         | 4 |   | 3 |
+        Given the places
+         | osm | class    | type           | extra+wikidata | name | admin | geometry    |
+         | R1  | boundary | administrative | Q34            | Foo  | 8     | (1,2,3,4,1) |
+        And the places
+         | osm | class    | type           | extra+wikidata | name |
+         | N9  | place    | city           | Q34            | Foo  |
+        When importing
+        Then placex contains
+         | object     | linked_place_id |
+         | N9         | R1 |
+
+
     @skip
     Scenario: Linked places expand default language names
         Given the grid


### PR DESCRIPTION
When trying to link boundaries and place nodes via their name, ignore possible matches when both objects have wikidata tags and the values differ. This should prevent false positive matches where town and suburb have similar names.

Fixes #4037.