### PR TITLE
Improve reverse geocoding near overlapping POIs

### DIFF
--- a/src/nominatim_api/reverse.py
+++ b/src/nominatim_api/reverse.py
@@ -355,7 +355,8 @@ class ReverseGeocoder:
             # a POI nearby and return that with preference.
             elif result.osm_type != 'N' and result.rank_search > 27 \
                     and result.distance == 0 \
-                    and row.best_inside:
+                    and row.best_inside \
+                    and (result.housenumber is None or result.housenumber == row.housenumber):
                 log().var_dump('POI near closest result area', row)
                 result = row
                 break  # it can't get better than that, everything else is farther away

--- a/src/nominatim_api/reverse.py
+++ b/src/nominatim_api/reverse.py
@@ -219,7 +219,8 @@ class ReverseGeocoder:
                              sa.func.first_value(sa.case((sa.or_(inner.c.rank_search <= 27,
                                                                  inner.c.osm_type == 'N'), None),
                                                          else_=inner.c._geometry))
-                                    .over(order_by=inner.c.distance)
+                                    .over(order_by=[inner.c.distance,
+                                                    sa.func.ST_Area(inner.c._geometry)])
                                     .label('_best_geometry')) \
                      .subquery()
 

--- a/test/bdd/features/db/query/reverse.feature
+++ b/test/bdd/features/db/query/reverse.feature
@@ -11,11 +11,27 @@ Feature: Reverse searches
           | W1  | aeroway | terminal   | (1,2,3,4,1) |
           | N9  | amenity | restaurant | 9           |
         When importing
-        And reverse geocoding 1.0001,1.0001
+        And reverse geocoding 1.0002,1.0001
         Then the result contains
          | object |
          | N9  |
         When reverse geocoding 1.0003,1.0001
+        Then the result contains
+         | object |
+         | W1  |
+
+
+    Scenario: POI in POI area with different housenumbers
+        Given the 0.0001 grid with origin 1,1
+          | 1 |   |  |  |  |  |  |  | 2 |
+          |   | 9 |  |  |  |  |  |  |   |
+          | 4 |   |  |  |  |  |  |  | 3 |
+        And the places
+          | osm | class   | type       | housenr | geometry    |
+          | W1  | aeroway | terminal   | 11      | (1,2,3,4,1) |
+          | N9  | amenity | restaurant | 13      | 9           |
+        When importing
+        And reverse geocoding 1.0002,1.0001
         Then the result contains
          | object |
          | W1  |


### PR DESCRIPTION
When POI areas overlap, choose the smaller one under the assumption that the smaller one is within the larger one. See #4105.

Choose a POI node inside a POI area over the area only when the POI area has no housenumber or the same. Fixes #3907.
