### PR TITLE
Add partial property for tokenizer

### DIFF
--- a/lib-sql/tokenizer/icu_tokenizer.sql
+++ b/lib-sql/tokenizer/icu_tokenizer.sql
@@ -217,6 +217,33 @@ END;
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION getorcreate_partial_words(lookup_terms TEXT[],
+                                                    OUT partial_tokens INT[])
+  AS $$
+DECLARE
+  term TEXT;
+  term_id INTEGER;
+BEGIN
+  partial_tokens := '{}'::INT[];
+  FOR term IN
+    SELECT DISTINCT trim(unnest(string_to_array(unnest(lookup_terms), ' ')))
+  LOOP
+    SELECT min(word_id) INTO term_id
+      FROM word WHERE word_token = term and type = 'w';
+
+    IF term_id IS NULL THEN
+      term_id := nextval('seq_word');
+      INSERT INTO word (word_id, word_token, type)
+        VALUES (term_id, term, 'w');
+    END IF;
+
+    partial_tokens := array_merge(partial_tokens, ARRAY[term_id]);
+  END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+
 
 CREATE OR REPLACE FUNCTION getorcreate_partial_word(partial TEXT)
   RETURNS INTEGER

--- a/src/nominatim_db/data/place_info.py
+++ b/src/nominatim_db/data/place_info.py
@@ -78,3 +78,8 @@ class PlaceInfo:
         return self.rank_address == 4 \
             and self.is_a('boundary', 'administrative') \
             and self.country_code is not None
+
+    def is_street(self) -> bool:
+        """ Return True when the place is a street object.
+        """
+        return 26 <= self.rank_address <= 27

--- a/src/nominatim_db/data/place_name.py
+++ b/src/nominatim_db/data/place_name.py
@@ -22,9 +22,17 @@ class PlaceName:
 
         In addition to that, a name may have arbitrary additional attributes.
         How attributes are used, depends on the sanitizers and token analysers.
-        The exception is the 'analyzer' attribute. This attribute determines
-        which token analysis module will be used to finalize the treatment of
-        names.
+
+        The default ICU token analyser currently understands the following
+        additional properties:
+
+        * `analyzer` determines which token analysis module will be used to
+           finalize the treatment of names.
+        * `partial` marks a name that is not a full name in itself but may
+          rarely appear in conjunction with the other names. Can be used to
+          allow prefixes and suffixes to be recognised but not found on their
+          own. Matches against such a partial match will always be lower ranked
+          than full name matches.
     """
 
     def __init__(self, name: str, kind: str, suffix: Optional[str],

--- a/src/nominatim_db/data/place_name.py
+++ b/src/nominatim_db/data/place_name.py
@@ -2,12 +2,12 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Data class for a single name of a place.
 """
-from typing import Optional, Dict, Mapping
+from typing import Optional, Mapping
 
 
 class PlaceName:
@@ -27,11 +27,12 @@ class PlaceName:
         names.
     """
 
-    def __init__(self, name: str, kind: str, suffix: Optional[str]):
+    def __init__(self, name: str, kind: str, suffix: Optional[str],
+                 attr: Optional[dict[str, str]] = None):
         self.name = name
         self.kind = kind
         self.suffix = suffix
-        self.attr: Dict[str, str] = {}
+        self.attr: dict[str, str] = {} if attr is None else attr
 
     def __repr__(self) -> str:
         return f"PlaceName(name={self.name!r},kind={self.kind!r},suffix={self.suffix!r})"

--- a/src/nominatim_db/tokenizer/icu_tokenizer.py
+++ b/src/nominatim_db/tokenizer/icu_tokenizer.py
@@ -622,12 +622,15 @@ class ICUNameAnalyzer(AbstractAnalyzer):
 
         for name in names:
             analyzer_id = name.get_attr('analyzer')
+            is_partial = name.get_attr('partial')
             analyzer = self.token_analysis.get_analyzer(analyzer_id)
             word_id = analyzer.get_canonical_id(name)
             if analyzer_id is None:
                 token_id = word_id
             else:
                 token_id = f'{word_id}@{analyzer_id}'
+            if is_partial:
+                token_id += '@@part'
 
             tokens = self._cache.names.get(token_id)
             if tokens is None:
@@ -640,9 +643,14 @@ class ICUNameAnalyzer(AbstractAnalyzer):
                     continue
 
                 with self.conn.cursor() as cur:
-                    cur.execute("""SELECT partial_tokens || full_token
-                                   FROM getorcreate_full_word(%s, %s, %s)""",
-                                (token_id, variants, lookups))
+                    if is_partial:
+                        cur.execute("SELECT * FROM getorcreate_partial_words(%s)",
+                                    (variants,))
+                    else:
+                        cur.execute("""SELECT partial_tokens || full_token
+                                       FROM getorcreate_full_word(%s, %s, %s)""",
+                                    (token_id, variants, lookups))
+
                     tokens = cast(tuple[list[int]], cur.fetchone())[0]
 
                 self._cache.names[token_id] = tokens


### PR DESCRIPTION
This adds support for tagging a name with a `partial` attribute. For such a name only the partial terms will be added to the search index, not the full term. The effect of this is that the name can be found, including in conjunction with other name of the place, but will not be boosted as a full word. This can be useful for optional prefixes and suffixes.
