### PR TITLE
utils - documentation still mentioned PHP scripts

### DIFF
--- a/utils/import_multiple_regions.sh
+++ b/utils/import_multiple_regions.sh
@@ -8,7 +8,7 @@
 
 #     *) Set up sequence.state for updates
 
-#     *) Setup nominatim db using 'setup.php --osm-file'
+#     *) Setup nominatim db using 'nominatim import'
 
 # Hint:
 #
@@ -17,7 +17,7 @@
 
 # ******************************************************************************
 
-touch2() { mkdir -p "$(dirname "$1")" && touch "$1" ; }
+touch2() { mkdir -p "$(dirname "$1")" && touch "$1"; }
 
 # ******************************************************************************
 # Configuration section: Variables in this section should be set according to your requirements
@@ -43,8 +43,7 @@ rm -rf tmp
 mkdir -p tmp
 popd
 
-for COUNTRY in $COUNTRIES;
-do
+for COUNTRY in $COUNTRIES; do
     echo "===================================================================="
     echo "$COUNTRY"
     echo "===================================================================="

--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -9,7 +9,7 @@
 #         1) pyosmium-get-changes (with -f sequence.state for getting sequenceNumber)
 
 #     *) Import diff
-#         1) utils/update.php --import-diff
+#         1) nominatim add-data --diff
 
 #     *) Index for all the countries at the end
 
@@ -40,8 +40,7 @@ FOLLOWUP="nominatim index"
 # ******************************************************************************
 UPDATEDIR="update"
 
-for COUNTRY in $COUNTRIES;
-do
+for COUNTRY in $COUNTRIES; do
     echo "===================================================================="
     echo "$COUNTRY"
     echo "===================================================================="
@@ -59,6 +58,6 @@ do
 done
 
 echo "===================================================================="
-echo "Reindexing" 
+echo "Reindexing"
 ${FOLLOWUP}
 echo "===================================================================="


### PR DESCRIPTION
The documentation inside `utils/*.sh` script still mentioned old Nominatim commands. The scripts themselves were updated 5 years ago already.

My automatic linter added whitespace changes, too. I hope that's fine.

No AI used.

For https://github.com/osm-search/Nominatim/issues/4134 where I suspect an LLM might've gotten confused about PHP being mentioned.