### PR TITLE
Allow importing areas for external postcode data

### DIFF
--- a/docs/customize/Postcodes.md
+++ b/docs/customize/Postcodes.md
@@ -1,31 +1,51 @@
 # External postcode data
 
-Nominatim creates a table of known postcode centroids during import. This table
-is used for searches of postcodes and for adding postcodes to places where the
-OSM data does not provide one. These postcode centroids are mainly computed
-from the OSM data itself. In addition, Nominatim supports reading postcode
-information from an external CSV file, to supplement the postcodes that are
-missing in OSM.
+Nominatim creates a table of known postcode centroids and geometries during import.
+This table is used for searches of postcodes and for adding postcodes to places where
+the OSM data does not provide one. These postcode centroids are mainly computed
+from the OSM data itself. In addition, Nominatim supports reading postcode information
+from external files to supplement the postcodes that are missing in OSM.
 
-To enable external postcode support, simply put one CSV file per country into
-your project directory and name it `<CC>_postcodes.csv`. `<CC>` must be the
-two-letter country code for which to apply the file. The file may also be
-gzipped. Then it must be called `<CC>_postcodes.csv.gz`.
+## Supported file formats
 
-The CSV file must use commas as a delimiter and have a header line. Nominatim
-expects three columns to be present: `postcode`, `lat` and `lon`. All other
-columns are ignored. `lon` and `lat` must describe the x and y coordinates of the
-postcode centroids in WGS84.
+Nominatim supports 2 data formats for external import:
 
