### PR TITLE
Improve language-awareness of `name:left` and `name:right` tags

### DIFF
--- a/lib-lua/themes/nominatim/presets.lua
+++ b/lib-lua/themes/nominatim/presets.lua
@@ -371,7 +371,8 @@ module.IGNORE_KEYS.metatags = {'note', 'note:*', 'source', 'source:*', '*source'
                                'is_in:postcode'}
 module.IGNORE_KEYS.name = {'name:full',
                            'name:etymology', 'name:etymology:*',
-                           'name:signed', 'name:botanical'}
+                           'name:signed', 'name:botanical',
+                           '*:forward', '*:backward'}
 module.IGNORE_KEYS.address = {'addr:street:*', 'addr:city:*', 'addr:district:*',
                               'addr:province:*', 'addr:subdistrict:*', 'addr:place:*',
                               'addr:TW:dataset'}

--- a/settings/icu_tokenizer.yaml
+++ b/settings/icu_tokenizer.yaml
@@ -53,6 +53,7 @@ sanitizers:
     - step: strip-brace-terms
     - step: tag-analyzer-by-language
       filter-kind: [".*name.*"]
+      suffix-ignore: [left,right]
       whitelist: [bg,ca,cs,da,de,el,en,es,et,eu,fi,fr,gl,hu,it,ja,mg,ms,nl,"no",pl,pt,ro,ru,sk,sl,sv,tr,uk,vi]
       use-defaults: all
       mode: append

--- a/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
@@ -46,27 +46,26 @@ class _AnalyzerByLanguage:
     def __init__(self, config: SanitizerConfig) -> None:
         self.filter_kind = config.get_filter('filter-kind')
         self.replace = config.get('mode', 'replace') != 'append'
-        self.whitelist = config.get('whitelist')
         self.suffix_ignore = set(config.get_string_list('suffix-ignore'))
+        whitelist = config.get('whitelist')
+        self.suffix_matcher: Callable[[str], bool]
+        if whitelist is None:
+            self.suffix_matcher = lambda s: len(s) in (2, 3) and s.islower()
+        else:
+            self.suffix_matcher = lambda s: s in whitelist
 
-        self._compute_default_languages(config.get('use-defaults', 'no'))
+        self._compute_default_languages(config.get('use-defaults', 'no'), whitelist)
 
-    def _compute_default_languages(self, use_defaults: str) -> None:
+    def _compute_default_languages(self, use_defaults: str, whitelist: Optional[list[str]]) -> None:
         self.deflangs: Dict[Optional[str], List[str]] = {}
 
         if use_defaults in ('mono', 'all'):
             for ccode, clangs in country_info.iterate('languages'):
                 if len(clangs) == 1 or use_defaults == 'all':
-                    if self.whitelist:
-                        self.deflangs[ccode] = [cl for cl in clangs if cl in self.whitelist]
+                    if whitelist:
+                        self.deflangs[ccode] = [cl for cl in clangs if cl in whitelist]
                     else:
                         self.deflangs[ccode] = clangs
-
-    def _suffix_matches(self, suffix: str) -> bool:
-        if self.whitelist is None:
-            return len(suffix) in (2, 3) and suffix.islower()
-
-        return suffix in self.whitelist
 
     def __call__(self, obj: ProcessInfo) -> None:
         if not obj.names:
@@ -77,7 +76,7 @@ class _AnalyzerByLanguage:
         for name in (n for n in obj.names
                      if not n.has_attr('analyzer') and self.filter_kind(n.kind)):
             if name.suffix and name.suffix not in self.suffix_ignore:
-                langs = [name.suffix] if self._suffix_matches(name.suffix) else None
+                langs = [name.suffix] if self.suffix_matcher(name.suffix) else None
             else:
                 langs = self.deflangs.get(obj.place.country_code)
 

--- a/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
@@ -17,6 +17,9 @@ Arguments:
     whitelist: Restrict the set of languages that should be tagged.
                Expects a list of acceptable suffixes. When unset,
                all 2- and 3-letter lower-case codes are accepted.
+    suffix-ignore: List of suffixes that are not language-related. Names
+                   with a suffix from that list will be handled like a name
+                   without suffix. (default: empty)
     use-defaults:  Configure what happens when the name has no suffix.
                    When set to 'all', a variant is created for
                    each of the default languages in the country
@@ -44,6 +47,7 @@ class _AnalyzerByLanguage:
         self.filter_kind = config.get_filter('filter-kind')
         self.replace = config.get('mode', 'replace') != 'append'
         self.whitelist = config.get('whitelist')
+        self.suffix_ignore = set(config.get_string_list('suffix-ignore'))
 
         self._compute_default_languages(config.get('use-defaults', 'no'))
 
@@ -72,7 +76,7 @@ class _AnalyzerByLanguage:
 
         for name in (n for n in obj.names
                      if not n.has_attr('analyzer') and self.filter_kind(n.kind)):
-            if name.suffix:
+            if name.suffix and name.suffix not in self.suffix_ignore:
                 langs = [name.suffix] if self._suffix_matches(name.suffix) else None
             else:
                 langs = self.deflangs.get(obj.place.country_code)

--- a/test/python/tokenizer/sanitizers/test_tag_analyzer_by_language.py
+++ b/test/python/tokenizer/sanitizers/test_tag_analyzer_by_language.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for the sanitizer that enables language-dependent analyzers.
@@ -258,3 +258,38 @@ class TestWhiteList:
 
     def test_empty_whitelist(self):
         assert self.run_sanitizer_on([], ref_yy='123') == [('123', '')]
+
+
+class TestSuffixIgnore:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+        setup_country_config(def_config)
+
+    def run_sanitizer_on(self, suffix_ignore, **kwargs):
+        place = PlaceInfo({'name': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': 'de'})
+        name, _ = PlaceSanitizer([{'step': 'tag-analyzer-by-language',
+                                   'mode': 'replace',
+                                   'use-defaults': 'mono',
+                                   'whitelist': ['de', 'en'],
+                                   'suffix-ignore': suffix_ignore}],
+                                 self.config).process_names(place)
+
+        assert all(isinstance(p.attr, dict) for p in name)
+        assert all(len(p.attr) <= 1 for p in name)
+        assert all(not p.attr or ('analyzer' in p.attr and p.attr['analyzer'])
+                   for p in name)
+
+        return sorted([(p.name, p.attr.get('analyzer', '')) for p in name])
+
+    def test_ignored_suffix(self):
+        assert self.run_sanitizer_on(['left'], name_left='foo') == [('foo', 'de')]
+
+    def test_not_ignored_suffix(self):
+        assert self.run_sanitizer_on(['left'], name_en='foo') == [('foo', 'en')]
+        assert self.run_sanitizer_on(['left'], name_fr='foo') == [('foo', '')]
+
+    def test_ignored_suffix_and_whitelisted(self):
+        assert self.run_sanitizer_on(['de'], name_de='foo') == [('foo', 'de')]


### PR DESCRIPTION
This adds a new option `suffix-ignore` parameter to the sanitizer responsible for enabling language-specific processing of names. Any suffixes listed in that parameter will interpreted as not designating a language. Names with such a suffix will be processed in the same way as name keys without any language suffix.

This is used in the default configuration to ensure that `name:left` and `name:right`  are processed according to the default language setting of the country, in particular, enabling abbreviation handling. Language-specific left and right names will still not work with this setting.

Also removes `name:forward` and `name:backward` as these should always be synonyms for `name:left` and `name:right`.