### PR TITLE
Improvements to regex query preprocessor

### DIFF
--- a/src/nominatim_api/query_preprocessing/config.py
+++ b/src/nominatim_api/query_preprocessing/config.py
@@ -5,10 +5,14 @@
 # Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
-Configuration for Sanitizers.
+Configuration for query preprocessors.
 """
-from typing import Any
+from typing import Any, TypeVar
 from collections import UserDict
+
+from ..errors import UsageError
+
+T = TypeVar('T')
 
 
 class QueryConfig(UserDict[str, Any]):
@@ -18,3 +22,18 @@ class QueryConfig(UserDict[str, Any]):
         accessors to standard preprocessor options that are used by many of the
         preprocessors.
     """
+
+    def require_typed(self, param: str, dtype: type[T]) -> T:
+        """ Return the value for the given parameter.
+            Raises a UsageError if the parameter is not present or
+            of the wrong type.
+        """
+        result = self.get(param)
+
+        if result is None:
+            raise UsageError(f"Parameter '{param}' missing.")
+
+        if not isinstance(result, dtype):
+            raise UsageError(f"Parameter '{param}' must be of type {dtype.__name__}")
+
+        return result

--- a/src/nominatim_api/query_preprocessing/regex_replace.py
+++ b/src/nominatim_api/query_preprocessing/regex_replace.py
@@ -37,7 +37,7 @@ class _GenericPreprocessing:
     def split_phrase(self, phrase: Phrase) -> Phrase:
         """This function performs replacements on the given text using regex patterns."""
         for item in self.compiled_patterns:
-            phrase.text = item[0].sub(item[1], phrase.text)
+            phrase.text = item[0].sub(item[1], phrase.text).strip()
 
         return phrase
 
@@ -46,7 +46,7 @@ class _GenericPreprocessing:
         Return the final Phrase list.
         Returns an empty list if there is nothing left after split_phrase.
         """
-        result = [p for p in map(self.split_phrase, phrases) if p.text.strip()]
+        result = [p for p in map(self.split_phrase, phrases) if p.text]
         return result
 
 

--- a/src/nominatim_api/query_preprocessing/regex_replace.py
+++ b/src/nominatim_api/query_preprocessing/regex_replace.py
@@ -2,10 +2,13 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 This preprocessor replaces values in a given input based on pre-defined regex rules.
+
+The preprocessor takes a list of replacements in the 'replacement' parameter.
+Each replacement takes the following arguments:
 
 Arguments:
     pattern: Regex pattern to be applied on the input

--- a/src/nominatim_api/query_preprocessing/regex_replace.py
+++ b/src/nominatim_api/query_preprocessing/regex_replace.py
@@ -29,7 +29,7 @@ class _GenericPreprocessing:
         """Initialise the _GenericPreprocessing class with patterns from the ICU config file."""
         self.config = config
 
-        match_patterns = self.config.get('replacements', 'Key not found')
+        match_patterns = self.config.require_typed('replacements', list)
         self.compiled_patterns = [
             (re.compile(item['pattern']), item['replace']) for item in match_patterns
             ]

--- a/test/python/api/query_processing/test_regex_replace.py
+++ b/test/python/api/query_processing/test_regex_replace.py
@@ -4,14 +4,15 @@
 #
 # Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
-'''
+"""
 Tests for replacing values in an input using custom regex.
-'''
+"""
 import pytest
 
 import nominatim_api.search.query as qmod
 from nominatim_api.query_preprocessing.config import QueryConfig
 from nominatim_api.query_preprocessing import regex_replace
+from nominatim_api.errors import UsageError
 
 
 def run_preprocessor_on(query):
@@ -46,3 +47,13 @@ def test_split_phrases(inp, outp):
 
     out = run_preprocessor_on(query)
     assert out == [qmod.Phrase(qmod.PHRASE_ANY, text) for text in outp]
+
+
+def test_missing_replacement_section():
+    with pytest.raises(UsageError, match="'replacements' missing"):
+        regex_replace.create(QueryConfig())
+
+
+def test_bad_type_for_replacement():
+    with pytest.raises(UsageError, match="'replacements' must be of type list"):
+        regex_replace.create(QueryConfig({'replacements': 'something'}))

--- a/test/python/api/query_processing/test_regex_replace.py
+++ b/test/python/api/query_processing/test_regex_replace.py
@@ -36,9 +36,9 @@ def run_preprocessor_on(query):
     (['http://osm.org'], []),
     (['https://www.openstreetmap.org/user/abc'], []),
     (['https://tile.openstreetmap.org/12/2048/2048.png'], []),
-    (['Check the map at https://www.openstreetmap.org'], ['Check the map at ']),
+    (['Check the map at https://www.openstreetmap.org'], ['Check the map at']),
     (['Use 203.0.113.255 for routing'], ['Use  for routing']),
-    (['Find maps at https://osm.org and http://openstreetmap.org'], ['Find maps at  and ']),
+    (['Find maps at https://osm.org and http://openstreetmap.org'], ['Find maps at  and']),
     (['203.0.113.255', 'Some Address'], ['Some Address']),
     (['https://osm.org', 'Another Place'], ['Another Place']),
 ])


### PR DESCRIPTION
This adds parameter checking to the configuration reader of the preprocessor so that it prints more meaningful error messages. Phrases are now stripped of leading and trailing spaces after replacement. And the documentation now mentions the required 'replacements' section.
