### PR TITLE
Enhance sanitizing for housenumbers

### DIFF
--- a/settings/sanitizers.yaml
+++ b/settings/sanitizers.yaml
@@ -7,6 +7,12 @@
   filter-name:
     - '.*=.*'
     - '.*https?:.*'
+- step: delete-names
+  type: address
+  filter-kind:
+    - unit
+    - floor
+    - flats
 - step: clean-housenumbers
   filter-kind:
     - housenumber

--- a/settings/sanitizers.yaml
+++ b/settings/sanitizers.yaml
@@ -1,10 +1,20 @@
+- step: delete-names
+  type: name
+  filter-name:
+    - '.*https?:.*'
+- step: delete-names
+  type: address
+  filter-name:
+    - '.*=.*'
+    - '.*https?:.*'
 - step: clean-housenumbers
   filter-kind:
     - housenumber
     - conscriptionnumber
     - streetnumber
   convert-to-name:
-    - (\A|.*,)[^\d,]{3,}(,.*|\Z)
+    - '.*[^;,]{15,}.*'
+    - '(\A|.*,)[^\d,]{3,}(,.*|\Z)'
 - step: clean-postcodes
   convert-to-address: yes
   default-pattern: "[A-Z0-9- ]{3,12}"


### PR DESCRIPTION
Drops `addr:*` tags from the search index when it contains what looks like an URL or an equal sign. Both are a sure sign of a tagging error. Names containing URLs are dropped as well. Even if they are valid, they will just create havoc with the search index.

Housenumbers with more than 15 characters are moved to names.

`addr:unit`, `addr:floor` and `addr:flats` are excluded completely from adding to the search index. Until now they would end up in the `nameaddress_vector` but not really searchable from there because they generally appear with a 'unit' or 'flat' classifier. The fields are still in the address field, so available for returning to the user.