### PR TITLE
feat: add support for country-specific sanitizers #4098

### DIFF
--- a/src/nominatim_db/tokenizer/place_sanitizer.py
+++ b/src/nominatim_db/tokenizer/place_sanitizer.py
@@ -8,7 +8,7 @@
 Handler for cleaning name and address tags in place information before it
 is handed to the token analysis.
 """
-from typing import Optional, Mapping, Sequence, Callable, Any, Dict
+from typing import Optional, Mapping, Sequence, Callable, Any
 
 from ..errors import UsageError
 from ..config import Configuration
@@ -16,32 +16,38 @@ from .sanitizers.config import SanitizerConfig
 from .sanitizers.base import SanitizerHandler, ProcessInfo
 from ..data.place_info import PlaceInfo
 
+SanitizerRules = Sequence[Mapping[str, Any]]
+
+
+def _validate_step(func: Mapping[str, Any]) -> str:
+    step = func.get('step')
+    if step is None:
+        raise UsageError("Sanitizer rule is missing the 'step' attribute.")
+    if not isinstance(step, str):
+        raise UsageError("'step' attribute must be a simple string.")
+    if step.startswith('_'):
+        raise UsageError("Illegal name for 'step', must not start with '_'.")
+    if step in ('base', 'config'):
+        raise UsageError("'base' and 'config' cannot be used as name for 'step'.")
+    return step
+
 
 class PlaceSanitizer:
     """ Controller class which applies sanitizer functions on the place
         names and address before they are used by the token analysers.
     """
 
-    def __init__(self, rules: Optional[Sequence[Mapping[str, Any]]],
+    def __init__(self, rules: Optional[SanitizerRules],
                  config: Configuration,
-                 country_rules: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None) -> None:
+                 country_rules: Optional[Mapping[str, SanitizerRules]] = None) -> None:
         self.handlers: list[Callable[[ProcessInfo], None]] = []
-        self._country_handlers: Dict[str, list[Callable[[ProcessInfo], None]]] = {}
+        self._country_handlers: dict[str, list[Callable[[ProcessInfo], None]]] = {}
 
         if rules:
             for func in rules:
-                if 'step' not in func:
-                    raise UsageError("Sanitizer rule is missing the 'step' attribute.")
-                if not isinstance(func['step'], str):
-                    raise UsageError("'step' attribute must be a simple string.")
-                if func['step'].startswith('_'):
-                    raise UsageError("Illegal name for 'step', must not start with '_'.")
-                if func['step'].startswith('_') or func['step'] in ('base', 'config'):
-                    raise UsageError("'base' and 'config' cannot be used as name for 'step'.")
-
+                step = _validate_step(func)
                 module: SanitizerHandler = \
-                    config.load_plugin_module(func['step'], 'nominatim_db.tokenizer.sanitizers')
-
+                    config.load_plugin_module(step, 'nominatim_db.tokenizer.sanitizers')
                 self.handlers.append(module.create(SanitizerConfig(func)))
 
         if country_rules:
@@ -50,23 +56,10 @@ class PlaceSanitizer:
                     continue
                 handlers: list[Callable[[ProcessInfo], None]] = []
                 for func in country_rules_list:
-                    if 'step' not in func:
-                        raise UsageError(
-                            "Sanitizer rule in country configuration is missing "
-                            "the 'step' attribute.")
-                    if not isinstance(func['step'], str):
-                        raise UsageError("'step' attribute must be a simple string.")
-                    if func['step'].startswith('_'):
-                        raise UsageError(
-                            "Illegal name for 'step', must not start with '_'.")
-                    if func['step'] in ('base', 'config'):
-                        raise UsageError(
-                            "'base' and 'config' cannot be used as name for 'step'.")
-
+                    step = _validate_step(func)
                     country_module: SanitizerHandler = \
-                        config.load_plugin_module(func['step'],
+                        config.load_plugin_module(step,
                                                   'nominatim_db.tokenizer.sanitizers')
-
                     handlers.append(country_module.create(SanitizerConfig(func)))
                 self._country_handlers[country] = handlers
 
@@ -106,7 +99,7 @@ def load_sanitizers(config: Configuration) -> PlaceSanitizer:
         rules = config.load_sub_configuration('icu_tokenizer.yaml')\
                       .get('sanitizers', [])
 
-    country_rules: Dict[str, Sequence[Mapping[str, Any]]] = {}
+    country_rules: dict[str, SanitizerRules] = {}
     country_config = config.load_sub_configuration('country_settings.yaml')
     for code, props in country_config.items():
         if 'sanitizers' in props:

--- a/src/nominatim_db/tokenizer/place_sanitizer.py
+++ b/src/nominatim_db/tokenizer/place_sanitizer.py
@@ -63,11 +63,11 @@ class PlaceSanitizer:
                         raise UsageError(
                             "'base' and 'config' cannot be used as name for 'step'.")
 
-                    module: SanitizerHandler = \
+                    country_module: SanitizerHandler = \
                         config.load_plugin_module(func['step'],
                                                   'nominatim_db.tokenizer.sanitizers')
 
-                    handlers.append(module.create(SanitizerConfig(func)))
+                    handlers.append(country_module.create(SanitizerConfig(func)))
                 self._country_handlers[country] = handlers
 
     def process_names(self, place: PlaceInfo) -> None:

--- a/src/nominatim_db/tokenizer/place_sanitizer.py
+++ b/src/nominatim_db/tokenizer/place_sanitizer.py
@@ -8,7 +8,7 @@
 Handler for cleaning name and address tags in place information before it
 is handed to the token analysis.
 """
