### PR TITLE
Make sure right index is hit when updating associatedStreet relations

### DIFF
--- a/lib-sql/functions.sql
+++ b/lib-sql/functions.sql
@@ -23,3 +23,4 @@
 {% endif %}
 
 {% include('functions/partition-functions.sql') %}
+{% include('functions/associated_street_triggers.sql') %}

--- a/lib-sql/functions/associated_street_triggers.sql
+++ b/lib-sql/functions/associated_street_triggers.sql
@@ -1,0 +1,41 @@
+-- SPDX-License-Identifier: GPL-2.0-only
+--
+-- This file is part of Nominatim. (https://nominatim.org)
+--
+-- Copyright (C) 2026 by the Nominatim developer community.
+-- For a full list of authors see the git log.
+
+-- Trigger functions for associated street relations.
+
+
+-- Invalidates house members of associatedStreet relations
+-- whenever the place_associated_street table is modified.
+-- osm2pgsql flex handles updates as DELETE-all + re-INSERT, so each
+-- row-level trigger call covers exactly one member.
+CREATE OR REPLACE FUNCTION invalidate_associated_street_members()
+  RETURNS TRIGGER
+  AS $$
+DECLARE
+  object RECORD;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    object := OLD;
+  ELSE
+    object := NEW;
+  END IF;
+
+  IF object.member_role = 'house' THEN
+    {% for otype in ('N', 'W', 'R') %}
+    IF object.member_type = '{{ otype }}' THEN
+      UPDATE placex SET indexed_status = 2
+       WHERE osm_type = '{{ otype }}'
+         AND osm_id = object.member_id
+         AND indexed_status = 0;
+    END IF;
+    {% endfor %}
+  END IF;
+
+  RETURN object;
+END;
+$$
+LANGUAGE plpgsql;

--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -1397,33 +1397,3 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-
-
--- Invalidates house members of associatedStreet relations
--- whenever the place_associated_street table is modified.
--- osm2pgsql flex handles updates as DELETE-all + re-INSERT, so each
--- row-level trigger call covers exactly one member.
-CREATE OR REPLACE FUNCTION invalidate_associated_street_members()
-  RETURNS TRIGGER
-  AS $$
-DECLARE
-  object RECORD;
-BEGIN
-  IF TG_OP = 'DELETE' THEN
-    object := OLD;
-  ELSE
-    object := NEW;
-  END IF;
-
-  IF object.member_role = 'house' THEN
-    UPDATE placex
-       SET indexed_status = 2
-     WHERE osm_type = object.member_type
-       AND osm_id = object.member_id
-       AND indexed_status = 0;
-  END IF;
-
-  RETURN object;
-END;
-$$
-LANGUAGE plpgsql;

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -496,3 +496,14 @@ def create_place_associated_street_table(conn: Connection, **_: Any) -> None:
             CREATE INDEX place_associated_street_relation_id_idx
               ON place_associated_street USING BTREE (relation_id);
         """)
+
+
+@_migration(5, 3, 99, 0)
+def create_associated_street_triggers(conn: Connection, config: Configuration, **_: Any) -> None:
+    """ Create triggers for tables on associated street tables.
+    """
+    SQLPreprocessor(conn, config).run_sql_file(conn, 'functions/associated_street_triggers.sql')
+    with conn.cursor() as cur:
+        cur.execute("""CREATE OR REPLACE TRIGGER place_associated_street_update
+                       AFTER INSERT OR DELETE ON place_associated_street
+                       FOR EACH ROW EXECUTE FUNCTION invalidate_associated_street_members()""")

--- a/src/nominatim_db/version.py
+++ b/src/nominatim_db/version.py
@@ -55,7 +55,7 @@ def parse_version(version: str) -> NominatimVersion:
     return NominatimVersion(*[int(x) for x in parts[:2] + parts[2].split('-')])
 
 
-NOMINATIM_VERSION = parse_version('5.3.0-0')
+NOMINATIM_VERSION = parse_version('5.3.99-0')
 
 POSTGRESQL_REQUIRED_VERSION = (12, 0)
 POSTGIS_REQUIRED_VERSION = (3, 0)


### PR DESCRIPTION
Fixes the update query to use hard-coded OSM types, so that the partial indexes over OSM IDs are hit.

Also adds another migration to set up the triggers for the associated street table.

Fixes #4070.