### PR TITLE
Update Rwanda language priority to rw, en, fr

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1495,7 +1495,7 @@ ru:
 # Rwanda (Rwanda)
 rw:
     partition: 102
-    languages: rw, fr, en
+    languages: rw, en, fr
     names: !include country-names/rw.yaml
     postcode: no
 


### PR DESCRIPTION
## Summary

Rwanda's language policy underwent a significant shift beginning in 2009 when the government transitioned the entire education system from French to English medium. English is now the primary language of government, education, business, and public administration alongside Kinyarwanda.

The current language ordering for Rwanda (`rw, fr, en`) reflects the pre-transition era and no longer matches ground truth. This PR updates it to `rw, en, fr`.

### Evidence

- Rwanda's revised Constitution (2003, amended 2015), Article 5: official languages are Kinyarwanda, English, French, and Swahili - in that order
- In 2009, Rwanda switched the entire education system to English medium, replacing French ([The Guardian, 2008](https://www.theguardian.com/world/2008/oct/14/rwanda-france))
- English is now the **sole medium of instruction** from primary school through university ([Wikipedia: Languages of Rwanda](https://en.wikipedia.org/wiki/Languages_of_Rwanda))
- There is a clear generational shift: most post-2000 Rwandans speak English, not French. French speakers are predominantly the pre-1994 generation educated under the Francophone system
- Rwanda joined the Commonwealth in 2009 and the East African Community (an English-speaking bloc)
- Street addressing was redesigned using English descriptors ("KG 1 Street", "KN 3 Avenue") rather than French ("Rue", "Boulevard")
- Government services ([Irembo](https://irembo.gov.rw)), legislation, and official communications are conducted primarily in English
- French has been effectively relegated to third-language status ([Wikipedia: Geographical distribution of French speakers](https://en.wikipedia.org/wiki/Geographical_distribution_of_French_speakers))

### Impact

With `fr` ordered before `en`, Nominatim defaults to French labels for Rwandan features that lack explicit language-tagged names, resulting in French geographic terms (Lac, Rivière, Colline, Marais) appearing in contexts where English equivalents (Lake, River, Hill, Wetland) better reflect current usage on the ground.

## AI usage

AI (Claude) was used to help draft the PR description text. The factual claims were verified against the linked sources. The code change itself (one line in `country_settings.yaml`) was written manually.

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description