-from typing import Optional, Mapping, Sequence, Callable, Any
+from typing import Optional, Mapping, Sequence, Callable, Any, Dict
 
 from ..errors import UsageError
 from ..config import Configuration
@@ -23,8 +23,10 @@ class PlaceSanitizer:
     """
 
     def __init__(self, rules: Optional[Sequence[Mapping[str, Any]]],
-                 config: Configuration) -> None:
+                 config: Configuration,
+                 country_rules: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None) -> None:
         self.handlers: list[Callable[[ProcessInfo], None]] = []
+        self._country_handlers: Dict[str, list[Callable[[ProcessInfo], None]]] = {}
 
         if rules:
             for func in rules:
@@ -42,6 +44,32 @@ class PlaceSanitizer:
 
                 self.handlers.append(module.create(SanitizerConfig(func)))
 
+        if country_rules:
+            for country, country_rules_list in country_rules.items():
+                if not country_rules_list:
+                    continue
+                handlers: list[Callable[[ProcessInfo], None]] = []
+                for func in country_rules_list:
+                    if 'step' not in func:
+                        raise UsageError(
+                            "Sanitizer rule in country configuration is missing "
+                            "the 'step' attribute.")
+                    if not isinstance(func['step'], str):
+                        raise UsageError("'step' attribute must be a simple string.")
+                    if func['step'].startswith('_'):
+                        raise UsageError(
+                            "Illegal name for 'step', must not start with '_'.")
+                    if func['step'] in ('base', 'config'):
+                        raise UsageError(
+                            "'base' and 'config' cannot be used as name for 'step'.")
+
+                    module: SanitizerHandler = \
+                        config.load_plugin_module(func['step'],
+                                                  'nominatim_db.tokenizer.sanitizers')
+
+                    handlers.append(module.create(SanitizerConfig(func)))
+                self._country_handlers[country] = handlers
+
     def process_names(self, place: PlaceInfo) -> None:
         """ Extract a sanitized list of names and address parts from the
             given place. The function returns a tuple
@@ -52,6 +80,10 @@ class PlaceSanitizer:
         for func in self.handlers:
             func(obj)
 
+        if place.country_code and place.country_code in self._country_handlers:
+            for func in self._country_handlers[place.country_code]:
+                func(obj)
+
         place.set_sanitized(obj.names, obj.address)
 
 
@@ -61,9 +93,12 @@ def load_sanitizers(config: Configuration) -> PlaceSanitizer:
         This looks for a configuration file 'sanitizers.yaml' and creates
         a sanitizer based on that.
 
-        Failing to find the file it will further look for the 'icu_tokenizer.yam;'
+        Failing to find the file it will further look for the 'icu_tokenizer.yaml'
         and read sanitizers from there. This is only for backward compatibility
         and will go away in the next major version.