-The postcode files are loaded only when there is data for the given country
-in your database. For example, if there is a `us_postcodes.csv` file in your
-project directory but you import only an excerpt of Italy, then the US postcodes
-will simply be ignored.
+### JSONL format
+
+The JSONL format may contain the postcode data along with a POLYGON or MULTIPOLYGON geometry
+of the postcode area. To enable external postcode support, put one file per country into
+your project directory and name it `<CC>_postcodes_geometry.<ext>`. `<CC>` must be the
+two-letter country code for which to apply the file. File type may be either `.jsonl` or
+`.jsonl.gz` (gzip compressed). The file must be in UTF-8 encoding and contain one JSON object
+per line with the following structure:
+
+#### GeoJSON Feature
+
+A standard [RFC7946](https://geojson.org) GeoJSON Feature object .
+
+* `geometry`: A GeoJSON geometry (Polygon/MultiPolygon).
+* `properties`: An object containing:
+  * `postcode`: (required) The postcode string.
+  * `lat`, `lon`: (optional) Coordinates for the centroid. If not provided, the centroid
+  is computed from the geometry. Thus centroid coordinates and geometry independently optional,
+  however at least one of them is required.
+
+### CSV format
+
+To enable external postcode support, put one file per country into
+your project directory and name it `<CC>_postcodes.<ext>`. `<CC>` must be the
+two-letter country code for which to apply the file. File type may be either `.csv` or `.csv.gz`
+(gzip compressed). The CSV file must use commas as a delimiter and have a header line. Nominatim
+expects three columns to be present: `postcode`, `lat` and `lon`. All other columns are ignored.
+`lon` and `lat` must describe the x and y coordinates of the postcode centroids in WGS84.
+
+The postcode area is assumed to be in a buffer around the centroid (typically 5km).
+
+## Usage
 
 As a rule, the external postcode data should be put into the project directory
 **before** starting the initial import. Still, you can add, remove and update the
-external postcode data at any time. Simply
-run:
+external postcode data at any time. Simply run:
 
 ```
 nominatim refresh --postcodes

--- a/lib-sql/tables/postcodes.sql
+++ b/lib-sql/tables/postcodes.sql
@@ -15,6 +15,7 @@ CREATE TABLE location_postcodes (
   indexed_date TIMESTAMP,
   country_code varchar(2) NOT NULL,
   postcode TEXT NOT NULL,
+  is_authoritative BOOLEAN NOT NULL DEFAULT FALSE,
   centroid GEOMETRY(Geometry, 4326) NOT NULL,
   geometry GEOMETRY(Geometry, 4326) NOT NULL
   );

--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import csv
 import gzip
 import logging
+import json
 from math import isfinite
 
 from psycopg import sql as pysql
@@ -59,9 +60,12 @@ class _PostcodeCollector:
         self.extent = default_extent
         self.exclude = exclude
         self.collected: Dict[str, PointsCentroid] = defaultdict(PointsCentroid)
+        self.geometries: Dict[str, str] = {}
+        self.is_authoritative: bool = False
         self.normalization_cache: Optional[Tuple[str, Optional[str]]] = None
 
-    def add(self, postcode: str, x: float, y: float) -> None:
+    def add(self, postcode: str, x: Optional[float], y: Optional[float],
+            extent: Optional[int] = None, geometry: Optional[str] = None) -> None:
         """ Add the given postcode to the collection cache. If the postcode
             already existed, it is overwritten with the new centroid.
         """
@@ -75,17 +79,27 @@ class _PostcodeCollector:
                 self.normalization_cache = (postcode, normalized)
 
             if normalized and normalized not in self.exclude:
-                self.collected[normalized] += (x, y)
+                if x is not None and y is not None:
+                    self.collected[normalized] += (x, y)
+                else:
+                    # Touch the collector to ensure the postcode is recorded
+                    self.collected[normalized]
 
-    def commit(self, conn: Connection, analyzer: AbstractAnalyzer,
-               project_dir: Optional[Path], is_initial: bool) -> None:
+                if geometry is not None:
+                    self.geometries[normalized] = geometry
+
+    def commit(self, conn: Connection, analyzer: AbstractAnalyzer, project_dir: Optional[Path],
+               is_initial: bool, use_geometry_file: Optional[bool]) -> None:
         """ Update postcodes for the country from the postcodes selected so far.
 
             When 'project_dir' is set, then any postcode files found in this
             directory are taken into account as well.
         """
         if project_dir is not None:
-            self._update_from_external(analyzer, project_dir)
+            if use_geometry_file:
+                self._update_from_external_geometry(analyzer, project_dir)
+            else:
+                self._update_from_external_centroid(analyzer, project_dir)
 
         if is_initial:
             to_delete = []
@@ -96,9 +110,21 @@ class _PostcodeCollector:
                             (self.country, ))
                 to_delete = [row[0] for row in cur if row[0] not in self.collected]
 
-        to_add = [dict(zip(('pc', 'x', 'y'), (k, *v.centroid())))
-                  for k, v in self.collected.items()]
+        to_add = []
+        for k, v in self.collected.items():
+            try:
+                x, y = v.centroid()
+            except ValueError:
+                x, y = None, None
+
+            geom = self.geometries.get(k)
+            if x is None and geom is None:
+                continue
+
+            to_add.append({'pc': k, 'x': x, 'y': y, 'geom': geom})
+
         self.collected = defaultdict(PointsCentroid)
+        self.geometries = {}
 
         LOG.info("Processing country '%s' (%s added, %s deleted).",
                  self.country, len(to_add), len(to_delete))
@@ -108,14 +134,18 @@ class _PostcodeCollector:
                 columns = ['country_code',
                            'rank_search',
                            'postcode',
+                           'is_authoritative',
                            'centroid',
                            'geometry']
                 values = [pysql.Literal(self.country),
                           pysql.Literal(_extent_to_rank(self.extent)),
                           pysql.Placeholder('pc'),
-                          pysql.SQL('ST_SetSRID(ST_MakePoint(%(x)s, %(y)s), 4326)'),
-                          pysql.SQL("""expand_by_meters(
-                                           ST_SetSRID(ST_MakePoint(%(x)s, %(y)s), 4326), {})""")
+                          pysql.Literal(self.is_authoritative),
+                          pysql.SQL("""COALESCE(ST_SetSRID(ST_MakePoint(%(x)s, %(y)s), 4326),
+                                                ST_Centroid(ST_GeomFromGeoJSON(%(geom)s)))"""),
+                          pysql.SQL("""COALESCE(ST_GeomFromGeoJSON(%(geom)s),
+                                                expand_by_meters(ST_SetSRID(
+                                                    ST_MakePoint(%(x)s, %(y)s), 4326), {}))""")
                                .format(pysql.Literal(self.extent))]
                 if is_initial:
                     columns.extend(('place_id', 'indexed_status'))
@@ -132,15 +162,86 @@ class _PostcodeCollector:
                                      AND osm_id is null
                             """, (self.country, to_delete))
 
-    def _update_from_external(self, analyzer: AbstractAnalyzer, project_dir: Path) -> None:
+    def _open_external_geometry_file(self, project_dir: Path) -> Optional[TextIO]:
+        for ext in ('jsonl', 'jsonl.gz'):
+            fname = project_dir / f'{self.country}_postcodes_geometry.{ext}'
+
+            if fname.is_file():
+                LOG.info("Using external postcode file '%s'.", fname)
+                if ext.endswith('.gz'):
+                    return gzip.open(fname, 'rt', encoding='utf-8')
+                else:
+                    return open(fname, 'r', encoding='utf-8')
+
+        return None
+
+    def _update_from_external_geometry(self, analyzer: AbstractAnalyzer, project_dir: Path) -> None:
         """ Look for an external postcode file for the active country in
             the project directory and add missing postcodes when found.
         """
-        csvfile = self._open_external(project_dir)
-        if csvfile is None:
-            return
+        jsonlfile = self._open_external_geometry_file(project_dir)
+        if jsonlfile is not None:
+            self.is_authoritative = True
+            for i, line in enumerate(jsonlfile, start=1):
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    LOG.warning("Ignored line no %s: Invalid JSON in external postcode file for"
+                                "country '%s'.", i, self.country)
+                    continue
 
-        try:
+                geometry = data.get('geometry')
+                if (not isinstance(geometry, dict)
+                        or geometry.get('type') not in ('Polygon', 'MultiPolygon')):
+                    LOG.warning("Ignored line no %s: Invalid geometry in external postcode file for"
+                                "country '%s'.", i, self.country)
+                    continue
+
+                props = data.get('properties', {})
+                raw_postcode = props.get('postcode')
+                if not raw_postcode:
+                    LOG.warning("Ignored line no %s: Missing postcode in external postcode file for"
+                                "country '%s'.", i, self.country)
+                    continue
+
+                lon = props.get('lon')
+                lat = props.get('lat')
+                if lon is not None and lat is not None:
+                    try:
+                        lon = _to_float(lon, 180)
+                        lat = _to_float(lat, 90)
+                    except ValueError:
+                        LOG.warning("Bad centroid %s, %s in line no %s for country '%s'. Defaulting"
+                                    " to geometry centroid.", lat, lon, i, self.country)
+                        lon, lat = None, None
+                else:
+                    lon, lat = None, None
+
+                if raw_postcode not in self.collected:
+                    self.add(raw_postcode, lon, lat,
+                             geometry=json.dumps(geometry))
+            jsonlfile.close()
+
+    def _open_external_centroid_file(self, project_dir: Path) -> Optional[TextIO]:
+        for ext in ('csv', 'csv.gz'):
+            fname = project_dir / f'{self.country}_postcodes.{ext}'
+
+            if fname.is_file():
+                LOG.info("Using external postcode file '%s'.", fname)
+                if ext.endswith('.gz'):
+                    return gzip.open(fname, 'rt', encoding='utf-8')
+                else:
+                    return open(fname, 'r', encoding='utf-8')
+
+        return None
+
+    def _update_from_external_centroid(self, analyzer: AbstractAnalyzer, project_dir: Path) -> None:
+        """ Look for an external postcode file for the active country in
+            the project directory and add missing postcodes when found.
+        """
+
+        csvfile = self._open_external_centroid_file(project_dir)
+        if csvfile is not None:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 if 'postcode' not in row or 'lat' not in row or 'lon' not in row:
@@ -148,33 +249,19 @@ class _PostcodeCollector:
                                 " Ignored.", self.country)
                     return
                 postcode = analyzer.normalize_postcode(row['postcode'])
+                try:
+                    # Do float conversation separately, it might throw
+                    x = _to_float(row['lon'], 180)
+                    y = _to_float(row['lat'], 90)
+                except ValueError:
+                    LOG.warning("Bad coordinates %s, %s in '%s' country postcode file.",
+                                row['lat'], row['lon'], self.country)
+                    continue
+
                 if postcode not in self.collected:
-                    try:
-                        # Do float conversation separately, it might throw
-                        centroid = (_to_float(row['lon'], 180),
-                                    _to_float(row['lat'], 90))
-                        self.collected[postcode] += centroid
-                    except ValueError:
-                        LOG.warning("Bad coordinates %s, %s in '%s' country postcode file.",
-                                    row['lat'], row['lon'], self.country)
+                    self.add(postcode, x, y)
 
-        finally:
             csvfile.close()
-
-    def _open_external(self, project_dir: Path) -> Optional[TextIO]:
-        fname = project_dir / f'{self.country}_postcodes.csv'
-
-        if fname.is_file():
-            LOG.info("Using external postcode file '%s'.", fname)
-            return open(fname, 'r', encoding='utf-8')
-
-        fname = project_dir / f'{self.country}_postcodes.csv.gz'
-
-        if fname.is_file():
-            LOG.info("Using external postcode file '%s'.", fname)
-            return gzip.open(fname, 'rt', encoding='utf-8')
-
-        return None
 
 
 def update_postcodes(dsn: str, project_dir: Optional[Path],
@@ -200,6 +287,10 @@ def update_postcodes(dsn: str, project_dir: Optional[Path],
                                 DISABLE TRIGGER location_postcodes_before_insert""")
             # Now update first postcode areas
             _update_postcode_areas(conn, analyzer, matcher, is_initial)
+            # Update postcode areas from external files, this will add new ones without overriding
+            # any existing postcode areas imported from OSM.
+            _update_external_postcode_areas(conn, analyzer, matcher, project_dir, is_initial)
+
             # Then fill with estimated postcode centroids from other info
             _update_guessed_postcode(conn, analyzer, matcher, project_dir, is_initial)
             if is_initial:
@@ -291,12 +382,46 @@ def _update_postcode_areas(conn: Connection, analyzer: AbstractAnalyzer,
                                    is_initial)
 
 
+def _update_external_postcode_areas(conn: Connection, analyzer: AbstractAnalyzer,
+                                    matcher: PostcodeFormatter,
+                                    project_dir: Optional[Path], is_initial: bool) -> None:
+    """ Look for external postcode JSONL files and import Polygons as authoritative
+        areas.
+    """
+
+    if project_dir is None:
+        return
+
+    todo_countries: set[str] = set()
+
+    with conn.cursor() as cur:
+        cur.execute("""SELECT DISTINCT country_code FROM placex
+                    WHERE country_code is not null""")
+        todo_countries = {row[0] for row in cur}
+
+    area_pcs = defaultdict(set)
+    with conn.cursor() as cur:
+        # Exclude postcodes that are already covered by OSM areas.
+        cur.execute("""SELECT country_code, postcode
+                       FROM location_postcodes
+                       WHERE osm_id is not null
+                       ORDER BY country_code""")
+        for cc, pc in cur:
+            area_pcs[cc].add(pc)
+
+    for country in todo_countries:
+        _PostcodeCollector(country, matcher.get_matcher(country),
+                           matcher.get_postcode_extent(country),
+                           exclude=area_pcs[country]).commit(conn, analyzer, project_dir,
+                                                             is_initial, True)
+
+
 def _update_guessed_postcode(conn: Connection, analyzer: AbstractAnalyzer,
                              matcher: PostcodeFormatter, project_dir: Optional[Path],
                              is_initial: bool) -> None:
     """ Computes artificial postcode centroids from the placex table,
-        potentially enhances it with external data and then updates the
-        postcodes in the table 'location_postcodes'.
+        potentially enhances it with external csv (postcode centroid data) file and then updates
+        the postcodes in the table 'location_postcodes'.
     """
     # First get the list of countries that currently have postcodes.
     # (Doing this before starting to insert, so it is fast on import.)
@@ -308,22 +433,30 @@ def _update_guessed_postcode(conn: Connection, analyzer: AbstractAnalyzer,
                             WHERE osm_id is null""")
             todo_countries = {row[0] for row in cur}
 
-    # Next, get the list of postcodes that are already covered by areas.
-    area_pcs = defaultdict(set)
+    # Next, get the list of authoritative postcodes comprising of postcodes that are already
+    # covered by areas and JSONL postcode import.
+    auth_pcs = defaultdict(set)
     with conn.cursor() as cur:
         cur.execute("""SELECT country_code, postcode
                        FROM location_postcodes WHERE osm_id is not null
+                            OR is_authoritative
                        ORDER BY country_code""")
         for cc, pc in cur:
-            area_pcs[cc].add(pc)
+            auth_pcs[cc].add(pc)
 
-    # Create a temporary table which contains coverage of the postcode areas.
+    # Create a temporary table which contains coverage of the postcode areas imported from osm
+    # and authoritative geometry imported through xx_postcode_geometry.jsonl.
     with conn.cursor() as cur:
         cur.execute("DROP TABLE IF EXISTS _global_postcode_area")
         cur.execute("""CREATE TABLE _global_postcode_area AS
                        (SELECT ST_SubDivide(ST_SimplifyPreserveTopology(
                                               ST_Union(geometry), 0.00001), 128) as geometry
-                        FROM place_postcode WHERE geometry is not null)
+                        FROM (
+                          SELECT geometry FROM place_postcode WHERE geometry is not null
+                          UNION
+                          SELECT geometry FROM location_postcodes
+                            WHERE is_authoritative
+                        ) x)
                     """)
         cur.execute("CREATE INDEX ON _global_postcode_area USING gist(geometry)")
 
@@ -348,22 +481,23 @@ def _update_guessed_postcode(conn: Connection, analyzer: AbstractAnalyzer,
         for country, postcode, x, y in cur:
             if collector is None or country != collector.country:
                 if collector is not None:
-                    collector.commit(conn, analyzer, project_dir, is_initial)
+                    collector.commit(conn, analyzer, project_dir, is_initial, False)
                 collector = _PostcodeCollector(country, matcher.get_matcher(country),
                                                matcher.get_postcode_extent(country),
-                                               exclude=area_pcs[country])
+                                               exclude=auth_pcs[country])
                 todo_countries.discard(country)
             collector.add(postcode, x, y)
 
         if collector is not None:
-            collector.commit(conn, analyzer, project_dir, is_initial)
+            collector.commit(conn, analyzer, project_dir, is_initial, False)
 
     # Now handle any countries that are only in the postcode table.
     for country in todo_countries:
         fmt = matcher.get_matcher(country)
         ext = matcher.get_postcode_extent(country)
         _PostcodeCollector(country, fmt, ext,
-                           exclude=area_pcs[country]).commit(conn, analyzer, project_dir, False)
+                           exclude=auth_pcs[country]).commit(conn, analyzer, project_dir,
+                                                             False, False)
 
     conn.execute("DROP TABLE IF EXISTS _global_postcode_area")
 

--- a/test/python/tools/test_postcodes.py
+++ b/test/python/tools/test_postcodes.py
@@ -8,6 +8,7 @@
 Tests for functions to maintain the artificial postcode table.
 """
 import subprocess
+import json
 
 import pytest
 
@@ -197,8 +198,8 @@ class TestPostcodes:
                                 (None, 'cc', 'DD23 T', 100, 56)}
 
     @pytest.mark.parametrize("gzipped", [True, False])
-    def test_postcodes_extern(self, postcode_update, tmp_path,
-                              insert_implicit_postcode, gzipped):
+    def test_postcodes_extern_csv(self, postcode_update, tmp_path,
+                                  insert_implicit_postcode, gzipped):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -213,8 +214,8 @@ class TestPostcodes:
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
                                 (None, 'xx', 'CD 4511', -10, -5)}
 
-    def test_postcodes_extern_bad_column(self, postcode_update, tmp_path,
-                                         insert_implicit_postcode):
+    def test_postcodes_extern_csv_bad_column(self, postcode_update, tmp_path,
+                                             insert_implicit_postcode):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -224,8 +225,8 @@ class TestPostcodes:
 
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12)}
 
-    def test_postcodes_extern_bad_number(self, postcode_update, insert_implicit_postcode,
-                                         tmp_path):
+    def test_postcodes_extern_csv_bad_number(self, postcode_update, insert_implicit_postcode,
+                                             tmp_path):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -236,6 +237,58 @@ class TestPostcodes:
 
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
                                 (None, 'xx', 'CD 4511', -10, -5)}
+
+    @pytest.mark.parametrize("gzipped", [True, False])
+    def test_postcodes_extern_jsonl(self, postcode_update, tmp_path,
+                                    insert_implicit_postcode, gzipped):
+        insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511', in_placex=True)
+
+        extfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        extfile.write_text(
+            json.dumps({'properties': {'postcode': 'CD 4511'},
+                        # Centroid : 0.5, 0.5
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n' +
+            json.dumps({'properties': {'postcode': '822114', 'lat': 0.1, 'lon': 0.2},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n', encoding='utf-8')
+
+        if gzipped:
+            subprocess.run(['gzip', str(extfile)])
+            assert not extfile.is_file()
+
+        postcode_update(tmp_path)
+
+        assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
+                                (None, 'xx', 'CD 4511', 0.5, 0.5),
+                                (None, 'xx', '822114', 0.2, 0.1)}
+
+    def test_postcodes_extern_jsonl_invalid_data(self, postcode_update, tmp_path,
+                                                 insert_implicit_postcode):
+        insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511', in_placex=True)
+
+        extfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        extfile.write_text(
+            # Invalid JSON
+            '{"geometry": {"type": "Polygon"}, "properties": {"postcode": "BAD"}\n'
+            # Missing geometry
+            + json.dumps({'properties': {'postcode': 'NOGEOM'}}) + '\n'
+            # Invalid geometry type
+            + json.dumps({'geometry': {'type': 'Point', 'coordinates': [0, 0]},
+                          'properties': {'postcode': 'BADGEOM'}}) + '\n'
+            # Missing postcode
+            + json.dumps({'properties': {'lat': 0, 'lon': 0},
+                          'geometry': {'type': 'Polygon', 'coordinates': [[
+                              [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n'
+            # Valid one
+            + json.dumps({'geometry': {'type': 'Polygon', 'coordinates': [[
+                [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+                'properties': {'postcode': 'GOOD'}}) + '\n', encoding='utf-8')
+
+        postcode_update(tmp_path)
+
+        assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
+                                (None, 'xx', 'GOOD', 0.5, 0.5)}
 
     def test_no_placex_entry(self, postcode_update, temp_db_cursor, place_postcode_row):
         # Rewrite the get_country_code function to verify its execution.


### PR DESCRIPTION
## Summary
Closes #4080
This PR introduces support for importing external postcode data in both csv and jsonl (json lines) formats, allowing for richer postcode geometry import. In JSONL files, we can now provide full geometries, and centroids (optional). 

The new JSONL files would need to placed in the project directory with name `XX_postcodes_geometry.jsonl`.

Currently OSM imported postcodes precede over jsonl imports which precedes csv imports.

The import logic, storage, and documentation are updated accordingly, and comprehensive tests are added for the new functionality.


### AI Usage
LLM based CLI tools were extensively used to understand the codebase and find out the relevant files pertaining the targeted changes.  


### Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description