### PR TITLE
Add some type aliases for better readability

### DIFF
--- a/src/nominatim_db/data/place_info.py
+++ b/src/nominatim_db/data/place_info.py
@@ -10,7 +10,7 @@ the tokenizer.
 """
 from typing import Optional, Mapping, Any, Tuple, cast
 
-from .place_name import PlaceName
+from .place_name import PlaceNames
 
 
 class PlaceInfo:
@@ -20,8 +20,8 @@ class PlaceInfo:
 
     def __init__(self, info: Mapping[str, Any]) -> None:
         self._info = info
-        self._searchable_names: list[PlaceName] = []
-        self._searchable_address: list[PlaceName] = []
+        self._searchable_names: PlaceNames = []
+        self._searchable_address: PlaceNames = []
 
     @property
     def name(self) -> Optional[Mapping[str, str]]:
@@ -47,13 +47,13 @@ class PlaceInfo:
         return self._info.get('address')
 
     @property
-    def searchable_names(self) -> list[PlaceName]:
+    def searchable_names(self) -> PlaceNames:
         """ List of place names that should be indexed for searching.
         """
         return self._searchable_names
 
     @property
-    def searchable_address(self) -> list[PlaceName]:
+    def searchable_address(self) -> PlaceNames:
         """ List of address terms that should be used to build the search
             index.
         """
@@ -101,6 +101,6 @@ class PlaceInfo:
         """
         return 26 <= self.rank_address <= 27
 
-    def set_sanitized(self, names: list[PlaceName], address: list[PlaceName]) -> None:
+    def set_sanitized(self, names: PlaceNames, address: PlaceNames) -> None:
         self._searchable_names = names
         self._searchable_address = address

--- a/src/nominatim_db/data/place_name.py
+++ b/src/nominatim_db/data/place_name.py
@@ -81,3 +81,6 @@ class PlaceName:
         """ Check if the given attribute is set.
         """
         return key in self.attr
+
+
+PlaceNames = list[PlaceName]

--- a/src/nominatim_db/tokenizer/base.py
+++ b/src/nominatim_db/tokenizer/base.py
@@ -15,7 +15,7 @@ from ..typing import Protocol
 from ..config import Configuration
 from ..db.connection import Connection
 from ..data.place_info import PlaceInfo
-from ..data.place_name import PlaceName
+from ..data.place_name import PlaceNames
 
 
 class AbstractAnalyzer(ABC):
@@ -91,7 +91,7 @@ class AbstractAnalyzer(ABC):
         """
 
     @abstractmethod
-    def add_country_names(self, country_code: str, names: list[PlaceName]) -> None:
+    def add_country_names(self, country_code: str, names: PlaceNames) -> None:
         """ Add the given names to the tokenizer's list of country tokens.
 
             Arguments:

--- a/src/nominatim_db/tokenizer/icu_tokenizer.py
+++ b/src/nominatim_db/tokenizer/icu_tokenizer.py
@@ -20,7 +20,7 @@ from ..db.connection import connect, Connection, Cursor, \
 from ..config import Configuration
 from ..db.sql_preprocessor import SQLPreprocessor
 from ..data.place_info import PlaceInfo
-from ..data.place_name import PlaceName
+from ..data.place_name import PlaceName, PlaceNames
 from .icu_rule_loader import ICURuleLoader
 from .icu_token_analysis import ICUTokenAnalysis
 from .base import AbstractAnalyzer, AbstractTokenizer
@@ -444,12 +444,12 @@ class ICUNameAnalyzer(AbstractAnalyzer):
 
         return len(to_delete)
 
-    def add_country_names(self, country_code: str, names: list[PlaceName]) -> None:
+    def add_country_names(self, country_code: str, names: PlaceNames) -> None:
         """ Add default names for the given country to the search index.
         """
         self._add_country_full_names(country_code, names, internal=True)
 
