### PR TITLE
Align meaning of attributes in query node

### DIFF
--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -11,7 +11,6 @@ from typing import Tuple, Dict, List, Optional, Iterator, Any, cast
 import dataclasses
 import difflib
 import re
-from itertools import zip_longest
 
 from icu import Transliterator
 
@@ -153,13 +152,14 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
 
         log().var_dump('Normalized query', query.source)
         if not query.source:
+            query.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)
             return query
 
         self.split_query(query)
         log().var_dump('Transliterated query',
-                       lambda: ''.join(f"{n.term_lookup}{n.btype}" for n in query.nodes)
+                       lambda: ''.join(f"{n.btype}{n.term_lookup}" for n in query.nodes)
                                + ' / '
-                               + ''.join(f"{n.term_normalized}{n.btype}" for n in query.nodes))
+                               + ''.join(f"{n.btype}{n.term_normalized}" for n in query.nodes))
         words = query.extract_words()
 
         for row in await self.lookup_in_db(list(words.keys())):
@@ -182,7 +182,7 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
 
         self.add_extra_tokens(query)
         for start, end, pc in self.postcode_parser.parse(query):
-            term = ' '.join(n.term_lookup for n in query.nodes[start + 1:end + 1])
+            term = ' '.join(n.term_lookup for n in query.nodes[start:end])
             query.add_token(qmod.TokenRange(start, end),
                             qmod.TOKEN_POSTCODE,
                             ICUToken(penalty=0.0, token=0, count=1, addr_count=1,
@@ -233,23 +233,23 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
     def split_query(self, query: qmod.QueryStruct) -> None:
         """ Transliterate the phrases and split them into tokens.
         """
+        breakchar: Optional[str] = qmod.BREAK_START
         for phrase in query.source:
-            query.nodes[-1].ptype = phrase.ptype
             phrase_split = re.split('([ :-])', phrase.text)
-            # The zip construct will give us the pairs of word/break from
-            # the regular expression split. As the split array ends on the
-            # final word, we simply use the fillvalue to even out the list and
-            # add the phrase break at the end.
-            for word, breakchar in zip_longest(*[iter(phrase_split)]*2, fillvalue=','):
-                if not word:
-                    continue
-                if trans := self.transliterator.transliterate(word):
-                    for term, term_word in self.split_transliteration(trans, word):
-                        if term:
-                            query.add_node(qmod.BREAK_TOKEN, phrase.ptype, term, term_word)
-                    query.nodes[-1].btype = breakchar
+            for word in phrase_split:
+                if breakchar is None:
+                    breakchar = word
+                else:
+                    if word:
+                        if trans := self.transliterator.transliterate(word):
+                            for term, term_word in self.split_transliteration(trans, word):
+                                if term:
+                                    query.add_node(breakchar, phrase.ptype, term, term_word)
+                                    breakchar = qmod.BREAK_TOKEN
+                    breakchar = None
+            breakchar = qmod.BREAK_PHRASE
 
-        query.nodes[-1].btype = qmod.BREAK_END
+        query.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)
 
     async def lookup_in_db(self, words: List[str]) -> 'sa.Result[Any]':
         """ Return the token information from the database for the
@@ -265,18 +265,22 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
     def add_extra_tokens(self, query: qmod.QueryStruct) -> None:
         """ Add tokens to query that are not saved in the database.
         """
-        need_hnr = False
+        candidate: Optional[str] = None
         for i, node in enumerate(query.nodes):
-            is_full_token = node.btype not in (qmod.BREAK_TOKEN, qmod.BREAK_PART)
-            if need_hnr and is_full_token \
-                    and len(node.term_normalized) <= 4 and node.term_normalized.isdigit():
-                query.add_token(qmod.TokenRange(i-1, i), qmod.TOKEN_HOUSENUMBER,
-                                ICUToken(penalty=0.2, token=0,
-                                         count=1, addr_count=1,
-                                         lookup_word=node.term_lookup,
-                                         word_token=node.term_lookup, info=None))
-
-            need_hnr = is_full_token and not node.has_tokens(i+1, qmod.TOKEN_HOUSENUMBER)
+            if node.btype in (qmod.BREAK_TOKEN, qmod.BREAK_PART):
+                candidate = None
+            else:
+                if candidate is not None:
+                    query.add_token(qmod.TokenRange(i - 1, i), qmod.TOKEN_HOUSENUMBER,
+                                    ICUToken(penalty=0.2, token=0,
+                                             count=1, addr_count=1,
+                                             lookup_word=candidate,
+                                             word_token=candidate, info=None))
+                if len(node.term_normalized) <= 4 and node.term_normalized.isdigit() \
+                        and not node.has_tokens(i+1, qmod.TOKEN_HOUSENUMBER):
+                    candidate = node.term_lookup
+                else:
+                    candidate = None
 
     def rerank_tokens(self, query: qmod.QueryStruct) -> None:
         """ Add penalties to tokens that depend on presence of other token.
@@ -289,7 +293,7 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                         if ttype != qmod.TOKEN_POSTCODE and \
                                (ttype != qmod.TOKEN_HOUSENUMBER or
                                 start + 1 > end or
-                                len(query.nodes[end].term_lookup) > 4):
+                                len(query.nodes[start].term_lookup) > 4):
                             for token in tokens:
                                 token.penalty += 0.39
                         if (start + 1 == end):
