### PR TITLE
Fix failure on non-null constraint when marking place for delete

### DIFF
--- a/lib-sql/functions/place_triggers.sql
+++ b/lib-sql/functions/place_triggers.sql
@@ -239,7 +239,7 @@ BEGIN
   END IF;
 
   INSERT INTO place_to_be_deleted (osm_type, osm_id, class, type, deferred)
-    VALUES(OLD.osm_type, OLD.osm_id, OLD.class, OLD.type, deferred);
+    VALUES(OLD.osm_type, OLD.osm_id, OLD.class, OLD.type, COALESCE(deferred, FALSE));
 
   RETURN NULL;
 END;


### PR DESCRIPTION
If a place is deleted that was present in the place table but not in the placex table, the update code hits a non-null constraint because it cannot determine if the place needs to be deferred.

Error message encountered:

```
Processing: Node(344k 49.1k/s) Way(11k 11.00k/s) Relation(0 0.0/s)
2026-04-18 17:22:33  ERROR: DB copy thread failed: Database error: ERROR:  null value in column "deferred" of relation "place_to_be_deleted" violates not-null constraint
DETAIL:  Failing row contains (W, 1030038114, boundary, administrative, null).
CONTEXT:  SQL statement "INSERT INTO place_to_be_deleted (osm_type, osm_id, class, type, deferred)
    VALUES(OLD.osm_type, OLD.osm_id, OLD.class, OLD.type, deferred)"
PL/pgSQL function place_delete() line 15 at SQL statement
```