### PR TITLE
Add sanitizer for suspicious ref values

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -127,7 +127,7 @@ jobs:
               if: matrix.dependencies == 'pip'
 
             - name: Python static typechecking
-              run: ../venv/bin/python -m mypy --strict --python-version 3.9 src
+              run: ../venv/bin/python -m mypy --strict --python-version 3.10 src
               working-directory: Nominatim
               if: matrix.dependencies == 'pip'
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-api:
 tests: mypy lint pytest bdd
 
 mypy:
-	mypy --strict --python-version 3.9 src
+	mypy --strict --python-version 3.10 src
 
 pytest:
 	pytest test/python

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -43,6 +43,11 @@ sanitizers:
     - step: clean-tiger-tags
     - step: split-name-list
       delimiters: ;
+    - step: delete-tags
+      filter-kind: ref
+      name:
+        - ".*,.*"
+        - ".{41,}"
     - step: strip-brace-terms
     - step: tag-analyzer-by-language
       filter-kind: [".*name.*"]

--- a/src/nominatim_db/config.py
+++ b/src/nominatim_db/config.py
@@ -202,7 +202,7 @@ class Configuration:
         if dsn.startswith('pgsql:'):
             return dict((p.split('=', 1) for p in dsn[6:].split(';')))
 
-        return conninfo_to_dict(dsn)  # type: ignore
+        return conninfo_to_dict(dsn)
 
     def get_import_style_file(self) -> Path:
         """ Return the import style file as a path object. Translates the

--- a/src/nominatim_db/db/connection.py
+++ b/src/nominatim_db/db/connection.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Specialised connection and cursor functions.
@@ -15,7 +15,7 @@ import psycopg
 import psycopg.types.hstore
 from psycopg import sql as pysql
 
-from ..typing import SysEnv
+from ..typing import SysEnv, QueryNoTemplate
 from ..errors import UsageError
 
 LOG = logging.getLogger()
@@ -24,7 +24,7 @@ Cursor = psycopg.Cursor[Any]
 Connection = psycopg.Connection[Any]
 
 
-def execute_scalar(conn: Connection, sql: psycopg.abc.Query, args: Any = None) -> Any:
+def execute_scalar(conn: Connection, sql: QueryNoTemplate, args: Any = None) -> Any:
     """ Execute query that returns a single value. The value is returned.
         If the query yields more than one row, a ValueError is raised.
     """

--- a/src/nominatim_db/db/query_pool.py
+++ b/src/nominatim_db/db/query_pool.py
@@ -14,9 +14,11 @@ import time
 
 import psycopg
 
+from ..typing import QueryNoTemplate
+
 LOG = logging.getLogger()
 
-QueueItem = Optional[Tuple[psycopg.abc.Query, Any]]
+QueueItem = Optional[Tuple[QueryNoTemplate, Any]]
 
 
 class QueryPool:
@@ -34,7 +36,7 @@ class QueryPool:
         self.pool = [asyncio.create_task(self._worker_loop_cancellable(dsn, **conn_args))
                      for _ in range(pool_size)]
 
-    async def put_query(self, query: psycopg.abc.Query, params: Any) -> None:
+    async def put_query(self, query: QueryNoTemplate, params: Any) -> None:
         """ Schedule a query for execution.
         """
         if self.is_cancelled:

--- a/src/nominatim_db/indexer/runners.py
+++ b/src/nominatim_db/indexer/runners.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Mix-ins that provide the actual commands for the indexer for various indexing
@@ -11,11 +11,10 @@ tasks.
 from typing import Any, Sequence
 
 from psycopg import sql as pysql
-from psycopg.abc import Query
 from psycopg.rows import DictRow
 from psycopg.types.json import Json
 
-from ..typing import Protocol
+from ..typing import Protocol, QueryNoTemplate
 from ..data.place_info import PlaceInfo
 from ..tokenizer.base import AbstractAnalyzer
 
@@ -30,9 +29,9 @@ def _analyze_place(place: DictRow, analyzer: AbstractAnalyzer) -> Json:
 
 class Runner(Protocol):
     def name(self) -> str: ...
-    def sql_count_objects(self) -> Query: ...
-    def sql_get_objects(self) -> Query: ...
-    def index_places_query(self, batch_size: int) -> Query: ...
+    def sql_count_objects(self) -> QueryNoTemplate: ...
+    def sql_get_objects(self) -> QueryNoTemplate: ...
+    def index_places_query(self, batch_size: int) -> QueryNoTemplate: ...
     def index_places_params(self, place: DictRow) -> Sequence[Any]: ...
 
 
@@ -50,7 +49,7 @@ class AbstractPlacexRunner:
         self.rank = rank
         self.analyzer = analyzer
 
-    def index_places_query(self, batch_size: int) -> Query:
+    def index_places_query(self, batch_size: int) -> QueryNoTemplate:
         return pysql.SQL(
             """ UPDATE placex
                 SET indexed_status = 0, address = v.addr, token_info = v.ti,
