### PR TITLE
Use locale-aware names for search result reranking

### DIFF
--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -175,6 +175,28 @@ class ForwardGeocoder:
 
         return final
 
+    def _get_result_rerank_text(self, result: SearchResult) -> str:
+        if not self.params.locales:
+            return result.display_name or ''
+
+        label_parts: List[str] = []
+        if result.address_rows:
+            for line in result.address_rows:
+                if line.isaddress and line.names:
+                    address_name = self.params.locales.display_name(line.names)
+                    if address_name and (
+                        not label_parts or label_parts[-1] != address_name
+                    ):
+                        label_parts.append(address_name)
+
+        if label_parts:
+            return ', '.join(label_parts)
+
+        if result.names:
+            return self.params.locales.display_name(result.names)
+
+        return result.display_name or ''
+
     def rerank_by_query(self, query: QueryStruct, results: SearchResults) -> None:
         """ Adjust the accuracy of the localized result according to how well
             they match the original query.
@@ -192,8 +214,12 @@ class ForwardGeocoder:
                or (result.importance is not None and result.importance < 0):
                 continue
             distance = 0.0
-            norm = self.query_analyzer.normalize_text(' '.join((result.display_name,
-                                                                result.country_code or '')))
+            # Use locale-aware text for word matching so that translated names
+            # (e.g., name:en) are included in the match pool.
+            rerank_text = self._get_result_rerank_text(result)
+            norm = self.query_analyzer.normalize_text(
+                ' '.join((rerank_text, result.country_code or ''))
+            )
             words = set((w for w in re.split('[-,: ]+', norm) if w))
             if not words:
                 continue

--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -7,7 +7,7 @@
 """
 Public interface to the search code.
 """
-from typing import List, Any, Optional, Iterator, Tuple, Dict, Set
+from typing import List, Any, Optional, Iterator, Tuple, Dict
 import itertools
 import re
 import difflib
@@ -175,11 +175,11 @@ class ForwardGeocoder:
 
         return final
 
-    def _get_result_rerank_text(self, result: SearchResult) -> Set[str]:
+    def _get_result_rerank_text(self, result: SearchResult) -> set[str]:
         if not self.params.locales:
             return {result.display_name} if result.display_name else set()
 
-        label_parts: Set[str] = set()
+        label_parts: set[str] = set()
         if result.address_rows:
             for line in result.address_rows:
                 if line.isaddress and line.names:

--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -7,7 +7,7 @@
 """
 Public interface to the search code.
 """
-from typing import List, Any, Optional, Iterator, Tuple, Dict
+from typing import List, Any, Optional, Iterator, Tuple, Dict, Set
 import itertools
 import re
 import difflib
@@ -175,27 +175,25 @@ class ForwardGeocoder:
 
         return final
 
-    def _get_result_rerank_text(self, result: SearchResult) -> str:
+    def _get_result_rerank_text(self, result: SearchResult) -> Set[str]:
         if not self.params.locales:
-            return result.display_name or ''
+            return {result.display_name} if result.display_name else set()
 
-        label_parts: List[str] = []
+        label_parts: Set[str] = set()
         if result.address_rows:
             for line in result.address_rows:
                 if line.isaddress and line.names:
                     address_name = self.params.locales.display_name(line.names)
-                    if address_name and (
-                        not label_parts or label_parts[-1] != address_name
-                    ):
-                        label_parts.append(address_name)
+                    if address_name:
+                        label_parts.add(address_name)
 
         if label_parts:
-            return ', '.join(label_parts)
+            return label_parts
 
         if result.names:
-            return self.params.locales.display_name(result.names)
+            return {self.params.locales.display_name(result.names)}
 
-        return result.display_name or ''
+        return {result.display_name} if result.display_name else set()
 
     def rerank_by_query(self, query: QueryStruct, results: SearchResults) -> None:
         """ Adjust the accuracy of the localized result according to how well
@@ -218,7 +216,7 @@ class ForwardGeocoder:
             # (e.g., name:en) are included in the match pool.
             rerank_text = self._get_result_rerank_text(result)
             norm = self.query_analyzer.normalize_text(
-                ' '.join((rerank_text, result.country_code or ''))
+                ' '.join((*rerank_text, result.country_code or ''))
             )
             words = set((w for w in re.split('[-,: ]+', norm) if w))
             if not words:
@@ -233,13 +231,11 @@ class ForwardGeocoder:
             # to offset this.
             if result.rank_address == 4:
                 if self.params.locales and result.names:
