### PR TITLE
Add sanitizer to create 'Rodovia BR-XXX' name in Brazil

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -220,6 +220,12 @@ br:
     postcode:
       pattern: "(ddddd)-?(ddd)"
       output: \1-\2
+    sanitizers:
+      - step: derive-names
+        filter-kind: ref
+        filter-rank: "26"
+        name-pattern: ([A-Z]{2,3}-\d+)
+        variants: Rodovia \1
 
 
 # The Bahamas (The Bahamas)


### PR DESCRIPTION
Adds a sanitizer specifically for Brazil: when a major highway has a ref of the form `BR-*`, then a searchable name `Rodovia BR-*` is added. This allows the street to be found under the name with the Rodovia prefix and, more importantly, ensures that addresses with `addr:street=Rodovia BR-*'` are correctly matched up with the street.

There is a corresponding PR for Nominatim QA at https://github.com/osm-search/Nominatim-Data-Analyser/pull/73

Closes #4075.