### PR TITLE
Use isdecimal() instead of isdigit() when converting to int

### DIFF
--- a/src/nominatim_api/search/db_searches/address_search.py
+++ b/src/nominatim_api/search/db_searches/address_search.py
@@ -266,7 +266,7 @@ class AddressSearch(base.AbstractSearch):
             place_sql = place_sql.where(self.qualifiers.sql_restrict(thnr))
 
         numerals = [int(n) for n in self.housenumbers.values
-                    if n.isdigit() and len(n) < 8]
+                    if n.isdecimal() and len(n) < 8]
         interpol_sql: SaColumn
         tiger_sql: SaColumn
         if numerals and \

--- a/src/nominatim_api/types.py
+++ b/src/nominatim_api/types.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Complex datatypes used by the Nominatim API.
@@ -81,7 +81,7 @@ class OsmID:
             a number pointing to the exact number requested. This function
             returns the housenumber as an int, if class is set and is a number.
         """
-        if self.osm_class and self.osm_class.isdigit():
+        if self.osm_class and self.osm_class.isdecimal():
             return int(self.osm_class)
         return None
 
@@ -495,10 +495,10 @@ def format_excluded(ids: Any) -> List[PlaceRef]:
             if i > 0:
                 result.append(PlaceID(i))
         elif isinstance(i, str):
-            if i.isdigit():
+            if i.isdecimal():
                 if int(i) > 0:
                     result.append(PlaceID(int(i)))
-            elif len(i) > 1 and i[0].upper() in ('N', 'W', 'R') and i[1:].isdigit():
+            elif len(i) > 1 and i[0].upper() in ('N', 'W', 'R') and i[1:].isdecimal():
                 if int(i[1:]) > 0:
                     result.append(OsmID(i[0].upper(), int(i[1:])))
             elif match := POSTCODE_REF_RE.fullmatch(i):

--- a/src/nominatim_api/v1/server_glue.py
+++ b/src/nominatim_api/v1/server_glue.py
@@ -255,7 +255,7 @@ async def lookup_endpoint(api: NominatimAPIAsync, params: ASGIAdaptor) -> Any:
     places = []
     for oid in (params.get('osm_ids') or '').split(','):
         oid = oid.strip()
-        if len(oid) > 1 and oid[0] in 'RNWrnw' and oid[1:].isdigit():
+        if len(oid) > 1 and oid[0] in 'RNWrnw' and oid[1:].isdecimal():
             places.append(OsmID(oid[0].upper(), int(oid[1:])))
 
     if len(places) > params.config().get_int('LOOKUP_MAX_COUNT'):

--- a/src/nominatim_db/cli.py
+++ b/src/nominatim_db/cli.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Command-line interface to the Nominatim functions for import, update,
@@ -168,7 +168,7 @@ class AdminServe:
         server_info = args.server.split(':', 1)
         host = server_info[0]
         if len(server_info) > 1:
-            if not server_info[1].isdigit():
+            if not server_info[1].isdecimal():
                 raise UsageError('Invalid format for --server parameter. Use <host>:<port>')
             port = int(server_info[1])
         else:

--- a/src/nominatim_db/clicmd/refresh.py
+++ b/src/nominatim_db/clicmd/refresh.py
@@ -26,7 +26,7 @@ def _parse_osm_object(obj: str) -> Tuple[str, int]:
     """ Parse the given argument into a tuple of OSM type and ID.
         Raises an ArgumentError if the format is not recognized.
     """
-    if len(obj) < 2 or obj[0].lower() not in 'nrw' or not obj[1:].isdigit():
+    if len(obj) < 2 or obj[0].lower() not in 'nrw' or not obj[1:].isdecimal():
         raise argparse.ArgumentTypeError("Cannot parse OSM ID. Expect format: [N|W|R]<id>.")
 
     return (obj[0].upper(), int(obj[1:]))

--- a/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
+++ b/src/nominatim_db/tokenizer/sanitizers/_derived_name_sanitizer.py
@@ -17,7 +17,7 @@ from ...errors import UsageError
 
 
 def _to_rank(rstr: str) -> int:
-    if not rstr.isdigit():
+    if not rstr.isdecimal():
         raise UsageError(f"Invalid rank parameter '{rstr}', must be a number.")
 
     rint = int(rstr)

--- a/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_housenumbers.py
@@ -57,7 +57,7 @@ class _HousenumberSanitizer:
             if itype is not None:
                 if itype == 'all':
                     itype = 1
-                elif len(itype) == 1 and itype.isdigit():
+                elif len(itype) == 1 and itype.isdecimal():
                     itype = int(itype)
                 elif itype not in ('odd', 'even'):
                     itype = None

--- a/src/nominatim_db/tools/admin.py
+++ b/src/nominatim_db/tools/admin.py
@@ -34,7 +34,7 @@ def _get_place_info(cursor: Cursor, osm_id: Optional[str],
     values: Tuple[Any, ...]
     if osm_id:
         osm_type = osm_id[0].upper()
-        if osm_type not in 'NWR' or not osm_id[1:].isdigit():
+        if osm_type not in 'NWR' or not osm_id[1:].isdecimal():
             LOG.fatal('OSM ID must be of form <N|W|R><id>. Got: %s', osm_id)
             raise UsageError("OSM ID parameter badly formatted")
 


### PR DESCRIPTION
As per [Python documentation](https://docs.python.org/3/library/stdtypes.html#str.isdigit): `isdigit()` includes numbers that need special handling and cannot be necessarily converted into numbers by `int()`. `isdecimal()` represents only base 10 numbers and is thus the better choice when converting to int.