-                    loc_names = [result.names[t] for t in self.params.locales.name_tags
-                                 if t in result.names]
-                    if loc_names:
-                        norm_loc = self.query_analyzer.normalize_text(' '.join(loc_names))
-                        loc_words = set(w for w in re.split('[-,: ]+', norm_loc) if w)
-                        if loc_words and loc_words.isdisjoint(qwords):
-                            result.accuracy += result.calculated_importance() * 0.5
+                    # Exclude country code from disjoint check
+                    check_words = (words - {result.country_code.lower()}) \
+                        if result.country_code else words
+                    if check_words and check_words.isdisjoint(qwords):
+                        result.accuracy += result.calculated_importance() * 0.5
                 else:
                     distance *= 2
             result.accuracy += distance * 0.3 / sum(len(w) for w in qwords)

--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -204,6 +204,7 @@ class ForwardGeocoder:
                   for word in re.split('[-,: ]+', phrase.text) if word]
         if not qwords:
             return
+        norm_query = self.query_analyzer.normalize_text(' '.join(qwords))
 
         for result in results:
             # Negative importance indicates ordering by distance, which is
@@ -231,12 +232,13 @@ class ForwardGeocoder:
             # to offset this.
             if result.rank_address == 4:
                 if self.params.locales and result.names:
-                    locale_name = self.params.locales.display_name(result.names)
-                    if locale_name:
-                        norm_name = self.query_analyzer.normalize_text(locale_name)
-                        norm_query = self.query_analyzer.normalize_text(' '.join(qwords))
-                        if norm_query != norm_name:
-                            result.accuracy += result.calculated_importance() * 0.5
+                    country_names = {self.query_analyzer.normalize_text(result.names[t])
+                                     for t in self.params.locales.name_tags
+                                     if t in result.names}
+                    if result.country_code:
+                        country_names.add(result.country_code)
+                    if norm_query not in country_names:
+                        result.accuracy += result.calculated_importance() * 0.5
                 else:
                     distance *= 2
             result.accuracy += distance * 0.3 / sum(len(w) for w in qwords)

--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -231,11 +231,12 @@ class ForwardGeocoder:
             # to offset this.
             if result.rank_address == 4:
                 if self.params.locales and result.names:
-                    # Exclude country code from disjoint check
-                    check_words = (words - {result.country_code.lower()}) \
-                        if result.country_code else words
-                    if check_words and check_words.isdisjoint(qwords):
-                        result.accuracy += result.calculated_importance() * 0.5
+                    locale_name = self.params.locales.display_name(result.names)
+                    if locale_name:
+                        norm_name = self.query_analyzer.normalize_text(locale_name)
+                        norm_query = self.query_analyzer.normalize_text(' '.join(qwords))
+                        if norm_query != norm_name:
+                            result.accuracy += result.calculated_importance() * 0.5
                 else:
                     distance *= 2
             result.accuracy += distance * 0.3 / sum(len(w) for w in qwords)

--- a/test/bdd/features/db/query/search_simple.feature
+++ b/test/bdd/features/db/query/search_simple.feature
@@ -100,3 +100,17 @@ Feature: Searching of simple objects
         Then result 0 contains
          | object |
          | N10    |
+
+    # github #3871
+    Scenario: Localized result name is used for reranking
+        Given the places
+         | osm | class | type | name+name | name+name:en | geometry   |
+         | N1  | place | city | Αθήνα     | Athens       | country:gr |
+         | N2  | place | town | Athens    |              | country:us |
+        When importing
+        And geocoding "Athens"
+         | accept-language |
+         | en              |
+        Then result 0 contains
+         | object |
+         | N1     |

--- a/test/bdd/features/db/query/search_simple.feature
+++ b/test/bdd/features/db/query/search_simple.feature
@@ -114,3 +114,9 @@ Feature: Searching of simple objects
         Then result 0 contains
          | object |
          | N1     |
+        When geocoding "Athens"
+         | accept-language |
+         | de              |
+        Then result 0 contains
+         | object |
+         | N2     |


### PR DESCRIPTION
## Summary
<!-- Describe the purpose of your pull request and, if present, link to existing issues. -->
Searching for "Athens" with `accept-language: en` returned **Athens, Georgia, US** before **Athens, Greece** because the reranking logic used `display_name` for word matching, which returned the local Greek name "Αθήνα". This caused a distance penalty for Athens, Greece since "Athens" had no match in the word set.

 Introduce `_get_result_rerank_text()` which builds the reranking text using locale-aware name resolution via `locales.display_name()`. This ensures that translated name variants (e.g., `name:en`) are included in the word matching pool when the caller specifies a language preference.

closes  #3871 #4062 

## AI usage
None

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