-    def _add_country_full_names(self, country_code: str, names: Sequence[PlaceName],
+    def _add_country_full_names(self, country_code: str, names: PlaceNames,
                                 internal: bool = False) -> None:
         """ Add names for the given country from an already sanitized
             name list.
@@ -525,8 +525,7 @@ class ICUNameAnalyzer(AbstractAnalyzer):
 
         return token_info.to_dict()
 
-    def _process_place_address(self, token_info: '_TokenInfo',
-                               address: Sequence[PlaceName]) -> None:
+    def _process_place_address(self, token_info: '_TokenInfo', address: PlaceNames) -> None:
         for item in address:
             if item.kind == 'postcode':
                 token_info.set_postcode(self._add_postcode(item))
@@ -601,7 +600,7 @@ class ICUNameAnalyzer(AbstractAnalyzer):
 
         return full
 
-    def _compute_name_tokens(self, names: Sequence[PlaceName]) -> set[int]:
+    def _compute_name_tokens(self, names: PlaceNames) -> set[int]:
         """ Computes the full name and partial name tokens for the given
             dictionary of names.
         """

--- a/src/nominatim_db/tokenizer/place_sanitizer.py
+++ b/src/nominatim_db/tokenizer/place_sanitizer.py
@@ -8,12 +8,12 @@
 Handler for cleaning name and address tags in place information before it
 is handed to the token analysis.
 """
-from typing import Optional, Mapping, Sequence, Callable, Any
+from typing import Optional, Mapping, Sequence, Any
 
 from ..errors import UsageError
 from ..config import Configuration
 from .sanitizers.config import SanitizerConfig
-from .sanitizers.base import SanitizerHandler, ProcessInfo
+from .sanitizers.base import SanitizerHandler, SanitizerFunc, ProcessInfo
 from ..data.place_info import PlaceInfo
 
 SanitizerRules = Sequence[Mapping[str, Any]]
@@ -40,8 +40,8 @@ class PlaceSanitizer:
     def __init__(self, rules: Optional[SanitizerRules],
                  config: Configuration,
                  country_rules: Optional[Mapping[str, SanitizerRules]] = None) -> None:
-        self.handlers: list[Callable[[ProcessInfo], None]] = []
-        self._country_handlers: dict[str, list[Callable[[ProcessInfo], None]]] = {}
+        self.handlers: list[SanitizerFunc] = []
+        self._country_handlers: dict[str, list[SanitizerFunc]] = {}
 
         if rules:
             for func in rules:
@@ -54,7 +54,7 @@ class PlaceSanitizer:
             for country, country_rules_list in country_rules.items():
                 if not country_rules_list:
                     continue
-                handlers: list[Callable[[ProcessInfo], None]] = []
+                handlers: list[SanitizerFunc] = []
                 for func in country_rules_list:
                     step = _validate_step(func)
                     country_module: SanitizerHandler = \

--- a/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
+++ b/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
@@ -10,7 +10,7 @@ Base class for sanitizers that derive new place names from existing ones.
 from typing import Sequence, Optional
 from abc import ABC, abstractmethod
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 from ...errors import UsageError
@@ -84,7 +84,7 @@ class DerivedNameSanitizer(ABC):
            and obj.place.rank_address in self.allowed_ranks\
            and (self.country_codes is None
                 or obj.place.country_code in self.country_codes):
-            filtered_names: list[PlaceName] = []
+            filtered_names: PlaceNames = []
 
             for name in names:
                 keep_name = True
@@ -102,7 +102,7 @@ class DerivedNameSanitizer(ABC):
 
     @abstractmethod
     def compute_derived_names(self, name: PlaceName,
-                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+                              obj: ProcessInfo) -> Optional[PlaceNames]:
         """ Filter function to be implemented by derived classes.
             Computes one or more derived names from the given name. The
             full object is handed in for references.

--- a/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
+++ b/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
@@ -38,12 +38,12 @@ Arguments:
           version if it doesn't exist yet. Any expanded version of the name
           that already exists will be kept.
 """
-from typing import Optional, Callable, Sequence
+from typing import Optional, Sequence
 from collections import defaultdict
 from dataclasses import dataclass
 
 from ...data.place_name import PlaceName, PlaceNames
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 
@@ -158,7 +158,7 @@ class _AffixSanitizer:
                                               {'partial': 'yes'}))
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create the affix handler.
     """
     return _AffixSanitizer(config)

--- a/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
+++ b/src/nominatim_db/tokenizer/sanitizers/affix_expansion.py
@@ -42,7 +42,7 @@ from typing import Optional, Callable, Sequence
 from collections import defaultdict
 from dataclasses import dataclass
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 
@@ -85,7 +85,7 @@ class _AffixSanitizer:
         if not obj.names:
             return
 
-        stem_names: list[PlaceName] = []
+        stem_names: PlaceNames = []
         affixes: dict[StemTuple, _AffixCollector] = defaultdict(_AffixCollector)
         for item in obj.names:
             if (stem := self.find_stem_kind(item, self.prefix_tags)) is not None:
@@ -96,7 +96,7 @@ class _AffixSanitizer:
                 stem_names.append(item)
 
         if affixes:
-            outnames: list[PlaceName] = []
+            outnames: PlaceNames = []
             for item in stem_names:
                 for stem, aff in affixes.items():
                     if item.kind == stem[0] and item.suffix == stem[1]:
@@ -124,7 +124,7 @@ class _AffixSanitizer:
 
         return None
 
-    def add_names(self, outnames: list[PlaceName], src: PlaceName,
+    def add_names(self, outnames: PlaceNames, src: PlaceName,
                   affix: _AffixCollector) -> None:
         fn = src.name
         sn = src.name

--- a/src/nominatim_db/tokenizer/sanitizers/base.py
+++ b/src/nominatim_db/tokenizer/sanitizers/base.py
@@ -45,11 +45,14 @@ class ProcessInfo:
         return out
 
 
+SanitizerFunc = Callable[[ProcessInfo], None]
+
+
 class SanitizerHandler(Protocol):
     """ Protocol for sanitizer modules.
     """
 
-    def create(self, config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+    def create(self, config: SanitizerConfig) -> SanitizerFunc:
         """
         Create a function for sanitizing a place.
 

