### PR TITLE
Adapt address ranking for various countries

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -126,6 +126,13 @@
       }
   }
 },
+{ "countries" : [ "au" ],
+  "tags" : {
+      "boundary" : {
+          "administrative6": [12, 0]
+      }
+  }
+},
 { "countries" : [ "ca" ],
   "tags" : {
       "place" : {

--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -170,6 +170,15 @@
       }
   }
 },
+{ "countries" : [ "br" ],
+  "tags" : {
+      "boundary" : {
+          "administrative5" : [10, 0],
+          "administrative6" : [12, 0],
+          "administrative7" : [14, 0]
+      }
+  }
+},
 { "countries" : ["se", "no"],
   "tags" : {
       "place" : {

--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -133,6 +133,18 @@
       }
   }
 },
+{ "countries": [ "cz" ],
+  "tags" : {
+      "boundary" : {
+          "administrative5": 12,
+          "administrative6": [13, 0],
+          "administrative7": [14, 0],
+          "administrative8": 14,
+          "administrative9": 15,
+          "administrative10": 16
+      }
+  }
+},
 { "countries" : [ "de" ],
   "tags" : {
       "place" : {


### PR DESCRIPTION
Czech Republic: removes the newly added SO ORP and SO POU boundaries from the address hierarchy and slightly adapts the levels for municipalities and villages. See #4059.

Brazil: removes the [Intermediate, Immediate and Metropolic Regions](https://en.wikipedia.org/wiki/Intermediate_and_Immediate_Geographic_Regions) from the address hierarchy. These seem to be purely administrative and their long names make geocoding in Brazil really slow.

Australia: remove LGA boundaries as discussed in https://community.openstreetmap.org/t/administrative-boundaries-for-non-administrative-areas-in-sydney-and-melbourne/140931

Fixes #3935.
