### PR TITLE
update_database.sh: Always execute nominatim index

### DIFF
--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -27,15 +27,11 @@ COUNTRIES="europe/monaco europe/andorra"
 UPDATEBASEURL="https://download.geofabrik.de"
 UPDATECOUNTRYPOSTFIX="-updates"
 
-# If you do not use Photon, let Nominatim handle (re-)indexing:
+# If you use Photon, update it, too (Photon server must be running and must have
+# been started with "-database", "-user", "-password" and "-enable-update-api"
+# parameters):
 #
-FOLLOWUP="nominatim index"
-#
-# If you use Photon, update Photon and let it handle the index
-# (Photon server must be running and must have been started with "-database",
-# "-user" and "-password" parameters):
-#
-#FOLLOWUP="curl http://localhost:2322/nominatim-update"
+#PHOTON_UPDATE="curl http://localhost:2322/nominatim-update"
 
 # ******************************************************************************
 UPDATEDIR="update"
@@ -59,5 +55,12 @@ done
 
 echo "===================================================================="
 echo "Reindexing"
-${FOLLOWUP}
+nominatim index
 echo "===================================================================="
+
+if [ -n "$var" ]; then
+  echo "===================================================================="
+  echo "Triggering asynchronous Photon update"
+  ${PHOTON_UPDATE}
+  echo "===================================================================="
+fi

--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -32,6 +32,7 @@ UPDATECOUNTRYPOSTFIX="-updates"
 # parameters):
 #
 #PHOTON_UPDATE="curl http://localhost:2322/nominatim-update"
+PHOTON_UPDATE="" # Just set to an empty string, if not wanted.
 
 # ******************************************************************************
 UPDATEDIR="update"

--- a/utils/update_database.sh
+++ b/utils/update_database.sh
@@ -58,7 +58,7 @@ echo "Reindexing"
 nominatim index
 echo "===================================================================="
 
-if [ -n "$var" ]; then
+if [ -n "$PHOTON_UPDATE" ]; then
   echo "===================================================================="
   echo "Triggering asynchronous Photon update"
   ${PHOTON_UPDATE}


### PR DESCRIPTION
## Summary
The script was misleading by implying that the Photon update also does the indexing of the Nominatim database, which is not the case, see [discussion](https://github.com/osm-search/Nominatim/discussions/4143).

## AI usage
None.

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
