### PR TITLE
Make sure countries are always initialised before calling indexer

### DIFF
--- a/src/nominatim_db/clicmd/index.py
+++ b/src/nominatim_db/clicmd/index.py
@@ -50,9 +50,12 @@ class UpdateIndex:
 
     async def _do_index(self, args: NominatimArgs) -> None:
         from ..tokenizer import factory as tokenizer_factory
+        from ..indexer.indexer import Indexer
+        from ..data import country_info
+
+        country_info.setup_country_config(args.config)
 
         tokenizer = tokenizer_factory.get_tokenizer_for_db(args.config)
-        from ..indexer.indexer import Indexer
 
         indexer = Indexer(args.config, tokenizer, args.threads or psutil.cpu_count() or 1)
 

--- a/src/nominatim_db/clicmd/refresh.py
+++ b/src/nominatim_db/clicmd/refresh.py
@@ -92,8 +92,11 @@ class UpdateRefresh:
     def run(self, args: NominatimArgs) -> int:
         from ..tools import refresh, postcodes
         from ..indexer.indexer import Indexer
+        from ..data import country_info
 
         need_function_refresh = args.functions
+
+        country_info.setup_country_config(args.config)
 
         if args.postcodes:
             if postcodes.can_compute(args.config.get_libpq_dsn()):


### PR DESCRIPTION
This adds country info initialisation for the index and refresh commands, which both might trigger indexing.