--- a/src/nominatim_db/tokenizer/sanitizers/base.py
+++ b/src/nominatim_db/tokenizer/sanitizers/base.py
@@ -2,16 +2,16 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Common data types and protocols for sanitizers.
 """
-from typing import Optional, List, Mapping, Callable
+from typing import Optional, Mapping, Callable
 
 from ...typing import Protocol, Final
 from ...data.place_info import PlaceInfo
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .config import SanitizerConfig
 
 
@@ -28,7 +28,7 @@ class ProcessInfo:
         self.address = self._convert_name_dict(place.address)
 
     @staticmethod
-    def _convert_name_dict(names: Optional[Mapping[str, str]]) -> List[PlaceName]:
+    def _convert_name_dict(names: Optional[Mapping[str, str]]) -> PlaceNames:
         """ Convert a dictionary of names into a list of PlaceNames.
             The dictionary key is split into the primary part of the key
             and the suffix (the part after an optional colon).

--- a/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
@@ -31,7 +31,7 @@ Arguments:
 from typing import Callable, Iterator, Iterable, Union
 import re
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 
@@ -62,7 +62,7 @@ class _HousenumberSanitizer:
                 elif itype not in ('odd', 'even'):
                     itype = None
 
-        new_address: list[PlaceName] = []
+        new_address: PlaceNames = []
         for item in obj.address:
             if self.filter_kind(item.kind):
                 if itype is not None and RANGE_REGEX.fullmatch(item.name):

--- a/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
@@ -28,11 +28,11 @@ Arguments:
                            when an 'interpolation' is present. (default: true)
 
 """
-from typing import Callable, Iterator, Iterable, Union
+from typing import Iterator, Iterable, Union
 import re
 
 from ...data.place_name import PlaceNames
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 RANGE_REGEX = re.compile(r'\d+-\d+')
@@ -113,7 +113,7 @@ class _HousenumberSanitizer:
         return []
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a housenumber processing function.
     """
 

--- a/src/nominatim_db/tokenizer/sanitizers/clean_postcodes.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_postcodes.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Sanitizer that filters postcodes by their officially allowed pattern.
@@ -20,10 +20,10 @@ Arguments:
                         objects that have no country assigned. These are always
                         assumed to have no postcode.
 """
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 from ...data.postcode_format import PostcodeFormatter
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 
@@ -70,7 +70,7 @@ class _PostcodeSanitizer:
             ' '.join(filter(lambda p: p is not None, match.groups()))
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a function that filters postcodes by their officially allowed pattern.
     """
 

