### PR TITLE
Move initial word statistics update into tokenizer finalization

### DIFF
--- a/src/nominatim_db/clicmd/setup.py
+++ b/src/nominatim_db/clicmd/setup.py
@@ -136,10 +136,8 @@ class SetupAll:
             if args.no_updates:
                 conn.autocommit = True
                 freeze.drop_update_tables(conn)
-        tokenizer.finalize_import(args.config)
-
-        LOG.warning('Recompute word counts')
-        tokenizer.update_statistics(args.config, threads=num_threads)
+        LOG.warning('Finalize search index')
+        tokenizer.finalize_import(args.config, threads=num_threads)
 
         end_time = time.time()
         elapsed = end_time - start_time

--- a/src/nominatim_db/tokenizer/base.py
+++ b/src/nominatim_db/tokenizer/base.py
@@ -147,7 +147,7 @@ class AbstractTokenizer(ABC):
         """
 
     @abstractmethod
-    def finalize_import(self, config: Configuration) -> None:
+    def finalize_import(self, config: Configuration, threads: int = 1) -> None:
         """ This function is called at the very end of an import when all
             data has been imported and indexed. The tokenizer may create
             at this point any additional indexes and data structures needed
@@ -155,6 +155,7 @@ class AbstractTokenizer(ABC):
 
             Arguments:
               config: Read-only object with configuration options.
+              threads: Number of threads to use
         """
 
     @abstractmethod

--- a/src/nominatim_db/tokenizer/icu_tokenizer.py
+++ b/src/nominatim_db/tokenizer/icu_tokenizer.py
@@ -68,11 +68,17 @@ class ICUTokenizer(AbstractTokenizer):
         with connect(self.dsn) as conn:
             self.loader.load_config_from_db(conn)
 
-    def finalize_import(self, config: Configuration) -> None:
+    def finalize_import(self, config: Configuration, threads: int = 2) -> None:
         """ Do any required postprocessing to make the tokenizer data ready
             for use.
         """
-        self._create_lookup_indices(config, 'word')
+        with connect(self.dsn) as conn:
+            reverse_only = not table_exists(conn, 'search_name')
+
+        if reverse_only:
+            self._create_lookup_indices(config, 'word')
+        else:
+            self.update_statistics(config, threads)
 
     def update_sql_functions(self, config: Configuration) -> None:
         """ Reimport the SQL functions for this tokenizer.

--- a/test/python/tokenizer/test_icu.py
+++ b/test/python/tokenizer/test_icu.py
@@ -191,8 +191,10 @@ def test_update_sql_functions(db_prop, temp_db_cursor,
     assert test_content == set((('1133', ), ))
 
 
-def test_finalize_import(tokenizer_factory, temp_db_cursor,
-                         test_config, sql_preprocessor_cfg):
+@pytest.mark.parametrize('reverse_only', [True, False])
+def test_finalize_import(tokenizer_factory, temp_db_cursor, load_sql,
+                         test_config, sql_preprocessor_cfg, reverse_only):
+    load_sql('tables/search_name.sql', create_reverse_only=reverse_only)
     tok = tokenizer_factory()
     tok.init_new_db(test_config)
 


### PR DESCRIPTION
Word counts are now computed as part of the finalization routine of the tokenizer. That way it can avoid creating lookup indexes on a word table that will be immediately replaced by a new word table.