### PR TITLE
remove legacy function create_postcode_word

### DIFF
--- a/lib-sql/tokenizer/icu_tokenizer.sql
+++ b/lib-sql/tokenizer/icu_tokenizer.sql
@@ -308,26 +308,3 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION create_postcode_word(postcode TEXT, lookup_terms TEXT[])
-  RETURNS BOOLEAN
-  AS $$
-DECLARE
-  existing INTEGER;
-BEGIN
-  SELECT count(*) INTO existing
-    FROM word WHERE word = postcode and type = 'P';
-
-  IF existing > 0 THEN
-    RETURN TRUE;
-  END IF;
-
-  -- postcodes don't need word ids
-  INSERT INTO word (word_token, type, word)
-    SELECT lookup_term, 'P', postcode FROM unnest(lookup_terms) as lookup_term;
-
-  RETURN FALSE;
-END;
-$$
-LANGUAGE plpgsql;
-


### PR DESCRIPTION
## Summary

Remove a legacy SQL function.

I ran `grep create_postcode_word` against the full repository and can't find a caller or database trigger.

Probably related to https://github.com/osm-search/Nominatim/pull/3665 a year ago.

## AI usage
Initial hint came from LLM when it explained a different postcode related tokenizer issue to me. I did all reviewing (grepping) and editing.

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