--- a/src/nominatim_db/tokenizer/sanitizers/clean_tiger_tags.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_tiger_tags.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Sanitizer that preprocesses tags from the TIGER import.
@@ -11,10 +11,9 @@ It makes the following changes:
 
 * remove state reference from tiger:county
 """
-from typing import Callable
 import re
 
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 COUNTY_MATCH = re.compile('(.*), [A-Z][A-Z]')
@@ -41,7 +40,7 @@ def _clean_tiger_county(obj: ProcessInfo) -> None:
             return
 
 
-def create(_: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(_: SanitizerConfig) -> SanitizerFunc:
     """ Create a function that preprocesses tags from the TIGER import.
     """
     return _clean_tiger_county

--- a/src/nominatim_db/tokenizer/sanitizers/config.py
+++ b/src/nominatim_db/tokenizer/sanitizers/config.py
@@ -7,21 +7,14 @@
 """
 Configuration for Sanitizers.
 """
-from typing import Sequence, Union, Optional, Pattern, Callable, Any, TYPE_CHECKING
+from typing import Sequence, Union, Optional, Pattern, Callable, Any
 from collections import UserDict
 import re
 
 from ...errors import UsageError
 
-# working around missing generics in Python < 3.8
-# See https://github.com/python/typing/issues/60#issuecomment-869757075
-if TYPE_CHECKING:
-    _BaseUserDict = UserDict[str, Any]
-else:
-    _BaseUserDict = UserDict
 
-
-class SanitizerConfig(_BaseUserDict):
+class SanitizerConfig(UserDict[str, Any]):
     """ The `SanitizerConfig` class is a read-only dictionary
         with configuration options for the sanitizer.
         In addition to the usual dictionary functions, the class provides

--- a/src/nominatim_db/tokenizer/sanitizers/delete_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_names.py
@@ -49,9 +49,9 @@ Arguments:
 
 
 """
-from typing import Callable, Sequence, Optional
+from typing import Callable, Optional
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
@@ -64,7 +64,7 @@ class _DeleteNameSanitizer(DerivedNameSanitizer):
         self.filter_name = config.get_filter('filter-name')
 
     def compute_derived_names(self, name: PlaceName,
-                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+                              obj: ProcessInfo) -> Optional[PlaceNames]:
         return [] if self.filter_name(name.name) else None
 
 

--- a/src/nominatim_db/tokenizer/sanitizers/delete_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_names.py
@@ -49,10 +49,10 @@ Arguments:
 
 
 """
-from typing import Callable, Optional
+from typing import Optional
 
 from ...data.place_name import PlaceName, PlaceNames
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
 
@@ -68,7 +68,7 @@ class _DeleteNameSanitizer(DerivedNameSanitizer):
         return [] if self.filter_name(name.name) else None
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a function to process removal of certain names.
     """
 

--- a/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
@@ -56,10 +56,10 @@ Arguments:
 
 
 """
-from typing import Callable, Optional
+from typing import Optional
 
 from ...data.place_name import PlaceName, PlaceNames
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
 
@@ -78,7 +78,7 @@ class _DeleteNameSanitizer(DerivedNameSanitizer):
         return [] if self.filter_name(name.name) else None
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a function to process removal of certain tags.
     """
 

--- a/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
+++ b/src/nominatim_db/tokenizer/sanitizers/delete_tags.py
@@ -56,9 +56,9 @@ Arguments:
 
 
 """
-from typing import Callable, Sequence, Optional
+from typing import Callable, Optional
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
@@ -74,7 +74,7 @@ class _DeleteNameSanitizer(DerivedNameSanitizer):
         self.filter_name = config.get_filter('name')
 
     def compute_derived_names(self, name: PlaceName,
-                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+                              obj: ProcessInfo) -> Optional[PlaceNames]:
         return [] if self.filter_name(name.name) else None
 
 

--- a/src/nominatim_db/tokenizer/sanitizers/derive_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/derive_names.py
@@ -52,9 +52,9 @@ Arguments:
                    the original is discarded when it matched the pattern.
                    (default: true)
 """
-from typing import Callable, Sequence, Optional
+from typing import Callable, Optional
 
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 from .base import ProcessInfo
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
@@ -67,8 +67,7 @@ class _NameSanitizer(DerivedNameSanitizer):
         self.pattern = config.get_pattern('name-pattern')
         self.replacements = config.get_string_list('variants')
 
-    def compute_derived_names(self, name: PlaceName,
-                              obj: ProcessInfo) -> Optional[Sequence[PlaceName]]:
+    def compute_derived_names(self, name: PlaceName, obj: ProcessInfo) -> Optional[PlaceNames]:
         if (m := self.pattern.fullmatch(name.name)) is not None:
             return [name.clone(name=n) for n in set(m.expand(r) for r in self.replacements)]
 

--- a/src/nominatim_db/tokenizer/sanitizers/derive_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/derive_names.py
@@ -52,10 +52,10 @@ Arguments:
                    the original is discarded when it matched the pattern.
                    (default: true)
 """
-from typing import Callable, Optional
+from typing import Optional
 
 from ...data.place_name import PlaceName, PlaceNames
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 from ._derived_name_sanitizer import DerivedNameSanitizer
 
