### PR TITLE
Add a line in CONTRIBUTING.md on agent-driven contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ description or in documentation need to
    sufficient. You need to show that the code actually solves the problem
    the PR claims to solve.
 
+We do not accept **under any circumstances** bulk-generated, agent-driven contributions.
+These PRs create a huge burden on the maintainers while not bringing a net-positive
+in increased engagement for the project.
+
 ## Getting Started with Development
 
 Please see the development section of the Nominatim documentation for


### PR DESCRIPTION
The repo has been hit by quite a few mass-produced PRs now. This just adds a section to explain that these PRs will not be accepted. Something to point contributors to when closing PRs.

Text is heavily inspired by [typescript-go's contributing document](https://github.com/microsoft/typescript-go/blob/main/CONTRIBUTING.md).