@@ -94,14 +93,14 @@ class BoundaryRunner(AbstractPlacexRunner):
     def name(self) -> str:
         return f"boundaries rank {self.rank}"
 
-    def sql_count_objects(self) -> Query:
+    def sql_count_objects(self) -> QueryNoTemplate:
         return pysql.SQL("""SELECT count(*) FROM placex
                             WHERE indexed_status > 0
                               AND rank_search = {}
                               AND class = 'boundary' and type = 'administrative'
                          """).format(pysql.Literal(self.rank))
 
-    def sql_get_objects(self) -> Query:
+    def sql_get_objects(self) -> QueryNoTemplate:
         return SELECT_SQL.format(pysql.SQL(
                 """WHERE placex.indexed_status > 0 and placex.rank_search = {}
                          and placex.class = 'boundary' and placex.type = 'administrative'
@@ -120,17 +119,17 @@ class InterpolationRunner:
     def name(self) -> str:
         return "interpolation lines (location_property_osmline)"
 
-    def sql_count_objects(self) -> Query:
+    def sql_count_objects(self) -> QueryNoTemplate:
         return """SELECT count(*) FROM location_property_osmline
                   WHERE indexed_status > 0"""
 
-    def sql_get_objects(self) -> Query:
+    def sql_get_objects(self) -> QueryNoTemplate:
         return """SELECT place_id, get_interpolation_address(address, osm_id) as address
                   FROM location_property_osmline
                   WHERE indexed_status > 0
                   ORDER BY geometry_sector"""
 
-    def index_places_query(self, batch_size: int) -> Query:
+    def index_places_query(self, batch_size: int) -> QueryNoTemplate:
         return pysql.SQL("""UPDATE location_property_osmline
                             SET indexed_status = 0, address = v.addr, token_info = v.ti
                             FROM (VALUES {}) as v(id, addr, ti)
@@ -149,15 +148,15 @@ class PostcodeRunner(Runner):
     def name(self) -> str:
         return "postcodes (location_postcodes)"
 
-    def sql_count_objects(self) -> Query:
+    def sql_count_objects(self) -> QueryNoTemplate:
         return 'SELECT count(*) FROM location_postcodes WHERE indexed_status > 0'
 
-    def sql_get_objects(self) -> Query:
+    def sql_get_objects(self) -> QueryNoTemplate:
         return """SELECT place_id FROM location_postcodes
                   WHERE indexed_status > 0
                   ORDER BY country_code, postcode"""
 
-    def index_places_query(self, batch_size: int) -> Query:
+    def index_places_query(self, batch_size: int) -> QueryNoTemplate:
         return pysql.SQL("""UPDATE location_postcodes SET indexed_status = 0
                                     WHERE place_id IN ({})""")\
                     .format(pysql.SQL(',').join((pysql.Placeholder() for _ in range(batch_size))))

--- a/src/nominatim_db/tools/check_database.py
+++ b/src/nominatim_db/tools/check_database.py
@@ -20,7 +20,7 @@ from ..tokenizer import factory as tokenizer_factory
 from . import freeze
 from ..version import NOMINATIM_VERSION, parse_version
 
-CHECKLIST = []
+CHECKLIST: list[Any] = []
 
 
 class CheckState(Enum):

--- a/src/nominatim_db/typing.py
+++ b/src/nominatim_db/typing.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Type definitions for typing annotations.
@@ -38,7 +38,9 @@ if TYPE_CHECKING:
     from typing_extensions import (Protocol as Protocol,
                                    Final as Final,
                                    TypedDict as TypedDict)
+    from psycopg.abc import (QueryNoTemplate as QueryNoTemplate)
 else:
     Protocol = object
     Final = 'Final'
     TypedDict = dict
+    QueryNoTemplate = 'QueryNoTemplate'

--- a/test/bdd/features/db/import/naming.feature
+++ b/test/bdd/features/db/import/naming.feature
@@ -102,3 +102,17 @@ Feature: Import and search of names
         Then the result set contains
             | object |
             | N3  |
+
+
+    Scenario: ref tags with full address are not searchable
+        Given the places
+            | osm | class   | type    | name+ref                         | geometry |
+            | N1  | amenity | postbox | Hoopter Straße 207, 21423 Winsen | 23 45    |
+        When importing
+        Then placex contains
+            | object | name+ref                         |
+            | N1     | Hoopter Straße 207, 21423 Winsen |
+        And search_name contains exactly
+            | object |
+        When geocoding "Hoopter Straße"
+        Then exactly 0 results are returned


### PR DESCRIPTION
This uses the delete-tags sanitizer to prevent some suspiciously looking ref tags from being added to the search index.

Right now this is mainly for catching German post box ref tags [containing full addresses](https://wiki.openstreetmap.org/wiki/DE:Tag:amenity%3Dpost_box#Beispiel) but it will also drop refs that are overly long. This only affects the search index. The refs will still be shown in the output.

Also fixes some new mypy warnings and increases the forced Python version for mypy to 3.10 as this is the minimum supported version now.

Closes #2652.