+
+        Additionally loads country-specific sanitizers from the country
+        settings configuration.
     """
     if config.config_file_exists('sanitizers.yaml'):
         rules = config.load_sub_configuration('sanitizers.yaml')
@@ -71,4 +106,10 @@ def load_sanitizers(config: Configuration) -> PlaceSanitizer:
         rules = config.load_sub_configuration('icu_tokenizer.yaml')\
                       .get('sanitizers', [])
 
-    return PlaceSanitizer(rules, config)
+    country_rules: Dict[str, Sequence[Mapping[str, Any]]] = {}
+    country_config = config.load_sub_configuration('country_settings.yaml')
+    for code, props in country_config.items():
+        if 'sanitizers' in props:
+            country_rules[code] = props['sanitizers']
+
+    return PlaceSanitizer(rules, config, country_rules)

--- a/test/python/tokenizer/test_place_sanitizer.py
+++ b/test/python/tokenizer/test_place_sanitizer.py
@@ -86,3 +86,74 @@ def test_sanitizer_missing_step_definition(def_config):
 def test_sanitizer_illegal_step_names(def_config, stepname):
     with pytest.raises(UsageError):
         sanitizer.PlaceSanitizer([{'step': stepname}], def_config)
+
+
+def test_country_sanitizer_applies_to_matching_country(def_config):
+    san = sanitizer.PlaceSanitizer(
+        [{'step': 'split-name-list'}],
+        def_config,
+        country_rules={'de': [{'step': 'split-name-list', 'delimiters': '-'}]})
+
+    place = PlaceInfo({'name': {'name': 'a;b-c'},
+                       'country_code': 'de'})
+    san.process_names(place)
+    name = place.searchable_names
+
+    assert len(name) == 3
+    assert {n.name for n in name} == {'a', 'b', 'c'}
+
+
+def test_country_sanitizer_skips_other_countries(def_config):
+    san = sanitizer.PlaceSanitizer(
+        [{'step': 'split-name-list'}],
+        def_config,
+        country_rules={'de': [{'step': 'split-name-list', 'delimiters': '-'}]})
+
+    place = PlaceInfo({'name': {'name': 'a;b-c'},
+                       'country_code': 'fr'})
+    san.process_names(place)
+    name = place.searchable_names
+
+    assert len(name) == 2
+    assert {n.name for n in name} == {'a', 'b-c'}
+
+
+def test_country_sanitizer_no_country_skipped(def_config):
+    san = sanitizer.PlaceSanitizer(
+        [{'step': 'split-name-list'}],
+        def_config,
+        country_rules={'de': [{'step': 'split-name-list', 'delimiters': '-'}]})
+
+    place = PlaceInfo({'name': {'name': 'a;b-c'}})
+    san.process_names(place)
+    name = place.searchable_names
+
+    assert len(name) == 2
+    assert {n.name for n in name} == {'a', 'b-c'}
+
+
+def test_country_sanitizer_empty_country_rules(def_config):
+    san = sanitizer.PlaceSanitizer(
+        [{'step': 'split-name-list'}],
+        def_config,
+        country_rules={'de': []})
+
+    place = PlaceInfo({'name': {'name': 'a;b-c'},
+                       'country_code': 'de'})
+    san.process_names(place)
+    name = place.searchable_names
+
+    assert len(name) == 2
+
+
+def test_country_sanitizer_missing_step_definition(def_config):
+    with pytest.raises(UsageError):
+        sanitizer.PlaceSanitizer([], def_config,
+                                  country_rules={'de': [{'id': 'split-name-list'}]})
+
+
+@pytest.mark.parametrize('stepname', ['_something', '__init__', 'base', 'config'])
+def test_country_sanitizer_illegal_step_names(def_config, stepname):
+    with pytest.raises(UsageError):
+        sanitizer.PlaceSanitizer([], def_config,
+                                  country_rules={'de': [{'step': stepname}]})

--- a/test/python/tokenizer/test_place_sanitizer.py
+++ b/test/python/tokenizer/test_place_sanitizer.py
@@ -148,12 +148,14 @@ def test_country_sanitizer_empty_country_rules(def_config):
 
 def test_country_sanitizer_missing_step_definition(def_config):
     with pytest.raises(UsageError):
-        sanitizer.PlaceSanitizer([], def_config,
-                                  country_rules={'de': [{'id': 'split-name-list'}]})
+        sanitizer.PlaceSanitizer(
+            [], def_config, country_rules={'de': [{'id': 'split-name-list'}]}
+        )
 
 
 @pytest.mark.parametrize('stepname', ['_something', '__init__', 'base', 'config'])
 def test_country_sanitizer_illegal_step_names(def_config, stepname):
     with pytest.raises(UsageError):
-        sanitizer.PlaceSanitizer([], def_config,
-                                  country_rules={'de': [{'step': stepname}]})
+        sanitizer.PlaceSanitizer(
+            [], def_config, country_rules={'de': [{'step': stepname}]}
+        )


### PR DESCRIPTION
Closes #4098

Add a sanitizers section in each country entry in country_settings.yaml. Country-specific sanitizers run after the generic sanitizers. PlaceSanitizer accepts an optional country_rules parameter. load_sanitizers() reads country-specific rules from the country settings file automatically.

Only the framework part is included. Actual rules will follow in a separate PR per #4075.