@@ -310,8 +314,8 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                                 partial.penalty += penalty
 
             # rerank tokens against the normalized form
-            norm = ''.join(f"{n.term_normalized}{'' if n.btype == qmod.BREAK_TOKEN else ' '}"
-                           for n in query.nodes[start + 1:end + 1]).strip()
+            norm = ''.join(f"{'' if n.btype == qmod.BREAK_TOKEN else ' '}{n.term_normalized}"
+                           for n in query.nodes[start:end]).strip()
             for ttype, tokens in tlist.items():
                 for token in tokens:
                     itok = cast(ICUToken, token)

--- a/src/nominatim_api/search/postcode_parser.py
+++ b/src/nominatim_api/search/postcode_parser.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Handling of arbitrary postcode tokens in tokenized query string.
@@ -57,28 +57,34 @@ class PostcodeParser:
         nodes = query.nodes
         outcodes: Set[Tuple[int, int, str]] = set()
 
-        terms = [n.term_normalized.upper() + n.btype for n in nodes]
-        for i in range(query.num_token_slots()):
-            if nodes[i].btype in '<,: ' and nodes[i + 1].btype != '`' \
-                    and (i == 0 or nodes[i - 1].ptype != qmod.PHRASE_POSTCODE):
-                if nodes[i].ptype == qmod.PHRASE_ANY:
-                    word = terms[i + 1]
-                    if word[-1] in ' -' and nodes[i + 2].btype != '`' \
-                            and nodes[i + 1].ptype == qmod.PHRASE_ANY:
-                        word += terms[i + 2]
-                        if word[-1] in ' -' and nodes[i + 3].btype != '`' \
-                                and nodes[i + 2].ptype == qmod.PHRASE_ANY:
-                            word += terms[i + 3]
+        start = 0
+        endnode = query.num_token_slots()
+        while start < endnode:
+            ptype = nodes[start].ptype
+            end = start + 1
+            while nodes[end].btype not in '>,:' and nodes[end].ptype == ptype:
+                end += 1
 
-                    self._match_word(word, i, False, outcodes)
-                elif nodes[i].ptype == qmod.PHRASE_POSTCODE:
-                    word = terms[i + 1]
-                    for j in range(i + 1, query.num_token_slots()):
-                        if nodes[j].ptype != qmod.PHRASE_POSTCODE:
-                            break
-                        word += terms[j + 1]
+            subnodes = nodes[start:end]
+            if ptype == qmod.PHRASE_POSTCODE:
+                self._match_word(''.join(f"{n.btype}{n.term_normalized.upper()}"
+                                         for n in subnodes)[1:] + nodes[end].btype,
+                                 start, True, outcodes)
+            elif ptype == qmod.PHRASE_ANY:
+                subnodes.reverse()
+                word = nodes[end].btype
+                substart = end - 1
+                for n in subnodes:
+                    if n.btype == '`' or word == '`':
+                        word = n.btype
+                    else:
+                        word = n.term_normalized.upper() + word
+                        if n.btype in '<,: ':
+                            self._match_word(word, substart, False, outcodes)
+                        word = n.btype + word
+                    substart -= 1
 
-                    self._match_word(word, i, True, outcodes)
+            start = end
 
         return outcodes
 

--- a/src/nominatim_api/search/query.py
+++ b/src/nominatim_api/search/query.py
@@ -190,10 +190,12 @@ class QueryNode:
     """ A node of the query representing a break between terms.
 
         The node also contains information on the source term
-        ending at the node. The tokens are created from this information.
+        starting at the node. The tokens are created from this information.
     """
     btype: BreakType
     ptype: PhraseType
+    """ Type of phrase for edges starting at this node.
+    """
 
     penalty: float
     """ Penalty for having a word break at this position. The penalty
@@ -201,10 +203,10 @@ class QueryNode:
         the word after the node.
     """
     term_lookup: str
-    """ Transliterated term ending at this node.
+    """ Transliterated term starting at this node.
     """
     term_normalized: str
-    """ Normalised form of term ending at this node.
+    """ Normalised form of term starting at this node.
     """
 
     starting: List[TokenList] = dataclasses.field(default_factory=list)
@@ -288,9 +290,7 @@ class QueryStruct:
     def __init__(self, source: List[Phrase]) -> None:
         self.source = source
         self.dir_penalty = 0.0