@@ -74,7 +74,7 @@ class _NameSanitizer(DerivedNameSanitizer):
         return None
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a function to process removal of certain names.
     """
 

--- a/src/nominatim_db/tokenizer/sanitizers/split_name_list.py
+++ b/src/nominatim_db/tokenizer/sanitizers/split_name_list.py
@@ -11,13 +11,11 @@ Arguments:
     delimiters: Define the set of characters to be used for
                 splitting the list. (default: ',;')
 """
-from typing import Callable
-
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a name processing function that splits name values with
         multiple values into their components.
     """

--- a/src/nominatim_db/tokenizer/sanitizers/strip_brace_terms.py
+++ b/src/nominatim_db/tokenizer/sanitizers/strip_brace_terms.py
@@ -2,20 +2,19 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 This sanitizer creates additional name variants for names that have
 addendums in brackets (e.g. "Halle (Saale)"). The additional variant contains
 only the main name part with the bracket part removed.
 """
-from typing import Callable
 
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 
-def create(_: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(_: SanitizerConfig) -> SanitizerFunc:
     """ Create a name processing function that creates additional name variants
         for bracket addendums.
     """

--- a/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
@@ -35,7 +35,7 @@ Arguments:
 from typing import Callable, Dict, Optional, List
 
 from ...data import country_info
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 
 
@@ -91,7 +91,7 @@ class _AnalyzerByLanguage:
         obj.names.extend(more_names)
 
 
-def create(config: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(config: SanitizerConfig) -> SanitizerFunc:
     """ Create a function that sets the analyzer property depending on the
         language of the tag.
     """

--- a/src/nominatim_db/tokenizer/sanitizers/tag_japanese.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_japanese.py
@@ -9,14 +9,14 @@ This sanitizer maps OSM data to Japanese block addresses.
 It replaces blocknumber and housenumber with housenumber,
 and quarter and neighbourhood with place.
 """
-from typing import Callable, Optional
+from typing import Optional
 
-from .base import ProcessInfo
+from .base import ProcessInfo, SanitizerFunc
 from .config import SanitizerConfig
 from ...data.place_name import PlaceName, PlaceNames
 
 
-def create(_: SanitizerConfig) -> Callable[[ProcessInfo], None]:
+def create(_: SanitizerConfig) -> SanitizerFunc:
     """Set up the sanitizer
     """
     return tag_japanese

--- a/src/nominatim_db/tokenizer/sanitizers/tag_japanese.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_japanese.py
@@ -2,21 +2,18 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2024 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 This sanitizer maps OSM data to Japanese block addresses.
 It replaces blocknumber and housenumber with housenumber,
 and quarter and neighbourhood with place.
 """
-
-
-from typing import Callable
-from typing import List, Optional
+from typing import Callable, Optional
 
 from .base import ProcessInfo
 from .config import SanitizerConfig
-from ...data.place_name import PlaceName
+from ...data.place_name import PlaceName, PlaceNames
 
 
 def create(_: SanitizerConfig) -> Callable[[ProcessInfo], None]:
@@ -25,11 +22,8 @@ def create(_: SanitizerConfig) -> Callable[[ProcessInfo], None]:
     return tag_japanese
 
 
-def reconbine_housenumber(
-    new_address: List[PlaceName],
-    tmp_housenumber: Optional[str],
-    tmp_blocknumber: Optional[str]
-) -> List[PlaceName]:
+def reconbine_housenumber(new_address: PlaceNames, tmp_housenumber: Optional[str],
+                          tmp_blocknumber: Optional[str]) -> PlaceNames:
     """ Recombine the tag of housenumber by using housenumber and blocknumber
     """
     if tmp_blocknumber and tmp_housenumber:
@@ -59,11 +53,8 @@ def reconbine_housenumber(
     return new_address
 
 
-def reconbine_place(
-    new_address: List[PlaceName],
-    tmp_neighbourhood: Optional[str],
-    tmp_quarter: Optional[str]
-) -> List[PlaceName]:
+def reconbine_place(new_address: PlaceNames, tmp_neighbourhood: Optional[str],
+                    tmp_quarter: Optional[str]) -> PlaceNames:
     """ Recombine the tag of place by using neighbourhood and quarter
     """
     if tmp_neighbourhood and tmp_quarter:


### PR DESCRIPTION
Adds two type aliases `PlaceNames` and `SanitizerFunc`. And also remove code only necessary for now unsupported Python versions. See individual commits.

