### PR TITLE
Fix display of rank 11 boundaries

### DIFF
--- a/src/nominatim_api/results.py
+++ b/src/nominatim_api/results.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Dataclasses for search results and helper functions to fill them.
@@ -594,7 +594,7 @@ async def complete_address_details(conn: SearchConnection, results: List[BaseRes
                     t.c.place_id, t.c.osm_type, t.c.osm_id, t.c.name,
                     t.c.class_, t.c.type, t.c.extratags,
                     t.c.admin_level, taddr.c.fromarea,
-                    sa.case((t.c.rank_address == 11, 5),
+                    sa.case((t.c.type == 'postcal_code', 5),
                             else_=t.c.rank_address).label('rank_address'),
                     taddr.c.distance, t.c.country_code, t.c.postcode)\
             .join(taddr, sa.or_(taddr.c.place_id == ltab.c.value['pid'].as_integer(),


### PR DESCRIPTION
Address ranks 11 and 5 used to be exclusively used for postcodes. It can however happen that a administrative boundary gets shifted to address rank 11 when there are shifts due to odd level combinations.

This changes the hack for changing the output rank address to level 5 to only work on postal boundaries so that admin boundaries at rank 11 come out correctly as state district boundaries.

Imports done with 5.3.2 and later won't have postal boundaries anymore. This piece of code just remains for backward compatibility with databases imported before 5.3.2.

Fixes #4084.
