### PR TITLE
Explicitly exclude source-only files from wheel builds

### DIFF
--- a/packaging/nominatim-api/pyproject.toml
+++ b/packaging/nominatim-api/pyproject.toml
@@ -53,6 +53,10 @@ exclude = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/nominatim_api"]
 
+exclude = [
+  "src/nominatim_api/config.py"
+]
+
 [tool.hatch.build.targets.wheel.force-include]
 "src/nominatim_db/config.py" = "nominatim_api/config.py"
 "extra_src/paths.py" = "nominatim_api/paths.py"

--- a/packaging/nominatim-db/pyproject.toml
+++ b/packaging/nominatim-db/pyproject.toml
@@ -61,6 +61,10 @@ exclude = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/nominatim_db"]
 
+exclude = [
+  "src/nominatim_db/paths.py"
+]
+
 [tool.hatch.build.targets.wheel.shared-scripts]
 "scripts" = "/"
 


### PR DESCRIPTION
There are a few python files that are replaced when distributing Nominatim as a package. The pyproject.toml file already correctly excluded the files to be replaced from the source distribution but forgot to do the same with the wheel distribution. That makes builds fail with the newest version of hatchling.