-        self.nodes: List[QueryNode] = \
-            [QueryNode(BREAK_START, source[0].ptype if source else PHRASE_ANY,
-                       0.0, '', '')]
+        self.nodes: List[QueryNode] = []
 
     def num_token_slots(self) -> int:
         """ Return the length of the query in vertice steps.
@@ -406,19 +406,18 @@ class QueryStruct:
             position within the query.
         """
         if endpos is None:
-            endpos = len(self.nodes)
+            endpos = len(self.nodes) - 1
 
         words: Dict[str, List[TokenRange]] = defaultdict(list)
 
-        for first, first_node in enumerate(self.nodes[start + 1:endpos], start):
+        for first, first_node in enumerate(self.nodes[start:endpos], start):
             word = first_node.term_lookup
             words[word].append(TokenRange(first, first + 1))
-            if first_node.btype != BREAK_PHRASE:
-                max_last = min(first + 20, endpos)
-                for last, last_node in enumerate(self.nodes[first + 2:max_last], first + 2):
-                    word = ' '.join((word, last_node.term_lookup))
-                    words[word].append(TokenRange(first, last))
-                    if last_node.btype == BREAK_PHRASE:
-                        break
+            max_last = min(first + 20, endpos)
+            for last, last_node in enumerate(self.nodes[first + 1:max_last], first + 2):
+                if last_node.btype == BREAK_PHRASE:
+                    break
+                word = f"{word} {last_node.term_lookup}"
+                words[word].append(TokenRange(first, last))
 
         return words

--- a/test/python/api/search/test_api_search_query.py
+++ b/test/python/api/search/test_api_search_query.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for tokenized query data structures.
@@ -64,14 +64,9 @@ def test_query_node_with_content(qnode):
     assert len(qnode.get_tokens(2, query.TOKEN_WORD)) == 1
 
 
-def test_query_struct_empty():
-    q = query.QueryStruct([])
-
-    assert q.num_token_slots() == 0
-
-
 def test_query_struct_with_tokens():
     q = query.QueryStruct([query.Phrase(query.PHRASE_ANY, 'foo bar')])
+    q.add_node(query.BREAK_START, query.PHRASE_ANY)
     q.add_node(query.BREAK_WORD, query.PHRASE_ANY)
     q.add_node(query.BREAK_END, query.PHRASE_ANY)
 
@@ -96,6 +91,7 @@ def test_query_struct_with_tokens():
 
 def test_query_struct_incompatible_token():
     q = query.QueryStruct([query.Phrase(query.PHRASE_COUNTRY, 'foo bar')])
+    q.add_node(query.BREAK_START, query.PHRASE_COUNTRY)
     q.add_node(query.BREAK_WORD, query.PHRASE_COUNTRY)
     q.add_node(query.BREAK_END, query.PHRASE_ANY)
 
@@ -107,6 +103,7 @@ def test_query_struct_incompatible_token():
 
 def test_query_struct_amenity_single_word():
     q = query.QueryStruct([query.Phrase(query.PHRASE_AMENITY, 'bar')])
+    q.add_node(query.BREAK_START, query.PHRASE_ANY)
     q.add_node(query.BREAK_END, query.PHRASE_ANY)
 
     q.add_token(query.TokenRange(0, 1), query.TOKEN_PARTIAL, mktoken(1))
@@ -120,6 +117,7 @@ def test_query_struct_amenity_single_word():
 
 def test_query_struct_amenity_two_words():
     q = query.QueryStruct([query.Phrase(query.PHRASE_AMENITY, 'foo bar')])
+    q.add_node(query.BREAK_START, query.PHRASE_AMENITY)
     q.add_node(query.BREAK_WORD, query.PHRASE_AMENITY)
     q.add_node(query.BREAK_END, query.PHRASE_ANY)
 

--- a/test/python/api/search/test_db_search_builder.py
+++ b/test/python/api/search/test_db_search_builder.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Tests for creating abstract searches from token assignments.
@@ -36,6 +36,7 @@ def make_query(*args):
     for _ in range(max(inner[0] for tlist in args for inner in tlist)):
         q.add_node(qmod.BREAK_WORD, qmod.PHRASE_ANY)
     q.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)
+    q.nodes[0].btype = qmod.BREAK_START
 
     for start, tlist in enumerate(args):
         for end, ttype, tinfos in tlist:
@@ -412,6 +413,7 @@ def make_counted_searches(name_part, name_full, address_part, address_full,
     for i in range(1 + num_address_parts):
         q.add_node(qmod.BREAK_WORD, qmod.PHRASE_ANY)
     q.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)
+    q.nodes[0].btype = qmod.BREAK_START
 
     q.add_token(TokenRange(0, 1), qmod.TOKEN_PARTIAL,
                 MyToken(0.5, 1, name_part, 1, 'name_part'))

