### PR TITLE
New sanitizers: delete-names and derive-names

### DIFF
--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -232,6 +232,14 @@ The following is a list of sanitizers that are shipped with Nominatim.
         heading_level: 6
         docstring_section_style: spacy
 
+##### derive-names
+
+::: nominatim_db.tokenizer.sanitizers.derive_names
+    options:
+        members: False
+        heading_level: 6
+        docstring_section_style: spacy
+
 ##### tag-japanese
 
 ::: nominatim_db.tokenizer.sanitizers.tag_japanese

--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -224,15 +224,15 @@ The following is a list of sanitizers that are shipped with Nominatim.
         heading_level: 6
         docstring_section_style: spacy
 
-#### delete-tags
+##### delete-names
 
-::: nominatim_db.tokenizer.sanitizers.delete_tags
+::: nominatim_db.tokenizer.sanitizers.delete_names
     options:
         members: False
         heading_level: 6
         docstring_section_style: spacy
 
-#### tag-japanese
+##### tag-japanese
 
 ::: nominatim_db.tokenizer.sanitizers.tag_japanese
     options:

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -43,9 +43,9 @@ sanitizers:
     - step: clean-tiger-tags
     - step: split-name-list
       delimiters: ;
-    - step: delete-tags
+    - step: delete-names
       filter-kind: ref
-      name:
+      filter-name:
         - ".*,.*"
         - ".{41,}"
     - step: strip-brace-terms

--- a/src/nominatim_db/tokenizer/place_sanitizer.py
+++ b/src/nominatim_db/tokenizer/place_sanitizer.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Handler for cleaning name and address tags in place information before it
@@ -33,6 +33,10 @@ class PlaceSanitizer:
                     raise UsageError("Sanitizer rule is missing the 'step' attribute.")
                 if not isinstance(func['step'], str):
                     raise UsageError("'step' attribute must be a simple string.")
+                if func['step'].startswith('_'):
+                    raise UsageError("Illegal name for 'step', must not start with '_'.")
+                if func['step'].startswith('_') or func['step'] in ('base', 'config'):
+                    raise UsageError("'base' and 'config' cannot be used as name for 'step'.")
 
                 module: SanitizerHandler = \
                     config.load_plugin_module(func['step'], 'nominatim_db.tokenizer.sanitizers')

