### PR TITLE
Add Support for External Postcode Geometry Import via JSONL Files

### DIFF
--- a/docs/customize/Postcodes.md
+++ b/docs/customize/Postcodes.md
@@ -1,31 +1,50 @@
 # External postcode data
 
-Nominatim creates a table of known postcode centroids during import. This table
-is used for searches of postcodes and for adding postcodes to places where the
-OSM data does not provide one. These postcode centroids are mainly computed
-from the OSM data itself. In addition, Nominatim supports reading postcode
-information from an external CSV file, to supplement the postcodes that are
-missing in OSM.
+Nominatim creates a table of known postcode centroids and geometries during import.
+This table is used for searches of postcodes and for adding postcodes to places where
+the OSM data does not provide one. These postcode centroids are mainly computed
+from the OSM data itself. In addition, Nominatim supports reading postcode information
+from external files to supplement the postcodes that are missing in OSM.
 
-To enable external postcode support, simply put one CSV file per country into
-your project directory and name it `<CC>_postcodes.csv`. `<CC>` must be the
-two-letter country code for which to apply the file. The file may also be
-gzipped. Then it must be called `<CC>_postcodes.csv.gz`.
+## Supported file formats
 
-The CSV file must use commas as a delimiter and have a header line. Nominatim
-expects three columns to be present: `postcode`, `lat` and `lon`. All other
-columns are ignored. `lon` and `lat` must describe the x and y coordinates of the
-postcode centroids in WGS84.
+Nominatim supports 2 data formats for external import:
 