--- a/test/python/api/search/test_postcode_parser.py
+++ b/test/python/api/search/test_postcode_parser.py
@@ -3,13 +3,12 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Test for parsing of postcodes in queries.
 """
 import re
-from itertools import zip_longest
 
 import pytest
 
@@ -67,8 +66,14 @@ def mk_query(inp):
     query = QueryStruct([])
     phrase_split = re.split(r"([ ,:'-])", inp)
 
-    for word, breakchar in zip_longest(*[iter(phrase_split)]*2, fillvalue='>'):
-        query.add_node(breakchar, PHRASE_ANY, word, word)
+    brk = '<'
+    for word in phrase_split:
+        if brk is None:
+            brk = word
+        else:
+            query.add_node(brk, PHRASE_ANY, word, word)
+            brk = None
+    query.add_node('>', PHRASE_ANY)
 
     return query
 
@@ -152,10 +157,10 @@ def test_postcode_inside_postcode_phrase(pc_config):
     parser = PostcodeParser(pc_config)
 
     query = QueryStruct([])
-    query.nodes[-1].ptype = PHRASE_STREET
-    query.add_node(',', PHRASE_STREET, '12345', '12345')
+    query.add_node('<', PHRASE_STREET, '12345', '12345')
     query.add_node(',', PHRASE_POSTCODE, 'xz', 'xz')
-    query.add_node('>', PHRASE_POSTCODE, '4444', '4444')
+    query.add_node(',', PHRASE_POSTCODE, '4444', '4444')
+    query.add_node('>', PHRASE_ANY)
 
     assert parser.parse(query) == {(2, 3, '4444')}
 
@@ -164,8 +169,8 @@ def test_partial_postcode_in_postcode_phrase(pc_config):
     parser = PostcodeParser(pc_config)
 
     query = QueryStruct([])
-    query.nodes[-1].ptype = PHRASE_POSTCODE
-    query.add_node(' ', PHRASE_POSTCODE, '2224', '2224')
-    query.add_node('>', PHRASE_POSTCODE, '12345', '12345')
+    query.add_node('<', PHRASE_POSTCODE, '2224', '2224')
+    query.add_node(' ', PHRASE_POSTCODE, '12345', '12345')
+    query.add_node('>', PHRASE_ANY)
 
     assert not parser.parse(query)

--- a/test/python/api/search/test_query.py
+++ b/test/python/api/search/test_query.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Test data types for search queries.
@@ -51,10 +51,11 @@ def test_token_range_unimplemented_ops():
 
 def test_query_extract_words():
     q = nq.QueryStruct([])
-    q.add_node(nq.BREAK_WORD, nq.PHRASE_ANY, '12', '')
-    q.add_node(nq.BREAK_TOKEN, nq.PHRASE_ANY, 'ab', '')
-    q.add_node(nq.BREAK_PHRASE, nq.PHRASE_ANY, '12', '')
-    q.add_node(nq.BREAK_END, nq.PHRASE_ANY, 'hallo', '')
+    q.add_node(nq.BREAK_START, nq.PHRASE_ANY, '12', '')
+    q.add_node(nq.BREAK_WORD, nq.PHRASE_ANY, 'ab', '')
+    q.add_node(nq.BREAK_TOKEN, nq.PHRASE_ANY, '12', '')
+    q.add_node(nq.BREAK_PHRASE, nq.PHRASE_ANY, 'hallo', '')
+    q.add_node(nq.BREAK_END, nq.PHRASE_ANY)
 
     words = q.extract_words()
 

--- a/test/python/api/search/test_token_assignment.py
+++ b/test/python/api/search/test_token_assignment.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Nominatim. (https://nominatim.org)
 #
-# Copyright (C) 2025 by the Nominatim developer community.
+# Copyright (C) 2026 by the Nominatim developer community.
 # For a full list of authors see the git log.
 """
 Test for creation of token assignments from tokenized queries.
@@ -29,7 +29,7 @@ def make_query(*args):
     dummy = MyToken(penalty=3.0, token=45, count=1, addr_count=1,
                     lookup_word='foo')
 
-    for btype, ptype, _ in args[1:]:
+    for btype, ptype, _ in args:
         q.add_node(btype, ptype)
         q.nodes[-1].penalty = PENALTY_BREAK[btype]
     q.add_node(qmod.BREAK_END, qmod.PHRASE_ANY)


### PR DESCRIPTION
Incoming queries are parsed by Nominatim into a word network. The nodes in this network represent the breaks between the minimal tokens in the query. These nodes contain some information about the break as well as attributes for the attached edges. For historical reasons some of the latter attributes refer to outgoing edges while others refer to incoming edges. That was quite confusing.

This PR harmonizes the attributes, so that all of them refer to outgoing edges.