### PR TITLE
Remove ranking exceptions for Slovakia

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -255,19 +255,6 @@
       }
   }
 },
-{ "countries" : ["sk"],
-  "tags" : {
-      "boundary" : {
-          "administrative5" : [10, 0],
-          "administrative6" : 11,
-          "administrative7" : [11, 0],
-          "administrative8" : 12,
-          "administrative9" : 16,
-          "administrative10" : 18,
-          "administrative11" : 20
-      }
-  }
-},
 { "countries" : ["jp"],
   "tags" : {
       "boundary" : {


### PR DESCRIPTION
The Slovakian community is busy [reorganising their admin boundaries](https://wiki.openstreetmap.org/wiki/Mechanical_Edits/Fjana/reorganization_of_boundaries_in_Slovakia). The new system is much closer to Nominatim's assumptions about admin levels. So we can get rid of all special rules for Slovakia.

Please note that the reorganisation is still ongoing. So you might want to hold off a bit reindexing all of the country with the new rules.