### PR TITLE
Do not search for countries when country restriction is in place

### DIFF
--- a/src/nominatim_api/search/db_searches/place_search.py
+++ b/src/nominatim_api/search/db_searches/place_search.py
@@ -64,7 +64,8 @@ class PlaceSearch(base.AbstractSearch):
             sql = sql.where(lookup.sql_condition(t))
 
         if self.countries:
-            sql = sql.where(t.c.country_code.in_(self.countries.values))
+            sql = sql.where(t.c.country_code.in_(self.countries.values))\
+                     .where(t.c.address_rank != 4)
 
         if self.postcodes:
             # if a postcode is given, don't search for state or country level objects

--- a/test/bdd/features/api/search/queries.feature
+++ b/test/bdd/features/api/search/queries.feature
@@ -203,10 +203,15 @@ Feature: Search queries
           | category | type |
           | highway  | residential |
 
-
     # github #1949
     Scenario: Addressdetails always return the place type
-       When geocoding "Vaduz"
-       Then result 0 contains
-         | address+town |
-         | Vaduz |
+        When geocoding "Vaduz"
+        Then result 0 contains
+          | address+town |
+          | Vaduz |
+
+    Scenario: Place searches with a country component should not return countries
+        When geocoding "Liechtenstein, LI"
+        Then result 0 contains
+          | place_rank |
+          | 30   |


### PR DESCRIPTION
When the query parser detects that a component of the query is a country name or country code, then it is fair to assume that the entire query is not for a country but something within the country.

Prevents Brasil from showing up for a query like 'Brasilia, BR'. Small side observation from #4088.