### PR TITLE
Add sanitizer for handling name prefixes and suffixes

### DIFF
--- a/docs/customize/Tokenizers.md
+++ b/docs/customize/Tokenizers.md
@@ -248,6 +248,14 @@ The following is a list of sanitizers that are shipped with Nominatim.
         heading_level: 6
         docstring_section_style: spacy
 
+##### affix-expansion
+
+::: nominatim_db.tokenizer.sanitizers.affix_expansion
+    options:
+        members: False
+        heading_level: 6
+        docstring_section_style: spacy
+
 #### Token Analysis
 
 Token analyzers take a full name and transform it into one or more normalized

--- a/lib-lua/themes/nominatim/presets.lua
+++ b/lib-lua/themes/nominatim/presets.lua
@@ -330,7 +330,8 @@ module.NAME_TAGS.core = {main = {'name', 'name:*',
                                  'place_name', 'place_name:*',
                                  'short_name', 'short_name:*'},
                          extra = {'ref', 'int_ref', 'nat_ref', 'reg_ref',
-                                  'loc_ref', 'old_ref', 'ISO3166-2'}
+                                  'loc_ref', 'old_ref', 'ISO3166-2',
+                                  '*:prefix', '*:suffix', 'name:prefix:*', 'name:suffix:*'}
                         }
 module.NAME_TAGS.address = {house = {'addr:housename'}}
 module.NAME_TAGS.poi = group_merge({main = {'brand'},
@@ -368,7 +369,7 @@ module.IGNORE_KEYS.metatags = {'note', 'note:*', 'source', 'source:*', '*source'
                                'ref:bygningsnr', 'ref:ruian:*', 'building:ruian:type',
                                'type',
                                'is_in:postcode'}
-module.IGNORE_KEYS.name = {'*:prefix', '*:suffix', 'name:prefix:*', 'name:suffix:*',
+module.IGNORE_KEYS.name = {'name:full',
                            'name:etymology', 'name:etymology:*',
                            'name:signed', 'name:botanical'}
 module.IGNORE_KEYS.address = {'addr:street:*', 'addr:city:*', 'addr:district:*',

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -43,6 +43,8 @@ sanitizers:
     - step: clean-tiger-tags
     - step: split-name-list
       delimiters: ;
+    - step: affix-expansion
+      mode: add-expanded
     - step: delete-names
       filter-kind: ref
       filter-name:

--- a/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
+++ b/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Sanitizer which creates derived names from prefix and suffix tags
+"""
+from typing import Optional, Callable, Sequence
+from collections import defaultdict
+from dataclasses import dataclass
+
+from ...data.place_name import PlaceName
+from .base import ProcessInfo
+from .config import SanitizerConfig
+
+
+class Mode:
+    FULL_NAME = 1
+    """ Only keep the name with prefix/suffix.
+    """
+    SHORT_NAME = 2
+    """ Only keep the name without prefix/suffix. Add prefix/suffix as a partial.
+    """
+    ALL_VARIANTS = 3
+    """ Add both variants with and without prefix/suffix as names.
+    """
+    ADD_EXPANDED = 5
+    """ Add the variant with prefix/suffix if not already present.
+    """
+    ADD_CONTRACTED = 6
+    """ Add the variant without prefix/suffix if not already present.
+    """
+
+
+StemTuple = tuple[str, Optional[str]]
+
+
+@dataclass
+class _AffixCollector:
+    prefix: Optional[str] = None
+    suffix: Optional[str] = None
+
+
+class _AffixSanitizer:
+
+    def __init__(self, config: SanitizerConfig) -> None:
+        self.prefix_tags = config.get_string_list('prefix-tags', ['prefix'])
+        self.suffix_tags = config.get_string_list('suffix-tags', ['suffix'])
+        self.mode = config.get_choice('mode', Mode, Mode.ALL_VARIANTS)
+
+    def __call__(self, obj: ProcessInfo) -> None:
+        if not obj.names:
+            return
+
+        stem_names: list[PlaceName] = []
+        affixes: dict[StemTuple, _AffixCollector] = defaultdict(_AffixCollector)
+        for item in obj.names:
+            if (stem := self.find_stem_kind(item, self.prefix_tags)) is not None:
+                affixes[stem].prefix = item.name
+            elif (stem := self.find_stem_kind(item, self.suffix_tags)) is not None:
+                affixes[stem].suffix = item.name
+            else:
+                stem_names.append(item)
+
+        if affixes:
+            outnames: list[PlaceName] = []
+            for item in stem_names:
+                for stem, aff in affixes.items():
+                    if item.kind == stem[0] and item.suffix == stem[1]:
+                        self.add_names(outnames, item, aff)
+                        break
+                else:
+                    outnames.append(item)
+
+            obj.names = outnames
+
+    def find_stem_kind(self, item: PlaceName, tags: Sequence[str]) -> Optional[StemTuple]:
+        if item.suffix and tags:
+            if item.suffix in tags:
+                return item.kind, None
+
+            parts = item.suffix.split(':', 1)
+            if len(parts) == 2:
+                if parts[0] in tags:
+                    return item.kind, parts[1]
+                if parts[1] in tags:
+                    return item.kind, parts[0]
+                parts = item.suffix.rsplit(':', 1)
+                if parts[1] in tags:
+                    return item.kind, parts[0]
+
+        return None
+
+    def add_names(self, outnames: list[PlaceName], src: PlaceName,
+                  affix: _AffixCollector) -> None:
+        fn = src.name
+        sn = src.name
+        if affix.prefix is not None:
+            prefix = affix.prefix + ' '
+            if fn.startswith(prefix):
+                sn = sn[len(prefix):]
+            else:
+                fn = prefix + fn
+        if affix.suffix is not None:
+            suffix = ' ' + affix.suffix
+            if fn.endswith(suffix):
+                sn = sn[:-len(suffix)]
+            else:
+                fn = fn + suffix
+
+        if self.mode & 1:
+            outnames.append(src.clone(name=fn))
+            if self.mode & 4 and src.name != fn:
+                outnames.append(src)
+        if self.mode & 2:
+            outnames.append(src.clone(name=sn))
+            if self.mode & 4 and src.name != sn:
+                outnames.append(src)
+            elif self.mode == 2:
+                if affix.prefix is not None:
+                    outnames.append(PlaceName(affix.prefix, 'prefix', None,
+                                              {'partial': 'yes'}))
+                if affix.suffix is not None:
+                    outnames.append(PlaceName(affix.suffix, 'suffix', None,
+                                              {'partial': 'yes'}))
+
+
+def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+    """ Create the affix handler.
+    """
+    return _AffixSanitizer(config)

--- a/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
+++ b/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
@@ -5,7 +5,38 @@
 # Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
-Sanitizer which creates derived names from prefix and suffix tags
+Sanitizer which contracts or expands names based on the presence of
+prefix and suffix tags.
+
+The sanitizer can handle three kinds of prefix/suffix tags: The most simple
+one is of the form `<kind>:<prefix-tag>`. It is presumed to refer to the
+name tag `<kind>`. For example, the `name:prefix` tag will be recognised
+as a prefix tag and paired with `name`, while `alt_name:suffix` is paired
+with `alt_name`. For name tags that are of the form `<kind>:<suffix>`,
+meaning that they have another suffix, for example a language suffix, to
+notations for the prefix/suffix tag are accepted: `<kind>:<prefix-tag>:<suffix>`
+and `<kind>:<suffix>:<prefix-tag>`. That means for a German name tag `name:de`
+both `name:prefix:de` and `name:de:prefix` will work.
+
+Arguments:
+    prefix-tags: Specifies how to identify tags containing name prefixes.
+                 This is a single string or a list of suffixes which identify
+                 prefix names.
+                 (default: prefix)
+    prefix-tags: Specifies how to identify tags containing name suffixes.
+                 This is a single string or a list of suffixes which identify
+                 suffix names.
+                 (default: suffix)
+    mode: Defines how names are handled. _full-name_ means to only keep the
+          expanded version of the name with prefix/suffix attached. _short-name_
+          means to only keep the contracted version without prefix/suffix.
+          Prefixes and suffixes are still added as partial terms to the index
+          and are thus still searchable. _all-variants_ adds the expanded and
+          contracted version of the name. _add_expanded_ adds the expanded
+          version if it doesn't exist yet. If name contains the contracted
+          name, then it will not be removed. _add_contracted_ add the contracted
+          version if it doesn't exist yet. Any expanded version of the name
+          that already exists will be kept.
 """
 from typing import Optional, Callable, Sequence
 from collections import defaultdict

--- a/src/nominatim_db/tokenizer/sanitizers/config.py
+++ b/src/nominatim_db/tokenizer/sanitizers/config.py
@@ -166,3 +166,47 @@ class SanitizerConfig(_BaseUserDict):
 
         raise ValueError("Default parameter must be a non-empty list or a string value \
                           ('PASS_ALL' or 'FAIL_ALL').")
+
+    def get_choice(self, param: str, opt_cls: type[Any], default: Optional[int] = None) -> int:
+        """ Return an integer representing a value from a fixed list of choices.
+
+            The choices must be given in form of a class containing class constants
+            of type int. The given value in the configuration must be a string which,
+            after having been cnverted to upper case and hyphens having been
+            replaced with underscores, corresponds to one of the class constants.
+            Only values starting with an ASCII letter and containing ASCII letters
+            and numbers, hyphen and underscore are accepted.
+
+            Arguments:
+                param: The parameter containing the choice variable.
+                opt_cls: The class describing valid choices.
+                default: Default value to use when none is supplied in the
+                         configuration. Must be an integer representing one
+                         of the choices. When left None (the default), then
+                         the parameter is required and leaving it out will
+                         throw an error.
+
+            Returns:
+                The integer with the selected choice.
+        """
+        value = self.data.get(param)
+
+        if value is None:
+            if default is None:
+                raise UsageError(f"Parameter {param} is missing but required.")
+            return default
+
+        if not isinstance(value, str):
+            raise UsageError(f"Parameter {param} must be a string.")
+
+        value = value.upper().replace('-', '_')
+
+        if re.fullmatch('[A-Z][A-Z0-9_]*', value) is None:
+            raise UsageError(f"Invalid value for parameter {param}.")
+
+        res = getattr(opt_cls, value, None)
+
+        if not isinstance(res, int):
+            raise UsageError(f"Invalid value for parameter {param}.")
+
+        return res

--- a/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 This sanitizer sets the `analyzer` property depending on the
@@ -10,7 +10,6 @@ language of the tag. The language is taken from the suffix of the name.
 If a name already has an analyzer tagged, then this is kept.
 
 Arguments:
-
     filter-kind: Restrict the names the sanitizer should be applied to
                  the given tags. The parameter expects a list of
                  regular expressions which are matched against 'kind'.

--- a/test/bdd/features/osm2pgsql/import/tags.feature
+++ b/test/bdd/features/osm2pgsql/import/tags.feature
@@ -22,7 +22,7 @@ Feature: Tag evaluation
         When loading osm data
             """
             n2001 Thighway=road,name=Foo,alt_name:de=Bar,ref=45
-            n2002 Thighway=road,name:prefix=Pre,name:suffix=Post,ref:de=55
+            n2002 Thighway=road,name:full=Full,ref:de=55
             n2003 Thighway=yes,name:%20%de=Foo,name=real1
             n2004 Thighway=yes,name:%a%de=Foo,name=real2
             n2005 Thighway=yes,name:%9%de=Foo,name:\\=real3
@@ -39,7 +39,7 @@ Feature: Tag evaluation
 
         And place contains
             | object | extratags!dict |
-            | N2002  | 'name:prefix': 'Pre', 'name:suffix': 'Post', 'ref:de': '55' |
+            | N2002  | 'name:full': 'Full', 'ref:de': '55' |
 
 
     Scenario: Name when using with_name flag

--- a/test/python/tokenizer/sanitizers/test_affix_expansion.py
+++ b/test/python/tokenizer/sanitizers/test_affix_expansion.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for the sanitizer that expands prefixes and suffixes.
+"""
+import pytest
+
+from nominatim_db.data.place_info import PlaceInfo
+from nominatim_db.tokenizer.place_sanitizer import PlaceSanitizer
+
+
+@pytest.fixture
+def run_sanitizer(def_config):
+    def _f(place, **kwargs):
+        args = {k.replace('_', '-'): v for k, v in kwargs.items()}
+        san = PlaceSanitizer([args | {'step': 'affix-expansion'}], def_config)
+        names, _ = san.process_names(place)
+        nameset = {(p.name, p.kind, p.suffix) for p in names}
+        assert len(names) == len(nameset)
+        return nameset
+
+    return _f
+
+
+def mk_place(names):
+    return PlaceInfo({'name': names, 'country_code': 'de', 'rank_address': 30})
+
+
+def test_default_settings(run_sanitizer):
+    place = mk_place({'name': 'Foo Street', 'name:prefix': 'North',
+                      'alt_name': 'Foo Street South', 'alt_name:suffix': 'South',
+                      'loc_name': 'Fun Mile'})
+
+    assert run_sanitizer(place) == {('Foo Street', 'name', None),
+                                    ('North Foo Street', 'name', None),
+                                    ('Foo Street South', 'alt_name', None),
+                                    ('Foo Street', 'alt_name', None),
+                                    ('Fun Mile', 'loc_name', None)}
+
+
+def test_custom_prefix(run_sanitizer):
+    place = mk_place({'name': 'Foo Street', 'name:start': 'North',
+                      'name:fr': 'West Bubble Street', 'name:begin:fr': 'West',
+                      'name:prefix': 'other'})
+
+    assert run_sanitizer(place, prefix_tags=['start', 'begin']) == \
+        {('Foo Street', 'name', None),
+         ('North Foo Street', 'name', None),
+         ('West Bubble Street', 'name', 'fr'),
+         ('Bubble Street', 'name', 'fr'),
+         ('other', 'name', 'prefix')}
+
+
+def test_custom_suffix(run_sanitizer):
+    place = mk_place({'name': 'Foo Street', 'name:end': 'B',
+                      'alt_name': 'Balula', 'alt_name:final': 'Loo',
+                      'name:de': 'H', 'name:de:prefix': 'N'})
+
+    assert run_sanitizer(place, suffix_tags=['end', 'final']) == \
+        {('Foo Street', 'name', None),
+         ('Foo Street B', 'name', None),
+         ('Balula', 'alt_name', None),
+         ('Balula Loo', 'alt_name', None),
+         ('H', 'name', 'de'),
+         ('N H', 'name', 'de')}
+
+
+@pytest.mark.parametrize('stem', ['Stem Road', 'Pre Stem Road',
+                                  'Stem Road Post', 'Pre Stem Road Post'])
+def test_prefix_and_suffix_given(run_sanitizer, stem):
+    place = mk_place({'name': stem, 'name:prefix': 'Pre', 'name:suffix': 'Post'})
+
+    assert run_sanitizer(place, mode='full-name') == \
+        {('Pre Stem Road Post', 'name', None)}
+    assert run_sanitizer(place, mode='short-name') == \
+        {('Stem Road', 'name', None), ('Pre', 'prefix', None), ('Post', 'suffix', None)}
+
+
+def test_modes_full_name_given(run_sanitizer):
+    place = mk_place({'name': 'Full Name Street', 'name:prefix': 'Full'})
+
+    assert run_sanitizer(place, mode='full-name') == \
+        {('Full Name Street', 'name', None)}
+    assert run_sanitizer(place, mode='short-name') == \
+        {('Name Street', 'name', None), ('Full', 'prefix', None)}
+    assert run_sanitizer(place, mode='all-variants') == \
+        {('Full Name Street', 'name', None), ('Name Street', 'name', None)}
+    assert run_sanitizer(place, mode='add-expanded') == \
+        {('Full Name Street', 'name', None)}
+    assert run_sanitizer(place, mode='add-contracted') == \
+        {('Full Name Street', 'name', None), ('Name Street', 'name', None)}
+
+
+def test_modes_short_name_given(run_sanitizer):
+    place = mk_place({'name': 'My Street', 'name:suffix': 'extra'})
+
+    assert run_sanitizer(place, mode='full-name') == \
+        {('My Street extra', 'name', None)}
+    assert run_sanitizer(place, mode='short-name') == \
+        {('My Street', 'name', None), ('extra', 'suffix', None)}
+    assert run_sanitizer(place, mode='all-variants') == \
+        {('My Street extra', 'name', None), ('My Street', 'name', None)}
+    assert run_sanitizer(place, mode='add-expanded') == \
+        {('My Street extra', 'name', None), ('My Street', 'name', None)}
+    assert run_sanitizer(place, mode='add-contracted') == \
+        {('My Street', 'name', None)}

--- a/test/python/tokenizer/sanitizers/test_sanitizer_config.py
+++ b/test/python/tokenizer/sanitizers/test_sanitizer_config.py
@@ -171,3 +171,41 @@ def test_create_kind_filter_many_negative(kind):
                            ).get_filter('filter-kind')
 
     assert not filt(kind)
+
+
+class MyOpts:
+    FOO = 1
+    bar = 2
+    FOO_BAR = 3
+    BAD = 'string'
+    _SECRET = 1
+
+    def FUNC():
+        pass
+
+
+def test_get_choice_missing_no_default():
+    with pytest.raises(UsageError, match='is missing'):
+        SanitizerConfig().get_choice('test', MyOpts)
+
+
+def test_get_choice_missing_default():
+    assert SanitizerConfig().get_choice('test', MyOpts, 99) == 99
+
+
+@pytest.mark.parametrize('value', [1, True, [], {}])
+def test_get_choice_bad_type(value):
+    with pytest.raises(UsageError, match='must be a string'):
+        SanitizerConfig({'test': value}).get_choice('test', MyOpts)
+
+
+@pytest.mark.parametrize('param,result', [('FOO', 1), ('foo', 1),
+                                          ('FOO_BAR', 3), ('foo-bar', 3)])
+def test_get_choice_positive_results(param, result):
+    assert SanitizerConfig({'test': param}).get_choice('test', MyOpts) == result
+
+
+@pytest.mark.parametrize('param', ['bar', 'BAD', '_SECRET', 'FUNC', '__init__'])
+def test_get_choice_bad_parameters(param):
+    with pytest.raises(UsageError, match='Invalid value'):
+        SanitizerConfig({'test': param}).get_choice('test', MyOpts)


### PR DESCRIPTION
This adds a new sanitizer `affix-expansion` which is able to put together names from the name stem and prefix/suffix tags. It can create expanded and shortened versions of the name according to the prefix/suffix information. There's three kind of tag combinations recognized:

* stem: `<kind>`  prefix: `<kind>:prefix` suffix `<kind>:suffix`
* stem: `<kind>:<suffix>`  prefix: `<kind>:prefix:<suffix>` suffix `<kind>:suffix:<suffix>`
* stem: `<kind>:<suffix>`  prefix: `<kind>:<suffix>:prefix` suffix `<kind>:<suffix>:suffix`

The marker for prefix/suffix tags is configurable. Not sure if that will ever be needed.

In the standard configuration affix expansion is enabled. That means the expanded form of the name is added when it is not yet present. This should resolve the Utah tagging (see #3280). `name:full` is removed as a recognised name tag. It never worked properly.