### PR TITLE
Fix Windows `ProactorEventLoop` incompatibility with psycopg async

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
                   path: nominatim-src.tar.bz2
                   retention-days: 1
 
-    tests:
+    tests-ubuntu:
         needs: create-archive
         strategy:
             matrix:
@@ -142,6 +142,14 @@ jobs:
 
     tests-windows:
         needs: create-archive
+        strategy:
+            matrix:
+                python: ['3.10', '3.14']
+                include:
+                    - python: '3.10'
+                      pyicu: 'v2.15/pyicu-2.15-cp310-cp310-win_amd64.whl'
+                    - python: '3.14'
+                      pyicu: 'v2.16.2/pyicu-2.16.2-cp314-cp314-win_amd64.whl'
         runs-on: windows-latest
 
         steps:
@@ -159,7 +167,13 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v6
               with:
-                  python-version: '3.14'
+                  python-version: ${{ matrix.python }}
+
+            - uses: actions/cache@v5
+              with:
+                  path: |
+                     C:\osm2pgsql
+                  key: osm2pgsql-windows-1
 
             - name: Install Spatialite
               run: |
@@ -169,8 +183,10 @@ jobs:
 
             - name: Install osm2pgsql
               run: |
-                  Invoke-WebRequest -Uri "https://osm2pgsql.org/download/windows/osm2pgsql-latest-x64.zip" -OutFile "osm2pgsql.zip"
-                  Expand-Archive -Path "osm2pgsql.zip" -DestinationPath "C:\osm2pgsql"
+                  if (-not (Test-Path "C:\osm2pgsql")) {
+                    Invoke-WebRequest -Uri "https://osm2pgsql.org/download/windows/osm2pgsql-latest-x64.zip" -OutFile "osm2pgsql.zip"
+                    Expand-Archive -Path "osm2pgsql.zip" -DestinationPath "C:\osm2pgsql"
+                  }
                   $BinDir = Get-ChildItem -Path "C:\osm2pgsql" -Recurse -Filter "osm2pgsql.exe" | Select-Object -ExpandProperty DirectoryName | Select-Object -First 1
                   if (-not $BinDir) {
                       Write-Error "Could not find osm2pgsql.exe"
@@ -186,19 +202,19 @@ jobs:
 
             - name: Install PyICU from wheel
               run: |
-                  python -m pip install https://github.com/cgohlke/pyicu-build/releases/download/v2.16.0/pyicu-2.16-cp314-cp314-win_amd64.whl
-                  
+                  python -m pip install https://github.com/cgohlke/pyicu-build/releases/download/${{ matrix.pyicu }}
+
             - name: Install test prerequisites
               run: |
                   python -m pip install -U pip
-                  python -m pip install pytest pytest-asyncio "psycopg[binary]!=3.3.0" python-dotenv pyyaml jinja2 psutil sqlalchemy pytest-bdd falcon starlette uvicorn asgi_lifespan aiosqlite osmium mwparserfromhell
+                  python -m pip install pytest pytest-asyncio async-timeout "psycopg[binary]!=3.3.0" python-dotenv pyyaml jinja2 psutil sqlalchemy pytest-bdd falcon starlette uvicorn asgi_lifespan aiosqlite osmium mwparserfromhell
 
             - name: Python unit tests
               run: |
                   python -m pytest test/python -k "not (import_osm or run_osm2pgsql)"
               working-directory: Nominatim
 
-    install:
+    install-ubuntu:
         runs-on: ubuntu-latest
         needs: create-archive
 
@@ -329,6 +345,123 @@ jobs:
             - name: Clean up database (reverse-only import)
               run: nominatim refresh --postcodes --word-tokens
               working-directory: /home/nominatim/nominatim-project
+
+    install-windows:
+        strategy:
+            matrix:
+                python: ['3.10', '3.14']
+                include:
+                    - python: '3.10'
+                      pyicu: 'v2.15/pyicu-2.15-cp310-cp310-win_amd64.whl'
+                    - python: '3.14'
+                      pyicu: 'v2.16.2/pyicu-2.16.2-cp314-cp314-win_amd64.whl'
+        runs-on: windows-latest
+        needs: create-archive
+        steps:
+            - uses: actions/download-artifact@v8
+              with:
+                  name: full-source
+
+            - name: Unpack Nominatim
+              run: tar xf nominatim-src.tar.bz2
+
+            - uses: ./Nominatim/.github/actions/setup-postgresql-windows
+              with:
+                  postgresql-version: 17
+
+            - name: Set up Python
+              uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python }}
+
+            - uses: actions/cache@v5
+              with:
+                  path: |
+                     C:\osm2pgsql
+                  key: osm2pgsql-windows-1
+
+            - name: Install osm2pgsql
+              run: |
+                  if (-not (Test-Path "C:\osm2pgsql")) {
+                    Invoke-WebRequest -Uri "https://osm2pgsql.org/download/windows/osm2pgsql-latest-x64.zip" -OutFile "osm2pgsql.zip"
+                    Expand-Archive -Path "osm2pgsql.zip" -DestinationPath "C:\osm2pgsql"
+                  }
+                  $BinDir = Get-ChildItem -Path "C:\osm2pgsql" -Recurse -Filter "osm2pgsql.exe" | Select-Object -ExpandProperty DirectoryName | Select-Object -First 1
+                  if (-not $BinDir) {
+                      Write-Error "Could not find osm2pgsql.exe"
+                      exit 1
+                  }
+                  echo "$BinDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+                  $FullExePath = Join-Path $BinDir "osm2pgsql.exe"
+                  echo "NOMINATIM_OSM2PGSQL_BINARY=$FullExePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+            - name: Setup virtual environment
+              run: |
+                  python -m venv venv
+                  .\venv\Scripts\python.exe -m pip install -U pip
+                  .\venv\Scripts\Activate.ps1
+              working-directory: Nominatim
+
+            - name: Install dependencies (pip)
+              run: |
+                  pip install "psycopg[binary]!=3.3.0" async-timeout python-dotenv pyyaml jinja2 psutil sqlalchemy falcon starlette uvicorn osmium mwparserfromhell
+                  pip install https://github.com/cgohlke/pyicu-build/releases/download/${{ matrix.pyicu }}
+              working-directory: Nominatim
+
+            - name: Prepare import environment
+              run: |
+                  Move-Item -Path "test\testdb\apidb-test-data.pbf" -Destination "test.pbf"
+                  mkdir data-env-reverse
+              working-directory: Nominatim
+
+            - name: Print version
+              run: |
+                  python nominatim-cli.py --version
+              working-directory: Nominatim
+
+            - name: Collect host OS information
+              run: python .\nominatim-cli.py admin --collect-os-info
+              working-directory: Nominatim
+
+            - name: Import
+              run: python .\nominatim-cli.py import --osm-file .\test.pbf
+              working-directory: Nominatim
+
+            - name: Import special phrases
+              run: python .\nominatim-cli.py special-phrases --import-from-wiki
+              working-directory: Nominatim
+
+            - name: Check full import
+              run: python .\nominatim-cli.py admin --check-database
+              working-directory: Nominatim
+
+            - name: Warm up database
+              run: python .\nominatim-cli.py admin --warm
+              working-directory: Nominatim
+
+            - name: Run update
+              run: |
+                  python .\nominatim-cli.py replication --init
+                  python .\nominatim-cli.py replication --once
+              working-directory: Nominatim
+
+            - name: Clean up database
+              run: python .\nominatim-cli.py refresh --postcodes --word-tokens
+              working-directory: Nominatim
+
+            - name: Run reverse-only import
+              run : |
+                  echo 'NOMINATIM_DATABASE_DSN="pgsql:dbname=reverse"' >> .env
+                  python ..\nominatim-cli.py import --osm-file ..\test.pbf --reverse-only --no-updates
+              working-directory: Nominatim/data-env-reverse
+
+            - name: Check reverse-only import
+              run: python ..\nominatim-cli.py admin --check-database
+              working-directory: Nominatim/data-env-reverse
+
+            - name: Clean up database (reverse-only import)
+              run: python ..\nominatim-cli.py refresh --postcodes --word-tokens
+              working-directory: Nominatim/data-env-reverse
 
     install-no-superuser:
       runs-on: ubuntu-24.04

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -27,7 +27,7 @@ For running Nominatim:
   * [PostgreSQL](https://www.postgresql.org) (12+ will work, 13+ strongly recommended)
   * [PostGIS](https://postgis.net) (3.0+ will work, 3.2+ strongly recommended)
   * [osm2pgsql](https://osm2pgsql.org) (1.8+)
-  * [Python 3](https://www.python.org/) (3.9+)
+  * [Python 3](https://www.python.org/) (3.9+, 3.10+ in case of Windows)
 
 Furthermore the following Python libraries are required:
 

--- a/lib-lua/flex-base.lua
+++ b/lib-lua/flex-base.lua
@@ -2,7 +2,7 @@
 local flex = require('themes/nominatim/init')
 
 function flex.load_topic(name, cfg)
-    local topic_file = debug.getinfo(1, "S").source:sub(2):match("(.*/)") .. 'themes/nominatim/topics/'.. name .. '.lua'
+    local topic_file = debug.getinfo(1, "S").source:sub(2):match("(.*[/\\])") .. 'themes/nominatim/topics/'.. name .. '.lua'
 
     if topic_file == nil then
         error('Cannot find topic: ' .. name)

--- a/src/nominatim_api/core.py
+++ b/src/nominatim_api/core.py
@@ -385,7 +385,10 @@ class NominatimAPI:
                   Settings in this mapping also have precedence over any
                   parameters found in the `.env` file of the project directory.
         """
-        self._loop = asyncio.new_event_loop()
+        if sys.platform == 'win32':
+            self._loop = asyncio.SelectorEventLoop()
+        else:
+            self._loop = asyncio.new_event_loop()
         self._async_api = NominatimAPIAsync(project_dir, environ, loop=self._loop)
 
     def close(self) -> None:

--- a/src/nominatim_db/cli.py
+++ b/src/nominatim_db/cli.py
@@ -13,7 +13,6 @@ import importlib
 import logging
 import sys
 import argparse
-import asyncio
 from pathlib import Path
 
 from .config import Configuration
@@ -21,6 +20,7 @@ from .errors import UsageError
 from . import clicmd
 from . import version
 from .clicmd.args import NominatimArgs, Subcommand
+from .utils.asyncio_utils import asyncio_run
 
 LOG = logging.getLogger()
 
@@ -158,7 +158,7 @@ class AdminServe:
                            help='Webserver framework to run. (default: falcon)')
 
     def run(self, args: NominatimArgs) -> int:
-        asyncio.run(self.run_uvicorn(args))
+        asyncio_run(self.run_uvicorn(args))
 
         return 0
 

--- a/src/nominatim_db/clicmd/add_data.py
+++ b/src/nominatim_db/clicmd/add_data.py
@@ -10,13 +10,13 @@ Implementation of the 'add-data' subcommand.
 from typing import cast
 import argparse
 import logging
-import asyncio
 
 import psutil
 
 from .args import NominatimArgs
 from ..db.connection import connect
 from ..tools.freeze import is_frozen
+from ..utils.asyncio_utils import asyncio_run
 
 
 LOG = logging.getLogger()
@@ -66,7 +66,7 @@ class UpdateAddData:
         from ..tools import add_osm_data
 
         if args.tiger_data:
-            return asyncio.run(self._add_tiger_data(args))
+            return asyncio_run(self._add_tiger_data(args))
 
         with connect(args.config.get_libpq_dsn()) as conn:
             if is_frozen(conn):

--- a/src/nominatim_db/clicmd/convert.py
+++ b/src/nominatim_db/clicmd/convert.py
@@ -9,11 +9,11 @@ Implementation of the 'convert' subcommand.
 """
 from typing import Set, Any, Union, Optional, Sequence
 import argparse
-import asyncio
 from pathlib import Path
 
 from ..errors import UsageError
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 
 class WithAction(argparse.Action):
@@ -82,8 +82,7 @@ class ConvertDB:
 
         if args.format == 'sqlite':
             from ..tools import convert_sqlite
-
-            asyncio.run(convert_sqlite.convert(args.project_dir, args.output, self.options))
+            asyncio_run(convert_sqlite.convert(args.project_dir, args.output, self.options))
             return 0
 
         return 1

--- a/src/nominatim_db/clicmd/export.py
+++ b/src/nominatim_db/clicmd/export.py
@@ -10,7 +10,6 @@ Implementation of the 'export' subcommand.
 from typing import Optional, List, cast
 import logging
 import argparse
-import asyncio
 import csv
 import sys
 
@@ -22,6 +21,7 @@ import sqlalchemy as sa
 
 from ..errors import UsageError
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 
 LOG = logging.getLogger()
@@ -82,7 +82,7 @@ class QueryExport:
                            help='Export only children of this OSM relation')
 
     def run(self, args: NominatimArgs) -> int:
-        return asyncio.run(export(args))
+        return asyncio_run(export(args))
 
 
 async def export(args: NominatimArgs) -> int:

--- a/src/nominatim_db/clicmd/index.py
+++ b/src/nominatim_db/clicmd/index.py
@@ -8,13 +8,13 @@
 Implementation of the 'index' subcommand.
 """
 import argparse
-import asyncio
 
 import psutil
 
 from ..db import status
 from ..db.connection import connect
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 
 class UpdateIndex:
@@ -39,7 +39,7 @@ class UpdateIndex:
                            help='Maximum/finishing rank')
 
     def run(self, args: NominatimArgs) -> int:
-        asyncio.run(self._do_index(args))
+        asyncio_run(self._do_index(args))
 
         if not args.no_boundaries and not args.boundaries_only \
            and args.minrank == 0 and args.maxrank == 30:

--- a/src/nominatim_db/clicmd/refresh.py
+++ b/src/nominatim_db/clicmd/refresh.py
@@ -11,12 +11,12 @@ from typing import Tuple, Optional
 import argparse
 import logging
 from pathlib import Path
-import asyncio
 
 from ..config import Configuration
 from ..db.connection import connect, table_exists
 from ..tokenizer.base import AbstractTokenizer
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 
 LOG = logging.getLogger()
@@ -103,7 +103,8 @@ class UpdateRefresh:
                                            args.project_dir, tokenizer,
                                            force_reimport=args.postcode_force_reimport)
                 indexer = Indexer(args.config, tokenizer, args.threads or 1)
-                asyncio.run(indexer.index_postcodes())
+
+                asyncio_run(indexer.index_postcodes())
             else:
                 LOG.error("The place table doesn't exist. "
                           "Postcode updates on a frozen database is not possible.")

--- a/src/nominatim_db/clicmd/replication.py
+++ b/src/nominatim_db/clicmd/replication.py
@@ -13,12 +13,12 @@ import datetime as dt
 import logging
 import socket
 import time
-import asyncio
 
 from ..db import status
 from ..db.connection import connect
 from ..errors import UsageError
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 LOG = logging.getLogger()
 
@@ -185,5 +185,5 @@ class UpdateReplication:
         if args.check_for_updates:
             return self._check_for_updates(args)
 
-        asyncio.run(self._update(args))
+        asyncio_run(self._update(args))
         return 0

--- a/src/nominatim_db/clicmd/setup.py
+++ b/src/nominatim_db/clicmd/setup.py
@@ -11,7 +11,6 @@ from typing import Optional
 import argparse
 import logging
 from pathlib import Path
-import asyncio
 
 import psutil
 
@@ -22,6 +21,7 @@ from ..db import status, properties
 from ..tokenizer.base import AbstractTokenizer
 from ..version import NOMINATIM_VERSION
 from .args import NominatimArgs
+from ..utils.asyncio_utils import asyncio_run
 
 import time
 
@@ -80,7 +80,7 @@ class SetupAll:
                 "Cannot use --continue and --prepare-database together."
             )
 
-        return asyncio.run(self.async_run(args))
+        return asyncio_run(self.async_run(args))
 
     async def async_run(self, args: NominatimArgs) -> int:
         from ..data import country_info

--- a/src/nominatim_db/utils/asyncio_utils.py
+++ b/src/nominatim_db/utils/asyncio_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Helper functions to get appropriate asyncio loop factory based on platform.
+"""
+import sys
+import asyncio
+import selectors
+from typing import TypeVar, Coroutine
+
+_T = TypeVar('_T')
+
+
+def asyncio_run(main: Coroutine[None, None, _T]) -> _T:
+    """ Execute the coroutine with compatible loop factory and return the result.
+    """
+    if sys.platform == "win32":
+        if sys.version_info >= (3, 12):
+            def loop_factory() -> asyncio.AbstractEventLoop:
+                return asyncio.SelectorEventLoop(selectors.DefaultSelector())
+            return asyncio.run(main, loop_factory=loop_factory)  # type: ignore[call-arg]
+        else:
+            if (asyncio.get_event_loop_policy() != asyncio.WindowsSelectorEventLoopPolicy()):
+                asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            return asyncio.run(main)
+    else:
+        return asyncio.run(main)

--- a/test/bdd/test_db.py
+++ b/test/bdd/test_db.py
@@ -9,7 +9,6 @@ Collector for BDD import acceptance tests.
 
 These tests check the Nominatim import chain after the osm2pgsql import.
 """
-import asyncio
 import re
 from collections import defaultdict
 
@@ -29,6 +28,7 @@ from nominatim_db import cli
 from nominatim_db.tools.database_import import load_data, create_table_triggers
 from nominatim_db.tools.postcodes import update_postcodes
 from nominatim_db.tokenizer import factory as tokenizer_factory
+from nominatim_db.utils.asyncio_utils import asyncio_run
 
 
 def _rewrite_placeid_field(field, new_field, datatable, place_ids):
@@ -233,7 +233,9 @@ def do_import(db_conn, def_config):
     """ Run a reduced version of the Nominatim import.
     """
     create_table_triggers(db_conn, def_config)
-    asyncio.run(load_data(def_config.get_libpq_dsn(), 1))
+
+    asyncio_run(load_data(def_config.get_libpq_dsn(), 1))
+
     tokenizer = tokenizer_factory.get_tokenizer_for_db(def_config)
     update_postcodes(def_config.get_libpq_dsn(), None, tokenizer)
     cli.nominatim(['index', '-q'], def_config.environ)

--- a/test/bdd/test_osm2pgsql.py
+++ b/test/bdd/test_osm2pgsql.py
@@ -7,7 +7,6 @@
 """
 Collector for BDD osm2pgsql import style tests.
 """
-import asyncio
 import random
 
 import pytest
@@ -18,6 +17,7 @@ from nominatim_db import cli
 from nominatim_db.tools.exec_utils import run_osm2pgsql
 from nominatim_db.tools.database_import import load_data, create_table_triggers
 from nominatim_db.tools.replication import run_osm2pgsql_updates
+from nominatim_db.utils.asyncio_utils import asyncio_run
 
 from utils.checks import check_table_content
 
@@ -86,7 +86,9 @@ def update_from_osm_file(db_conn, def_config, osm2pgsql_options, opl_writer, doc
         The data is expected as attached text in OPL format.
     """
     create_table_triggers(db_conn, def_config)
-    asyncio.run(load_data(def_config.get_libpq_dsn(), 1))
+
+    asyncio_run(load_data(def_config.get_libpq_dsn(), 1))
+
     cli.nominatim(['index'], def_config.environ)
     cli.nominatim(['refresh', '--functions'], def_config.environ)
 

--- a/test/bdd/utils/api_runner.py
+++ b/test/bdd/utils/api_runner.py
@@ -7,8 +7,8 @@
 """
 Various helper classes for running Nominatim commands.
 """
-import asyncio
 from collections import namedtuple
+from nominatim_db.utils.asyncio_utils import asyncio_run
 
 APIResponse = namedtuple('APIResponse', ['endpoint', 'status', 'body', 'headers'])
 
@@ -21,7 +21,7 @@ class APIRunner:
         self.exec_engine = create_func(environ)
 
     def run(self, endpoint, params, http_headers):
-        return asyncio.run(self.exec_engine(endpoint, params, http_headers))
+        return asyncio_run(self.exec_engine(endpoint, params, http_headers))
 
     def run_step(self, endpoint, base_params, datatable, fmt, http_headers):
         if fmt:

--- a/test/bdd/utils/db.py
+++ b/test/bdd/utils/db.py
@@ -7,7 +7,6 @@
 """
 Helper functions for managing test databases.
 """
-import asyncio
 import psycopg
 from psycopg import sql as pysql
 
@@ -17,6 +16,7 @@ from nominatim_db.data.country_info import setup_country_tables, create_country_
 from nominatim_db.tools.refresh import create_functions, load_address_levels_from_config
 from nominatim_db.tools.exec_utils import run_osm2pgsql
 from nominatim_db.tokenizer import factory as tokenizer_factory
+from nominatim_db.utils.asyncio_utils import asyncio_run
 
 
 class DBManager:
@@ -96,7 +96,8 @@ class DBManager:
             load_address_levels_from_config(conn, config)
             create_partition_tables(conn, config)
             create_functions(conn, config, enable_diff_updates=False)
-            asyncio.run(create_search_indices(conn, config))
+
+            asyncio_run(create_search_indices(conn, config))
 
             tokenizer = tokenizer_factory.create_tokenizer(config)
             create_country_names(conn, tokenizer, config)

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -8,9 +8,16 @@ import itertools
 import sys
 import asyncio
 from pathlib import Path
+from packaging.version import Version
+import pytest_asyncio
 
 if sys.platform == 'win32':
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    if Version(pytest_asyncio.__version__) >= Version("1.4.0"):
+        # pytest-asyncio hook for event loop factory.
+        def pytest_asyncio_loop_factories(config, item):
+            return {"selector": asyncio.SelectorEventLoop}
+    else:
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 import psycopg
 from psycopg import sql as pysql


### PR DESCRIPTION
## Summary
Closes #3598 

Replaced the past attempt of fixing this in the test conftest using `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())`, as loop policies are in line to be deprecated with forthcoming Python 3.16.

Added a small helper (`get_loop_factory()`) that returns a `SelectorEventLoop`-based factory on Windows and `None` everywhere else, on other platforms this leaves `asyncio.run()` to choose it's own optimal `loop_factory` depending on platform.

The `pytest-asyncio` suite gets a [pytest_asyncio_loop_factories](https://pytest-asyncio.readthedocs.io/en/v1.4.0/how-to-guides/run_test_with_specific_loop_factories.html) hook in conftest.

Added Windows install jobs to CI basically mirroring the existing Ubuntu ones.

Also encountered a regex issue with `flex-base.lua` while running on Windows: the topic file path matching only handled `/` and broke on Windows paths `\\`.

## AI usage
Not used.

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
