### PR TITLE
Preserve not-null constraints when recreating the word table

### DIFF
--- a/src/nominatim_db/tokenizer/icu_tokenizer.py
+++ b/src/nominatim_db/tokenizer/icu_tokenizer.py
@@ -122,7 +122,8 @@ class ICUTokenizer(AbstractTokenizer):
                 cur.execute('ANALYSE word_frequencies')
                 LOG.info('Update word table with recomputed frequencies')
                 drop_tables(conn, 'tmp_word')
-                cur.execute("""CREATE TABLE tmp_word AS
+                cur.execute("CREATE TABLE tmp_word (LIKE word)")
+                cur.execute("""INSERT INTO tmp_word
                                 SELECT word_id, word_token, type, word,
                                        coalesce(word.info, '{}'::jsonb)
                                        - 'count' - 'addr_count' ||


### PR DESCRIPTION
`CREATE TABLE ... AS` can create a copy of the table but won't preserve non-null constraints and similar.

Switch to using `CREATE TABLE ... (LIKE .. )`, which creates a copy of the table structure preserving non-null constraints. Then insert data into the newly created table with a single `INSERT INTO ... SELECT`.