--- a/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
+++ b/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Base class for sanitizers that derive new place names from existing ones.
+"""
+from typing import Sequence, Optional
+from abc import ABC, abstractmethod
+
+from ...data.place_name import PlaceName
+from .base import ProcessInfo
+from .config import SanitizerConfig
+from ...errors import UsageError
+
+
+def _to_rank(rstr: str) -> int:
+    if not rstr.isdigit():
+        raise UsageError(f"Invalid rank parameter '{rstr}', must be a number.")
+
+    rint = int(rstr)
+
+    if rint < 0 or rint > 30:
+        raise UsageError(f"Rank parameter '{rstr}' out of range. Must be between 0 and 30.")
+
+    return rint
+
+
+def _make_rank_set(ranks: Sequence[str]) -> set[int]:
+    """ Parses the rank descriptions and returns a set of permissible ranks.
+    """
+    allowed_ranks = set()
+
+    for rank in ranks:
+        parts = [_to_rank(x) for x in rank.split('-')]
+
+        if len(parts) == 1:
+            allowed_ranks.add(parts[0])
+        elif len(parts) == 2:
+            allowed_ranks.update(range(parts[0], parts[1] + 1))
+        else:
+            raise UsageError(f"Rank parameter '{rank}' is not a value or range.")
+
+    return allowed_ranks
+
+
+class DerivedNameSanitizer(ABC):
+    """ Abstract sanitizer class for sanitizers that add new place names
+        based on the existing ones. The class provides basic filter
+        configuration to restrict the names affected:
+
+        * type (name vs. address)
+        * kind (single value or list of regexes to match against kind)
+        * suffix (single value or list of regexes to match against kind)
+        * country_code: string or list of two-letter country codes
+        * rank_address: string or list of ranks or rank ranges
+
+        Further more, it can be configured if the original name should
+        be kept.
+
+        If a place name is deemed relevant, calls the handler function
+        which must then return a list of derived place name objects.
+    """
+
+    def __init__(self, config: SanitizerConfig, keep_original: bool = True,
+                 filter_kind_option: str = 'filter-kind',
+                 filter_country_option: str = 'filter-country',
+                 filter_suffix_option: str = 'filter-suffix',
+                 filter_rank_option: str = 'filter-rank') -> None:
+        self.type = config.get('type', 'name')
+        self.filter_kind = config.get_filter(filter_kind_option)
+        self.country_codes = config.get_string_list(filter_country_option) \
+            if filter_country_option in config else None
+        self.filter_suffix = config.get_filter(filter_suffix_option)
+        self.allowed_ranks = _make_rank_set(config.get_string_list(filter_rank_option, ["0-30"]))
+        self.keep_original = keep_original
+
+    def __call__(self, obj: ProcessInfo) -> None:
+        names = obj.names if self.type == 'name' else obj.address
+
+        if names \
+           and obj.place.rank_address in self.allowed_ranks\
+           and (self.country_codes is None
+                or obj.place.country_code in self.country_codes):
+            filtered_names: list[PlaceName] = []
+
+            for name in names:
+                keep_name = True
+                if self.filter_kind(name.kind) and self.filter_suffix(name.suffix or ''):
+                    if (new_names := self.compute_derived_names(name, obj)) is not None:
+                        filtered_names.extend(new_names)
+                        keep_name = self.keep_original
+                if keep_name:
+                    filtered_names.append(name)
+
+            if self.type == 'name':
+                obj.names = filtered_names
+            else:
+                obj.address = filtered_names
+
+    @abstractmethod
+    def compute_derived_names(self, name: PlaceName,
+                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+        """ Filter function to be implemented by derived classes.
+            Computes one or more derived names from the given name. The
+            full object is handed in for references.
+
+            Return None if the name should not be processed by the sanitizer.
+            Otherwise return a list of place names that either replace the
+            original one or are added, depending on the setting of 'keep_original'.
+        """
+        return None

--- a/src/nominatim_db/tokenizer/sanitizers/config.py
+++ b/src/nominatim_db/tokenizer/sanitizers/config.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Configuration for Sanitizers.
@@ -28,6 +28,25 @@ class SanitizerConfig(_BaseUserDict):
         accessors to standard sanitizer options that are used by many of the
         sanitizers.
     """