-The postcode files are loaded only when there is data for the given country
-in your database. For example, if there is a `us_postcodes.csv` file in your
-project directory but you import only an excerpt of Italy, then the US postcodes
-will simply be ignored.
+### JSONL format
+
+The JSONL format may contain the postcode data along with a POLYGON or MULTIPOLYGON geometry
+of the postcode area. To enable external postcode support, put one file per country into
+your project directory and name it `<CC>_postcodes_geometry.<ext>`. `<CC>` must be the
+two-letter country code for which to apply the file. File type may be either `.jsonl` or
+`.jsonl.gz` (gzip compressed). The file must be in UTF-8 encoding and contain one JSON object
+per line with the following structure:
+
+#### GeoJSON Feature
+
+A standard [RFC7946](https://geojson.org) GeoJSON Feature object.
+
+* `geometry`: (required) A GeoJSON geometry (Polygon/MultiPolygon).
+* `properties`: (required) An object containing:
+  * `postcode`: (required) The postcode string.
+  * `lat`, `lon`: (optional) Coordinates for the centroid. If not provided, the centroid
+  is computed from the geometry.
+
+### CSV format
+
+To enable external postcode support, put one file per country into
+your project directory and name it `<CC>_postcodes.<ext>`. `<CC>` must be the
+two-letter country code for which to apply the file. File type may be either `.csv` or `.csv.gz`
+(gzip compressed). The CSV file must use commas as a delimiter and have a header line. Nominatim
+expects three columns to be present: `postcode`, `lat` and `lon`. All other columns are ignored.
+`lon` and `lat` must describe the x and y coordinates of the postcode centroids in WGS84.
+
+The postcode area is assumed to be in a buffer around the centroid (typically 5km).
+
+## Usage
 
 As a rule, the external postcode data should be put into the project directory
 **before** starting the initial import. Still, you can add, remove and update the
-external postcode data at any time. Simply
-run:
+external postcode data at any time. Simply run:
 
 ```
 nominatim refresh --postcodes

--- a/docs/develop/Database-Layout.md
+++ b/docs/develop/Database-Layout.md
@@ -119,13 +119,15 @@ the placex table. Only the following columns are special:
 Address interpolations are always ways in OSM, which is why there is no column
 `osm_type`.
 
-The **location_postcodes** table holds computed postcode assembled from the
-postcode information available in OSM. When a postcode has a postcode area
-relation, then the table stores its full geometry. For all other postcode
-the centroid is computed using the position of all OSM object that reference
-the same postoce. The `osm_id` field can be used to distinguish the two.
-When set, it refers to the OSM relation with the postcode area.
-The meaning of the columns in the table is again the same as that of the
+The **location_postcodes** table holds computed postcode assembled from the postcode information
+available in OSM. When a postcode has a postcode area relation, or when the postcode geometry is
+[imported via JSONL files](../customize/Postcodes.md#jsonl-format) then the table stores
+its full geometry. For all other postcodes the centroid is computed using the position of all OSM
+objects that reference the same postcode. The `osm_id` and `is_area` fields can be used to
+distinguish the two. When `osm_id` is set, it refers to the OSM relation with the postcode area,
+and `is_area` is `true` for postcodes with a mature geometry (either from a postcode OSM area
+relation or imported via JSONL), `false` for postcodes without a mature geometry (guessed
+postcode geometries). The meaning of other columns in the table is again the same as that of the
 placex table.
 
 Every place needs an address, a set of surrounding places that describe the

--- a/lib-sql/functions/postcode_triggers.sql
+++ b/lib-sql/functions/postcode_triggers.sql
@@ -119,6 +119,7 @@ BEGIN
     UPDATE location_postcodes p
       SET osm_id = NEW.osm_id,
           indexed_status = 2,
+          is_area = NEW.is_area,
           centroid = NEW.centroid,
           geometry = NEW.geometry
       WHERE p.country_code = NEW.country_code AND p.postcode = NEW.postcode;

--- a/lib-sql/tables/postcodes.sql
+++ b/lib-sql/tables/postcodes.sql
@@ -15,6 +15,7 @@ CREATE TABLE location_postcodes (
   indexed_date TIMESTAMP,
   country_code varchar(2) NOT NULL,
   postcode TEXT NOT NULL,
+  is_area BOOLEAN NOT NULL DEFAULT FALSE,
   centroid GEOMETRY(Geometry, 4326) NOT NULL,
   geometry GEOMETRY(Geometry, 4326) NOT NULL
   );

--- a/src/nominatim_api/search/db_searches/postcode_search.py
+++ b/src/nominatim_api/search/db_searches/postcode_search.py
@@ -49,7 +49,7 @@ class PostcodeSearch(base.AbstractSearch):
                 .where(t.c.postcode.in_(pcs))
 
         if details.geometry_output:
-            pcgeom = sa.case((sa.func.ST_NPoints(t.c.geometry) > 5, t.c.geometry),
+            pcgeom = sa.case((t.c.is_area, t.c.geometry),
                              else_=t.c.centroid)
             sql = base.add_geometry_columns(sql, pcgeom, details)
 

--- a/src/nominatim_api/sql/sqlalchemy_schema.py
+++ b/src/nominatim_api/sql/sqlalchemy_schema.py
@@ -76,6 +76,7 @@ class SearchTables:
             sa.Column('indexed_date', sa.DateTime),
             sa.Column('country_code', sa.String(2), nullable=False),
             sa.Column('postcode', sa.Text, nullable=False),
+            sa.Column('is_area', sa.Boolean, default=False, nullable=False),
             sa.Column('centroid', Geometry, nullable=False),
             sa.Column('geometry', Geometry, nullable=False))
 

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -507,3 +507,15 @@ def create_associated_street_triggers(conn: Connection, config: Configuration, *
         cur.execute("""CREATE OR REPLACE TRIGGER place_associated_street_update
                        AFTER INSERT OR DELETE ON place_associated_street
                        FOR EACH ROW EXECUTE FUNCTION invalidate_associated_street_members()""")
+
+
+@_migration(5, 3, 99, 1)
+def alter_location_postcode_add_area_flag(conn: Connection, **_: Any) -> None:
+    """ Add is_area flag to location_postcodes table
+    """
+    with conn.cursor() as cur:
+        if not table_has_column(conn, 'location_postcodes', 'is_area'):
+            cur.execute("""ALTER TABLE location_postcodes
+                        ADD COLUMN is_area BOOLEAN NOT NULL DEFAULT FALSE""")
+            cur.execute("""UPDATE location_postcodes
+                        SET is_area = true WHERE osm_id IS NOT NULL""")

--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import csv
 import gzip
 import logging
+import json
 from math import isfinite
 
 from psycopg import sql as pysql
@@ -46,6 +47,15 @@ def _extent_to_rank(extent: int) -> int:
     if extent <= 3000:
         return 23
     return 21
+
+
+def _open_external_file(fname: Path) -> TextIO:
+    """ Open an external postcode data file, handling both flat text
+        and gzip compression transparently based on the file extension.
+    """
+    if fname.suffix == '.gz':
+        return gzip.open(fname, 'rt', encoding='utf-8')
+    return open(fname, 'r', encoding='utf-8')
 
 
 class _PostcodeCollector:
@@ -91,8 +101,9 @@ class _PostcodeCollector:
             to_delete = []
         else:
             with conn.cursor() as cur:
+                # Ensure we only drop non-area artificial points on point updates
                 cur.execute("""SELECT postcode FROM location_postcodes
-                               WHERE country_code = %s AND osm_id is null""",
+                               WHERE country_code = %s AND osm_id IS NULL AND NOT is_area""",
                             (self.country, ))
                 to_delete = [row[0] for row in cur if row[0] not in self.collected]
 
@@ -129,18 +140,18 @@ class _PostcodeCollector:
             if to_delete:
                 cur.execute("""DELETE FROM location_postcodes
                                WHERE country_code = %s and postcode = any(%s)
-                                     AND osm_id is null
+                                     AND osm_id is null and not is_area
                             """, (self.country, to_delete))
 
     def _update_from_external(self, analyzer: AbstractAnalyzer, project_dir: Path) -> None:
         """ Look for an external postcode file for the active country in
             the project directory and add missing postcodes when found.
         """
-        csvfile = self._open_external(project_dir)
-        if csvfile is None:
+        fname = self._find_external_centroid_file(project_dir)
+        if fname is None:
             return
 
-        try:
+        with _open_external_file(fname) as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 if 'postcode' not in row or 'lat' not in row or 'lon' not in row:
@@ -158,22 +169,12 @@ class _PostcodeCollector:
                         LOG.warning("Bad coordinates %s, %s in '%s' country postcode file.",
                                     row['lat'], row['lon'], self.country)
 
-        finally:
-            csvfile.close()
-
-    def _open_external(self, project_dir: Path) -> Optional[TextIO]:
-        fname = project_dir / f'{self.country}_postcodes.csv'
-
-        if fname.is_file():
-            LOG.info("Using external postcode file '%s'.", fname)
-            return open(fname, 'r', encoding='utf-8')
-
-        fname = project_dir / f'{self.country}_postcodes.csv.gz'
-
-        if fname.is_file():
-            LOG.info("Using external postcode file '%s'.", fname)
-            return gzip.open(fname, 'rt', encoding='utf-8')
-
+    def _find_external_centroid_file(self, project_dir: Path) -> Optional[Path]:
+        for ext in ('csv', 'csv.gz'):
+            fname = project_dir / f'{self.country}_postcodes.{ext}'
+            if fname.is_file():
+                LOG.info("Using external postcode file '%s'.", fname)
+                return fname
         return None
 
 
@@ -200,6 +201,8 @@ def update_postcodes(dsn: str, project_dir: Optional[Path],
                                 DISABLE TRIGGER location_postcodes_before_insert""")
             # Now update first postcode areas
             _update_postcode_areas(conn, analyzer, matcher, is_initial)
+            # Update postcode areas from external geometry files
+            _update_external_postcode_areas(conn, analyzer, matcher, project_dir, is_initial)
             # Then fill with estimated postcode centroids from other info
             _update_guessed_postcode(conn, analyzer, matcher, project_dir, is_initial)
             if is_initial:
@@ -224,11 +227,12 @@ def _insert_postcode_areas(conn: Connection, country_code: str,
     if pcs:
         with conn.cursor() as cur:
             columns = ['osm_id', 'country_code',
-                       'rank_search', 'postcode',
+                       'rank_search', 'postcode', 'is_area',
                        'centroid', 'geometry']
             values = [pysql.Identifier('osm_id'), pysql.Identifier('country_code'),
                       pysql.Literal(_extent_to_rank(extent)), pysql.Placeholder('out'),
-                      pysql.Identifier('centroid'), pysql.Identifier('geometry')]
+                      pysql.Literal(True), pysql.Identifier('centroid'),
+                      pysql.Identifier('geometry')]
             if is_initial:
                 columns.extend(('place_id', 'indexed_status'))
                 values.extend((pysql.SQL("nextval('seq_place')"), pysql.Literal(1)))
@@ -291,12 +295,158 @@ def _update_postcode_areas(conn: Connection, analyzer: AbstractAnalyzer,
                                    is_initial)
 
 
+def _find_external_geometry_file(project_dir: Path, country: str) -> Optional[Path]:
+    for ext in ('jsonl', 'jsonl.gz'):
+        fname = project_dir / f'{country}_postcodes_geometry.{ext}'
+        if fname.is_file():
+            LOG.info("Using external postcode file '%s'.", fname)
+            return fname
+    return None
+
+
+def _insert_external_postcode_areas(conn: Connection, country_code: str,
+                                    extent: int, pcs: list[dict[str, Optional[str | float]]],
+                                    is_initial: bool) -> None:
+    if not pcs:
+        return
+
+    if not is_initial:
+        # first get the list of existing postcodes from previous geometry import.
+        with conn.cursor() as cur:
+            cur.execute("""SELECT postcode FROM location_postcodes
+                            WHERE country_code = %s AND osm_id IS NULL AND is_area""",
+                        (country_code,))
+            existing_pcs = {row[0] for row in cur}
+
+        new_pcs = {p['postcode'] for p in pcs}
+
+        # Delete postcodes that were previously imported but no longer appear
+        to_delete = existing_pcs - new_pcs
+
+        if to_delete:
+            with conn.cursor() as cur:
+                cur.execute("""DELETE FROM location_postcodes
+                            WHERE country_code = %s AND osm_id IS NULL AND is_area
+                            AND postcode = any(%s)
+                            """, (country_code, list(to_delete)))
+
+    with conn.cursor() as cur:
+        columns = ['country_code', 'rank_search', 'postcode',
+                   'is_area', 'centroid', 'geometry']
+        values = [
+            pysql.Literal(country_code),
+            pysql.Literal(_extent_to_rank(extent)),
+            pysql.Placeholder('postcode'),
+            pysql.Literal(True),
+            pysql.SQL("""COALESCE(
+                           ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s), 4326),
+                           ST_Centroid(ST_GeomFromGeoJSON(%(geometry)s))
+                         )"""),
+            pysql.SQL("ST_GeomFromGeoJSON(%(geometry)s)"),
+        ]
+        if is_initial:
+            columns.extend(('place_id', 'indexed_status'))
+            values.extend((pysql.SQL("nextval('seq_place')"), pysql.Literal(1)))
+
+        cur.executemany(
+            pysql.SQL("INSERT INTO location_postcodes ({}) VALUES ({})").format(
+                pysql.SQL(',').join(pysql.Identifier(c) for c in columns),
+                pysql.SQL(',').join(values)
+            ),
+            pcs
+        )
+
+
+def _update_external_postcode_areas(conn: Connection, analyzer: AbstractAnalyzer,
+                                    matcher: PostcodeFormatter,
+                                    project_dir: Optional[Path], is_initial: bool) -> None:
+    if project_dir is None:
+        return
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT country_code FROM country_name")
+        todo_countries = {row[0] for row in cur}
+
+    # Exclude postcodes that are already covered by OSM areas.
+    area_pcs: dict[str, set[str]] = defaultdict(set)
+    with conn.cursor() as cur:
+        cur.execute("""SELECT country_code, postcode FROM location_postcodes
+                       WHERE is_area = true AND osm_id IS NOT NULL""")
+        for cc, pc in cur:
+            area_pcs[cc].add(pc)
+
+    for country in todo_countries:
+        fmt = matcher.get_matcher(country)
+        if fmt is None:
+            continue
+
+        fname = _find_external_geometry_file(project_dir, country)
+        if fname is None:
+            continue
+
+        pcs = []
+        with _open_external_file(fname) as jsonlfile:
+            for i, line in enumerate(jsonlfile, start=1):
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    LOG.warning("Ignored line %s: bad JSON for country '%s'.", i, country)
+                    continue
+
+                geometry = data.get('geometry')
+                if (not isinstance(geometry, dict) or
+                        geometry.get('type') not in ('Polygon', 'MultiPolygon') or
+                        not isinstance(geometry.get('coordinates'), list)):
+                    LOG.warning("Ignored line %s: bad geometry for country '%s'.", i, country)
+                    continue
+
+                props = data.get('properties')
+                if not isinstance(props, dict):
+                    LOG.warning("Ignored line %s: bad properties for country '%s'.", i, country)
+                    continue
+
+                raw_postcode = props.get('postcode')
+                if not raw_postcode:
+                    LOG.warning("Ignored line %s: missing postcode for country '%s'.", i, country)
+                    continue
+
+                m = fmt.match(raw_postcode)
+                if not m:
+                    continue
+                normalized = fmt.normalize(m)
+
+                if normalized in area_pcs[country]:
+                    continue
+
+                # parse optional centroid
+                lon, lat = None, None
+                if props.get('lon') is not None and props.get('lat') is not None:
+                    try:
+                        lat = _to_float(props['lat'], 90)
+                        lon = _to_float(props['lon'], 180)
+                    except ValueError:
+                        LOG.warning("Bad centroid on line %s for country '%s', "
+                                    "will use geometry centroid.", i, country)
+                        lat, lon = None, None
+
+                pcs.append({
+                    'postcode': normalized,
+                    'geometry': json.dumps(geometry),
+                    'lon': lon,
+                    'lat': lat,
+                })
+
+        _insert_external_postcode_areas(conn, country,
+                                        matcher.get_postcode_extent(country),
+                                        pcs, is_initial)
+
+
 def _update_guessed_postcode(conn: Connection, analyzer: AbstractAnalyzer,
                              matcher: PostcodeFormatter, project_dir: Optional[Path],
                              is_initial: bool) -> None:
     """ Computes artificial postcode centroids from the placex table,
-        potentially enhances it with external data and then updates the
-        postcodes in the table 'location_postcodes'.
+        potentially enhances it with external postcode centroid data and then updates
+        the postcodes in the table 'location_postcodes'.
     """
     # First get the list of countries that currently have postcodes.
     # (Doing this before starting to insert, so it is fast on import.)
@@ -305,25 +455,26 @@ def _update_guessed_postcode(conn: Connection, analyzer: AbstractAnalyzer,
     else:
         with conn.cursor() as cur:
             cur.execute("""SELECT DISTINCT country_code FROM location_postcodes
-                            WHERE osm_id is null""")
+                            WHERE osm_id is null AND not is_area""")
             todo_countries = {row[0] for row in cur}
 
-    # Next, get the list of postcodes that are already covered by areas.
+    # Next, get the list of postcodes already covered by areas (both OSM and geometry import).
     area_pcs = defaultdict(set)
     with conn.cursor() as cur:
         cur.execute("""SELECT country_code, postcode
-                       FROM location_postcodes WHERE osm_id is not null
+                       FROM location_postcodes WHERE is_area
                        ORDER BY country_code""")
         for cc, pc in cur:
             area_pcs[cc].add(pc)
 
-    # Create a temporary table which contains coverage of the postcode areas.
+    # Create a temporary table which contains coverage of the postcode areas imported from osm
+    # and external geometry imported through xx_postcode_areas.jsonl.
     with conn.cursor() as cur:
         cur.execute("DROP TABLE IF EXISTS _global_postcode_area")
         cur.execute("""CREATE TABLE _global_postcode_area AS
                        (SELECT ST_SubDivide(ST_SimplifyPreserveTopology(
                                               ST_Union(geometry), 0.00001), 128) as geometry
-                        FROM place_postcode WHERE geometry is not null)
+                        FROM location_postcodes WHERE is_area)
                     """)
         cur.execute("CREATE INDEX ON _global_postcode_area USING gist(geometry)")
 

--- a/src/nominatim_db/tools/postcodes.py
+++ b/src/nominatim_db/tools/postcodes.py
@@ -159,7 +159,7 @@ class _PostcodeCollector:
                                 " Ignored.", self.country)
                     return
                 postcode = analyzer.normalize_postcode(row['postcode'])
-                if postcode not in self.collected:
+                if postcode not in self.collected and postcode not in self.exclude:
                     try:
                         # Do float conversation separately, it might throw
                         centroid = (_to_float(row['lon'], 180),

--- a/src/nominatim_db/version.py
+++ b/src/nominatim_db/version.py
@@ -55,7 +55,7 @@ def parse_version(version: str) -> NominatimVersion:
     return NominatimVersion(*[int(x) for x in parts[:2] + parts[2].split('-')])
 
 
-NOMINATIM_VERSION = parse_version('5.3.99-0')
+NOMINATIM_VERSION = parse_version('5.3.99-1')
 
 POSTGRESQL_REQUIRED_VERSION = (12, 0)
 POSTGIS_REQUIRED_VERSION = (3, 0)

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -339,13 +339,13 @@ def postcode_table(temp_db_with_extensions, load_sql):
 
 @pytest.fixture
 def postcode_row(postcode_table, temp_db_cursor):
-    def _add(country, postcode, x=34.5, y=-9.33):
+    def _add(country, postcode, x=34.5, y=-9.33, is_area=False):
         geom = _with_srid(f"POINT({x} {y})")
         return temp_db_cursor.insert_row(
             'location_postcodes',
             place_id=pysql.SQL("nextval('seq_place')"),
             indexed_status=pysql.Literal(1),
-            country_code=country, postcode=postcode,
+            country_code=country, postcode=postcode, is_area=is_area,
             centroid=geom,
             rank_search=pysql.Literal(16),
             geometry=('ST_Expand(%s::geometry, 0.005)', geom))

--- a/test/python/tools/test_postcodes.py
+++ b/test/python/tools/test_postcodes.py
@@ -8,6 +8,7 @@
 Tests for functions to maintain the artificial postcode table.
 """
 import subprocess
+import json
 
 import pytest
 
@@ -20,11 +21,13 @@ import dummy_tokenizer
 
 
 @pytest.fixture
-def insert_implicit_postcode(placex_row, place_postcode_row):
+def insert_implicit_postcode(placex_row, place_postcode_row, country_row):
     """ Insert data into the placex and place table
         which can then be used to compute one postcode.
     """
     def _insert_implicit_postcode(osm_id, country, geometry, postcode, in_placex=False):
+        country_row(country=country, names={"name": country})
+
         if in_placex:
             placex_row(osm_id=osm_id, country=country, geom=geometry,
                        centroid=geometry,
@@ -36,10 +39,12 @@ def insert_implicit_postcode(placex_row, place_postcode_row):
 
 
 @pytest.fixture
-def insert_postcode_area(place_postcode_row):
+def insert_postcode_area(place_postcode_row, country_row):
     """ Insert an area around a centroid to the postcode table.
     """
     def _do(osm_id, country, postcode, x, y):
+        country_row(country=country, names={"name": country})
+
         x1, x2, y1, y2 = x - 0.001, x + 0.001, y - 0.001, y + 0.001
         place_postcode_row(osm_type='R', osm_id=osm_id, postcode=postcode, country=country,
                            centroid=f"POINT({x} {y})",
@@ -197,8 +202,78 @@ class TestPostcodes:
                                 (None, 'cc', 'DD23 T', 100, 56)}
 
     @pytest.mark.parametrize("gzipped", [True, False])
-    def test_postcodes_extern(self, postcode_update, tmp_path,
-                              insert_implicit_postcode, gzipped):
+    def test_postcodes_extern_jsonl(self, postcode_update, tmp_path,
+                                    insert_implicit_postcode, gzipped):
+        insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
+
+        extfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        extfile.write_text(
+            json.dumps({'properties': {'postcode': 'CD 4511'},
+                        # Centroid : 0.5, 0.5
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n' +
+            json.dumps({'properties': {'postcode': '822114', 'lat': 0.1, 'lon': 0.2},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n', encoding='utf-8')
+
+        if gzipped:
+            subprocess.run(['gzip', str(extfile)])
+            assert not extfile.is_file()
+
+        postcode_update(tmp_path)
+
+        assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
+                                (None, 'xx', 'CD 4511', 0.5, 0.5),
+                                (None, 'xx', '822114', 0.2, 0.1)}
+
+    def test_postcodes_extern_jsonl_invalid_data(self, postcode_update, tmp_path,
+                                                 insert_implicit_postcode):
+        insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
+
+        extfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        extfile.write_text(
+            # Invalid JSON
+            '{"geometry": {"type": "Polygon"}, "properties": {"postcode": "BAD"}\n'
+            # Missing geometry
+            + json.dumps({'properties': {'postcode': 'NOGEOM'}}) + '\n'
+            # Invalid geometry type
+            + json.dumps({'geometry': {'type': 'Point', 'coordinates': [0, 0]},
+                          'properties': {'postcode': 'BADGEOM'}}) + '\n'
+            # Missing postcode
+            + json.dumps({'properties': {'lat': 0, 'lon': 0},
+                          'geometry': {'type': 'Polygon', 'coordinates': [[
+                              [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n'
+            # Valid one
+            + json.dumps({'geometry': {'type': 'Polygon', 'coordinates': [[
+                [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+                'properties': {'postcode': 'GOOD'}}) + '\n', encoding='utf-8')
+
+        postcode_update(tmp_path)
+
+        assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
+                                (None, 'xx', 'GOOD', 0.5, 0.5)}
+
+    def test_postcodes_extern_jsonl_overwrite_past_import(self, postcode_update, tmp_path,
+                                                          postcode_row, country_row):
+        country_row(country="xx", names={"name": "xx"})
+        postcode_row('xx', '822114', 83.8, 24.1, True)  # area from past geometry import
+        postcode_row('xx', '110000', 77.2, 28.6, True)
+
+        extfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        extfile.write_text(
+            # overwrites past postcode
+            json.dumps({'properties': {'postcode': '822114'},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n', encoding='utf-8')
+
+        postcode_update(tmp_path)
+
+        # pc 110000 no longer exist in import file, thus deleted
+        assert self.row_set == {(None, 'xx', '822114', 0.5, 0.5)}
+
+    @pytest.mark.parametrize("gzipped", [True, False])
+    def test_postcodes_extern_csv(self, postcode_update, tmp_path,
+                                  insert_implicit_postcode, gzipped):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -213,8 +288,8 @@ class TestPostcodes:
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
                                 (None, 'xx', 'CD 4511', -10, -5)}
 
-    def test_postcodes_extern_bad_column(self, postcode_update, tmp_path,
-                                         insert_implicit_postcode):
+    def test_postcodes_extern_csv_bad_column(self, postcode_update, tmp_path,
+                                             insert_implicit_postcode):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -224,8 +299,8 @@ class TestPostcodes:
 
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12)}
 
-    def test_postcodes_extern_bad_number(self, postcode_update, insert_implicit_postcode,
-                                         tmp_path):
+    def test_postcodes_extern_csv_bad_number(self, postcode_update, insert_implicit_postcode,
+                                             tmp_path):
         insert_implicit_postcode(1, 'xx', 'POINT(10 12)', 'AB 4511')
 
         extfile = tmp_path / 'xx_postcodes.csv'
@@ -236,6 +311,43 @@ class TestPostcodes:
 
         assert self.row_set == {(None, 'xx', 'AB 4511', 10, 12),
                                 (None, 'xx', 'CD 4511', -10, -5)}
+
+    def test_postcodes_import_precedence(self, postcode_update, tmp_path,
+                                         insert_implicit_postcode, insert_postcode_area):
+        # osm area precedes all external imoprts
+        insert_postcode_area(3, 'xx', '110000', 77.2, 28.6)
+        # guessed postcode area from osm points, should be overwritten by geometry import
+        insert_implicit_postcode(1, 'xx', 'POINT(10 12)', '822114')
+        insert_implicit_postcode(2, 'xx', 'POINT(0 12)', '822114')
+
+        josnlfile = tmp_path / 'xx_postcodes_geometry.jsonl'
+        josnlfile.write_text(
+            # ignored, osm area takes precedence over geometry import
+            json.dumps({'properties': {'postcode': '110000', 'lat': 0.1, 'lon': 0.2},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}}) + '\n' +
+            # geometry import takes precedence over guessed postcode from osm points
+            json.dumps({'properties': {'postcode': '822114'},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]}}) + '\n' +
+            # geometry import takes precedence over csv import
+            json.dumps({'properties': {'postcode': '822115'},
+                        'geometry': {'type': 'Polygon', 'coordinates': [[
+                            [0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]}}) + '\n', encoding='utf-8')
+
+        csvfile = tmp_path / 'xx_postcodes.csv'
+        csvfile.write_text(
+            "postcode,lat,lon\n"
+            "822115,0.2,0.2\n"  # ignored, geometry import takes precedence over csv import
+            "822116,-5,-10",  # added
+            encoding='utf-8')
+
+        postcode_update(tmp_path)
+
+        assert self.row_set == {(None, 'xx', '822114', 5, 5),
+                                (None, 'xx', '822115', 1, 1),
+                                (3, 'xx', '110000', 77.2, 28.6),
+                                (None, 'xx', '822116', -10, -5)}
 
     def test_no_placex_entry(self, postcode_update, temp_db_cursor, place_postcode_row):
         # Rewrite the get_country_code function to verify its execution.


### PR DESCRIPTION
## Summary
Closes #4080
This PR introduces support for importing external postcode data in both csv and jsonl (json lines) formats, allowing for richer postcode geometry import. In JSONL files, we can now provide full geometries, and centroids (optional).

The new JSONL files would need to placed in the project directory with name XX_postcodes_geometry.jsonl.

Currently OSM imported postcodes precede over jsonl imports which precedes csv imports (csv imports are at the same confidence level with guessed postcode areas).

The import logic, storage, and documentation are updated accordingly, and comprehensive tests are added for the new functionality.

Also introduces a new `is_area` flag in `location_postcodes` table.

## AI usage
LLM based CLI tools were extensively used to understand the codebase and find out the relevant files pertaining the targeted changes.

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