+
+    def get_pattern(self, param: str, default: Optional[str] = None,
+                    flags: int = 0) -> re.Pattern[str]:
+        """ Extract a configuration parameter as a regular expression
+            and return a compiled regex pattern. Use 'flags' to initiate
+            the pattern with different compile flags.
+
+            If 'default' is not given, then the parameter must exist
+            or a UsageError is thrown.
+        """
+        strpattern = self.data.get(param, default)
+
+        if strpattern is None:
+            raise UsageError(f"Parameter {param} is missing but required.")
+
+        if not isinstance(strpattern, str):
+            raise UsageError(f"Parameter {param} must be a string.")
+
+        return re.compile(strpattern, flags=flags)
 
     def get_string_list(self, param: str, default: Sequence[str] = tuple()) -> Sequence[str]:
         """ Extract a configuration parameter as a string list.

--- a/src/nominatim_db/tokenizer/sanitizers/delete_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_names.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Sanitizer which prevents certain names from getting into the search index.
+It removes names which matches all selected properties.
+
+Arguments:
+    type: Define which type of names should be considered for removal:
+          proper names of the object ('name') or names defining the address
+          ('address'). (default: 'name')
+
+    filter-kind: Define which 'kind' of names are affected.
+                 Takes a string or list of strings where each
+                 string is a regular expression. A name is considered
+                 to be a candidate for removal if its 'kind' property
+                 fully matches any of the given regular expressions.
+                 (default: no filter)
+
+    filter-suffix: Define the 'suffix' property of the names which should be
+                   removed. Takes a string or list of strings where each
+                   string is a regular expression. A tag is considered to be a
+                   candidate for removal if its 'suffix' property fully
+                   matches any of the given regular expressions.
+                   (default: no filter)
+
+    filter-name: Select a subset of name values to be deleted.
+                 Takes a string or list of strings where each string
+                 is a regular expression. A tag is considered to be a candidate
+                 for removal if its name fully matches any of the given regular
+                 expressions.
+                 (default: no filter)
+
+    filter-country: Define the country code of places whose names should be
+                    considered for removed. Takes a string or list of strings
+                    where each string is a two-letter lower-case country code.
+                    (default: no filter)
+
+    filter-rank: Define the address rank of places whose names should be
+                 considered for removal. Takes a string or list of strings
+                 where each string is a number or range of number or the
+                 form <from>-<to>.
+                 See https://nominatim.org/release-docs/latest/customize/Ranking/#address-rank
+                 to learn more about address rank.
+                 (default: no filter)
+
+
+"""
+from typing import Callable, Sequence, Optional
+
+from ...data.place_name import PlaceName
+from .base import ProcessInfo
+from .config import SanitizerConfig
+from ._derived_name_sanitizer import DerivedNameSanitizer
+
+
+class _DeleteNameSanitizer(DerivedNameSanitizer):
+
+    def __init__(self, config: SanitizerConfig) -> None:
+        super().__init__(config, keep_original=False)
+        self.filter_name = config.get_filter('filter-name')
+
+    def compute_derived_names(self, name: PlaceName,
+                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+        return [] if self.filter_name(name.name) else None
+
+
+def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+    """ Create a function to process removal of certain names.
+    """
+
+    return _DeleteNameSanitizer(config)

--- a/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
@@ -5,6 +5,8 @@
 # Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
+DEPRECATED, use delete-names instead.
+
 Sanitizer which prevents certain tags from getting into the search index.
 It remove tags which matches all properties given below.
 

--- a/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Sanitizer which prevents certain tags from getting into the search index.
@@ -54,72 +54,30 @@ Arguments:
 
 
 """
-from typing import Callable, List, Tuple, Sequence
+from typing import Callable, Sequence, Optional
 
 from ...data.place_name import PlaceName
 from .base import ProcessInfo
 from .config import SanitizerConfig
+from ._derived_name_sanitizer import DerivedNameSanitizer
 
 
-class _TagSanitizer:
+class _DeleteNameSanitizer(DerivedNameSanitizer):
 
     def __init__(self, config: SanitizerConfig) -> None:
-        self.type = config.get('type', 'name')
-        self.filter_kind = config.get_filter('filter-kind')
-        self.country_codes = config.get_string_list('country_code', [])
-        self.filter_suffix = config.get_filter('suffix')
+        super().__init__(config, keep_original=False,
+                         filter_country_option='country_code',
+                         filter_suffix_option='suffix',
+                         filter_rank_option='rank_address')
         self.filter_name = config.get_filter('name')
-        self.allowed_ranks = self._set_allowed_ranks(
-            config.get_string_list("rank_address", ["0-30"])
-        )
 
-        self.has_country_code = config.get('country_code', None) is not None
-
-    def __call__(self, obj: ProcessInfo) -> None:
-        tags = obj.names if self.type == 'name' else obj.address
-
-        if not tags \
-           or not self.allowed_ranks[obj.place.rank_address] \
-           or self.has_country_code \
-           and obj.place.country_code not in self.country_codes:
-            return
-
-        filtered_tags: List[PlaceName] = []
-
-        for tag in tags:
-
-            if not self.filter_kind(tag.kind) \
-               or not self.filter_suffix(tag.suffix or '') \
-               or not self.filter_name(tag.name):
-                filtered_tags.append(tag)
-
-        if self.type == 'name':
-            obj.names = filtered_tags
-        else:
-            obj.address = filtered_tags
-
-    def _set_allowed_ranks(self, ranks: Sequence[str]) -> Tuple[bool, ...]:
-        """ Returns a tuple of 31 boolean values corresponding to the
-            address ranks 0-30. Value at index 'i' is True if rank 'i'
-            is present in the ranks or lies in the range of any of the
-            ranks provided in the sanitizer configuration, otherwise
-            the value is False.
-        """
-        allowed_ranks = [False] * 31
-
-        for rank in ranks:
-            intvl = [int(x) for x in rank.split('-')]
-
-            start, end = intvl[0], intvl[0] if len(intvl) == 1 else intvl[1]
-
-            for i in range(start, end + 1):
-                allowed_ranks[i] = True
-
-        return tuple(allowed_ranks)
+    def compute_derived_names(self, name: PlaceName,
+                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+        return [] if self.filter_name(name.name) else None
 
 
 def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
     """ Create a function to process removal of certain tags.
     """
 
-    return _TagSanitizer(config)
+    return _DeleteNameSanitizer(config)

--- a/src/nominatim_db/tokenizer/sanitizers/derive_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/derive_names.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+This sanitizer can create additional name variants based on existing
+names.
+
+Arguments:
+    type: Define which type of names should be considered for removal:
+          proper names of the object ('name') or names defining the address
+          ('address'). (default: 'name')
+
+    filter-kind: Define which 'kind' of names are affected.
+                 Takes a string or list of strings where each
+                 string is a regular expression. A name is considered
+                 to be a candidate for removal if its 'kind' property
+                 fully matches any of the given regular expressions.
+                 (default: no filter)
+
+    filter-suffix: Restrict sanitizer to names with certain 'suffix' properties.
+                   Takes a string or list of strings where each
+                   string is a regular expression. A tag is considered to be a
+                   candidate for removal if its 'suffix' property fully
+                   matches any of the given regular expressions.
+                   (default: no filter)
+
+    filter-country: Restrict sanitizer to given countries. Takes a string or
+                    list of strings where each string is a two-letter
+                    lower-case country code.
+                    (default: no filter)
+
+    filter-rank: Define the address rank of places whose names should be
+                 considered. Takes a string or list of strings
+                 where each string is a number or range of number or the
+                 form <from>-<to>.
+                 See https://nominatim.org/release-docs/latest/customize/Ranking/#address-rank
+                 to learn more about address rank.
+                 (default: no filter)
+
+    name-pattern: Regular expression to match the name proper against. Replacements
+                  will only be made when the full name matches against this expression.
+                  The expression may contain capture expressions which can
+                  be used in the variant expression below.
+
+    variants: Single string or list of strings of new variants to be created.
+              The string may contain numbered backreferences, e.g. `\1`.
+
+    keep-original: When set to true, the original name will be kept. Otherwise
+                   the original is discarded when it matched the pattern.
+                   (default: true)
+"""
+from typing import Callable, Sequence, Optional
+
+from ...data.place_name import PlaceName
+from .base import ProcessInfo
+from .config import SanitizerConfig
+from ._derived_name_sanitizer import DerivedNameSanitizer
+
+
+class _NameSanitizer(DerivedNameSanitizer):
+
+    def __init__(self, config: SanitizerConfig) -> None:
+        super().__init__(config, keep_original=config.get_bool('keep-original', True))
+        self.pattern = config.get_pattern('name-pattern')
+        self.replacements = config.get_string_list('variants')
+
+    def compute_derived_names(self, name: PlaceName,
+                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+        if (m := self.pattern.fullmatch(name.name)) is not None:
+            return [name.clone(name=n) for n in set(m.expand(r) for r in self.replacements)]
+
+        return None
+
+
+def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+    """ Create a function to process removal of certain names.
+    """
+
+    return _NameSanitizer(config)

--- a/test/python/tokenizer/sanitizers/test_delete_names.py
+++ b/test/python/tokenizer/sanitizers/test_delete_names.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for the sanitizer that deletes names.
+"""
+import pytest
+
+from nominatim_db.data.place_info import PlaceInfo
+from nominatim_db.tokenizer.place_sanitizer import PlaceSanitizer
+
+
+class TestWithDefault:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, type, **kwargs):
+
+        place = PlaceInfo({type: {k.replace('_', ':'): v for k, v in kwargs.items()},
+                          'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names'}
+
+        name, address = PlaceSanitizer([sanitizer_args],
+                                       self.config).process_names(place)
+
+        return {'name': sorted([(p.name, p.kind, p.suffix or '') for p in name]),
+                'address': sorted([(p.name, p.kind, p.suffix or '') for p in address])}
+
+    def test_on_name(self):
+        res = self.run_sanitizer_on('name', name='foo', ref='bar', ref_abc='baz')
+
+        assert res.get('name') == []
+
+    def test_on_address(self):
+        res = self.run_sanitizer_on('address', name='foo', ref='bar', ref_abc='baz')
+
+        assert res.get('address') == [('bar', 'ref', ''), ('baz', 'ref', 'abc'),
+                                      ('foo', 'name', '')]
+
+
+class TestTypeField:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, type, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names',
+                          'type': type}
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '') for p in name])
+
+    def test_name_type(self):
+        res = self.run_sanitizer_on('name', name='foo', ref='bar', ref_abc='baz')
+
+        assert res == []
+
+    def test_address_type(self):
+        res = self.run_sanitizer_on('address', name='foo', ref='bar', ref_abc='baz')
+
+        assert res == [('bar', 'ref', ''), ('baz', 'ref', 'abc'),
+                       ('foo', 'name', '')]
+
+
+class TestFilterKind:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, filt, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names',
+                          'filter-kind': filt}
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '') for p in name])
+
+    def test_single_exact_name(self):
+        res = self.run_sanitizer_on(['name'], ref='foo', name='foo',
+                                    name_abc='bar', ref_abc='bar')
+
+        assert res == [('bar', 'ref', 'abc'), ('foo', 'ref', '')]
+
+    def test_single_pattern(self):
+        res = self.run_sanitizer_on(['.*name'],
+                                    name_fr='foo', ref_fr='foo', namexx_fr='bar',
+                                    shortname_fr='bar', name='bar')
+
+        assert res == [('bar', 'namexx', 'fr'), ('foo', 'ref', 'fr')]
+
+    def test_multiple_patterns(self):
+        res = self.run_sanitizer_on(['.*name', 'ref'],
+                                    name_fr='foo', ref_fr='foo', oldref_fr='foo',
+                                    namexx_fr='bar', shortname_fr='baz', name='baz')
+
+        assert res == [('bar', 'namexx', 'fr'), ('foo', 'oldref', 'fr')]
+
+
+class TestRankAddress:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, rank_addr, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names',
+                          'filter-rank': rank_addr}
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '') for p in name])
+
+    def test_single_rank(self):
+        res = self.run_sanitizer_on('30', name='foo', ref='bar')
+
+        assert res == []
+
+    def test_single_rank_fail(self):
+        res = self.run_sanitizer_on('28', name='foo', ref='bar')
+
+        assert res == [('bar', 'ref', ''), ('foo', 'name', '')]
+
+    def test_ranged_rank_pass(self):
+        res = self.run_sanitizer_on('26-30', name='foo', ref='bar')
+
+        assert res == []
+
+    def test_ranged_rank_fail(self):
+        res = self.run_sanitizer_on('26-29', name='foo', ref='bar')
+
+        assert res == [('bar', 'ref', ''), ('foo', 'name', '')]
+
+    def test_mixed_rank_pass(self):
+        res = self.run_sanitizer_on(['4', '20-28', '30', '10-12'], name='foo', ref='bar')
+
+        assert res == []
+
+    def test_mixed_rank_fail(self):
+        res = self.run_sanitizer_on(['4-8', '10', '26-29', '18'], name='foo', ref='bar')
+
+        assert res == [('bar', 'ref', ''), ('foo', 'name', '')]
+
+
+class TestSuffix:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, suffix, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names',
+                          'filter-suffix': suffix}
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '') for p in name])
+
+    def test_single_suffix(self):
+        res = self.run_sanitizer_on('abc', name='foo', name_abc='foo',
+                                    name_pqr='bar', ref='bar', ref_abc='baz')
+
+        assert res == [('bar', 'name', 'pqr'), ('bar', 'ref', ''), ('foo', 'name', '')]
+
+    def test_multiple_suffix(self):
+        res = self.run_sanitizer_on(['abc.*', 'pqr'], name='foo', name_abcxx='foo',
+                                    ref_pqr='bar', name_pqrxx='baz')
+
+        assert res == [('baz', 'name', 'pqrxx'), ('foo', 'name', '')]
+
+
+class TestCountryCodes:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, country_code, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {'step': 'delete-names',
+                          'filter-country': country_code}
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind) for p in name])
+
+    def test_single_country_code_pass(self):
+        res = self.run_sanitizer_on('de', name='foo', ref='bar')
+
+        assert res == []
+
+    def test_single_country_code_fail(self):
+        res = self.run_sanitizer_on('in', name='foo', ref='bar')
+
+        assert res == [('bar', 'ref'), ('foo', 'name')]
+
+    def test_empty_country_code_list(self):
+        res = self.run_sanitizer_on([], name='foo', ref='bar')
+
+        assert res == [('bar', 'ref'), ('foo', 'name')]
+
+    def test_multiple_country_code_pass(self):
+        res = self.run_sanitizer_on(['in', 'de', 'fr'], name='foo', ref='bar')
+
+        assert res == []
+
+    def test_multiple_country_code_fail(self):
+        res = self.run_sanitizer_on(['in', 'au', 'fr'], name='foo', ref='bar')
+
+        assert res == [('bar', 'ref'), ('foo', 'name')]
+
+
+class TestAllParameters:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, country_code, rank_addr, suffix, **kwargs):
+
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de', 'rank_address': 30})
+
+        sanitizer_args = {
+                        'step': 'delete-names',
+                        'type': 'name',
+                        'filter-kind': ['name', 'ref'],
+                        'filter-country': country_code,
+                        'filter-rank': rank_addr,
+                        'filter-suffix': suffix,
+                        'filter-name': r'[\s\S]*',
+                    }
+
+        name, _ = PlaceSanitizer([sanitizer_args],
+                                 self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '') for p in name])
+
+    def test_string_arguments_pass(self):
+        res = self.run_sanitizer_on('de', '25-30', r'[\s\S]*',
+                                    name='foo', ref='foo', name_abc='bar', ref_abc='baz')
+
+        assert res == []
+
+    def test_string_arguments_fail(self):
+        res = self.run_sanitizer_on('in', '25-30', r'[\s\S]*',
+                                    name='foo', ref='foo', name_abc='bar', ref_abc='baz')
+
+        assert res == [('bar', 'name', 'abc'), ('baz', 'ref', 'abc'),
+                       ('foo', 'name', ''), ('foo', 'ref', '')]
+
+    def test_list_arguments_pass(self):
+        res = self.run_sanitizer_on(['de', 'in'], ['20-28', '30'], [r'abc.*', r'[\s\S]*'],
+                                    name='foo', ref='foo', name_abcxx='bar', ref_pqr='baz')
+
+        assert res == []
+
+    def test_list_arguments_fail(self):
+        res = self.run_sanitizer_on(['de', 'in'], ['14', '20-29'], [r'abc.*', r'pqr'],
+                                    name='foo', ref_abc='foo', name_abcxx='bar', ref_pqr='baz')
+
+        assert res == [('bar', 'name', 'abcxx'), ('baz', 'ref', 'pqr'),
+                       ('foo', 'name', ''), ('foo', 'ref', 'abc')]
+
+    def test_mix_arguments_pass(self):
+        res = self.run_sanitizer_on('de', ['10', '20-28', '30'], r'[\s\S]*',
+                                    name_abc='foo', ref_abc='foo', name_abcxx='bar', ref_pqr='baz')
+
+        assert res == []
+
+    def test_mix_arguments_fail(self):
+        res = self.run_sanitizer_on(['de', 'in'], ['10', '20-28', '30'], r'abc.*',
+                                    name='foo', ref='foo', name_pqr='bar', ref_pqr='baz')
+
+        assert res == [('bar', 'name', 'pqr'), ('baz', 'ref', 'pqr'),
+                       ('foo', 'name', ''), ('foo', 'ref', '')]

--- a/test/python/tokenizer/sanitizers/test_derive_names.py
+++ b/test/python/tokenizer/sanitizers/test_derive_names.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for the sanitizer that creates derived names using regular expressions.
+"""
+import pytest
+
+from nominatim_db.errors import UsageError
+from nominatim_db.data.place_info import PlaceInfo
+from nominatim_db.tokenizer.place_sanitizer import PlaceSanitizer
+
+
+@pytest.fixture
+def mk_sanitizer(def_config):
+    def _f(**kwargs):
+        args = {k.replace('_', '-'): v for k, v in kwargs.items()}
+        return PlaceSanitizer([args | {'step': 'derive-names'}], def_config)
+
+    return _f
+
+
+def test_no_parameters(mk_sanitizer):
+    with pytest.raises(UsageError, match='name-pattern is missing'):
+        mk_sanitizer()
+
+
+@pytest.mark.parametrize('prim,out', [('name', 0), ('address', 1)])
+@pytest.mark.parametrize('keep', [True, False])
+def test_name_deletion(mk_sanitizer, prim, out, keep):
+    san = mk_sanitizer(name_pattern='A.*B', type=prim, keep_original=keep)
+
+    names = dict(name='AltBoom', alt_name='foo', loc_name='AltB')
+    place = PlaceInfo({'name': names, 'address': names,
+                       'country_code': 'de', 'rank_address': 30})
+
+    res = san.process_names(place)
+
+    assert len(res[(out + 1) % 2]) == 3
+    if keep:
+        assert len(res[out]) == 3
+    else:
+        assert {(p.kind, p.name) for p in res[out]} == {('name', 'AltBoom'),
+                                                        ('alt_name', 'foo')}
+
+
+@pytest.fixture
+def simple_replace(mk_sanitizer):
+    def _impl(name, pattern, *variants, keep=True):
+        san = mk_sanitizer(name_pattern=pattern, type='name', keep_original=keep,
+                           variants=variants)
+        place = PlaceInfo({'name': {'name': name}, 'country_code': 'de', 'rank_address': 30})
+        out, _ = san.process_names(place)
+
+        return {p.name for p in out}
+    return _impl
+
+
+def test_variant_single_name(simple_replace):
+    assert simple_replace('A', 'A', 'The A') == {'A', 'The A'}
+
+
+def test_replace_single_name(simple_replace):
+    assert simple_replace('A', 'A', 'The A', keep=False) == {'The A'}
+
+
+def test_variant_with_multiple_names(simple_replace):
+    assert simple_replace('A', 'A', 'A1', 'A2', 'A1') == {'A', 'A1', 'A2'}
+
+
+def test_variant_with_group_replacement(simple_replace):
+    assert simple_replace('abc X', '(.*) X', r'\1 Y') == {'abc X', 'abc Y'}

--- a/test/python/tokenizer/sanitizers/test_sanitizer_config.py
+++ b/test/python/tokenizer/sanitizers/test_sanitizer_config.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for sanitizer configuration helper functions.
@@ -11,6 +11,29 @@ import pytest
 
 from nominatim_db.errors import UsageError
 from nominatim_db.tokenizer.sanitizers.config import SanitizerConfig
+
+
+def test_pattern_error_on_missing():
+    with pytest.raises(UsageError):
+        SanitizerConfig().get_pattern('foo')
+
+
+def test_pattern_default_on_missing():
+    pat = SanitizerConfig().get_pattern('foo', '.*')
+    assert pat.pattern == '.*'
+
+
+def test_pattern_good_with_group():
+    pat = SanitizerConfig({'foo': 'x(X)'}).get_pattern('foo', '.*')
+
+    assert pat.pattern == 'x(X)'
+    assert pat.groups == 1
+
+
+@pytest.mark.parametrize('value', [True, 1, {}, ['a', 'b']])
+def test_pattern_bad(value):
+    with pytest.raises(UsageError):
+        SanitizerConfig({'foo': value}).get_pattern('foo')
 
 
 def test_string_list_default_empty():

--- a/test/python/tokenizer/test_place_sanitizer.py
+++ b/test/python/tokenizer/test_place_sanitizer.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for execution of the sanitztion step.
@@ -75,3 +75,9 @@ def test_sanitizer_empty_list(def_config, rules):
 def test_sanitizer_missing_step_definition(def_config):
     with pytest.raises(UsageError):
         sanitizer.PlaceSanitizer([{'id': 'split-name-list'}], def_config)
+
+
+@pytest.mark.parametrize('stepname', ['_something', '__init__', 'base', 'config'])
+def test_sanitizer_illegal_step_names(def_config, stepname):
+    with pytest.raises(UsageError):
+        sanitizer.PlaceSanitizer([{'step': stepname}], def_config)


### PR DESCRIPTION
This adds two new sanitizers:

* _delete-names_ allows to remove names according to a pattern. This is a replacement for delete-tags with slightly more standardized parameter names.
* _derive-names_ allows to create additional names by deriving them from an existing one. Can also be used to add names given certain conditions.

The delete-tags sanitizer is now deprecated and will be remove in the new major version.

Also cleans up the sanitizer code a little and adds additional check to avoid helper modules being loaded as a sanitizer.