### PR TITLE
Use ltree categories column instead of place_classtype tables

### DIFF
--- a/lib-sql/indices.sql
+++ b/lib-sql/indices.sql
@@ -104,7 +104,6 @@ CREATE INDEX IF NOT EXISTS idx_osmline_parent_osm_id
     INCLUDE (startnumber, endnumber) {{db.tablespace.search_index}}
     WHERE startnumber is not null;
 ---
-  CREATE INDEX IF NOT EXISTS idx_placex_categories ON placex
-    USING GIST(categories gist__ltree_ops) {{db.tablespace.search_index}}
-    WHERE categories IS NOT NULL;
+  CREATE INDEX IF NOT EXISTS idx_placex_centroid_categories ON placex
+    USING GIST(centroid, categories gist__ltree_ops(siglen=8)) {{db.tablespace.search_index}};
 {% endif %}

--- a/src/nominatim_api/connection.py
+++ b/src/nominatim_api/connection.py
@@ -125,6 +125,10 @@ class SearchConnection:
     async def get_class_table(self, cls: str, typ: str) -> Optional[SaFromClause]:
         """ Lookup up if there is a classtype table for the given category
             and return a SQLAlchemy table for it, if it exists.
+
+            TODO: the place_classtype_* tables are obsolete now that the search
+            side queries the ltree categories column. This helper and the
+            tables are to be deprecated soon.
         """
         if self._classtables is None:
             res = await self.execute(sa.text("""SELECT tablename FROM pg_tables

--- a/src/nominatim_api/search/db_searches/base.py
+++ b/src/nominatim_api/search/db_searches/base.py
@@ -7,15 +7,15 @@
 """
 Interface for classes implementing a database search.
 """
-from typing import Any, Callable, List, Optional
+from typing import Callable, List
 import abc
 import re
 
 import sqlalchemy as sa
-from sqlalchemy.ext.compiler import compiles
 
 from ...typing import SaFromClause, SaSelect, SaColumn, SaExpression, SaLambdaSelect
 from ...sql.sqlalchemy_types import Geometry
+from ...sql.sqlalchemy_functions import CategoryMatch
 from ...connection import SearchConnection
 from ...types import SearchDetails, DataLayer, GeometryFormat
 from ...results import SearchResults
@@ -34,59 +34,28 @@ def _sanitize_label(part: str) -> str:
     return part.replace('-', '_')
 
 
-def category_ltree(cls: str, typ: str) -> Optional[str]:
+def is_ltree_category(cls: str) -> bool:
+    """ Check whether the given class can form a valid ltree category label.
+        Types are always sanitized, so only the class may render a category
+        unrepresentable. Non-conforming categories are rejected during token
+        collection so that search never has to fall back to an unindexed query.
+    """
+    return bool(cls) and not _LTREE_INVALID.search(cls)
+
+
+def category_ltree(cls: str, typ: str) -> str:
     """ Build the 'osm.<class>.<type>' ltree string for a class/type pair,
-        mirroring the Lua get_category(). Returns None when the class cannot
-        form a valid ltree label, in which case no stored category can match.
+        mirroring the Lua get_category(). The class must be a valid ltree
+        label (see is_ltree_category()).
     """
-    if not cls or _LTREE_INVALID.search(cls):
-        return None
     return f'osm.{_sanitize_label(cls)}.{_sanitize_label(typ)}'
-
-
-class CategoryMatch(sa.sql.expression.FunctionElement[Any]):
-    """ Match a placex row against a single (class, type) category.
-
-        On PostgreSQL this queries the ltree 'categories' column using the
-        GiST index (``categories <@ 'osm.<class>.<type>'``). On SQLite, which
-        has no ltree support, it falls back to class/type equality; those
-        columns are still present and populated.
-    """
-    inherit_cache = True
-
-    def __init__(self, table: SaFromClause, ltree: str, cls: str, typ: str) -> None:
-        super().__init__(table.c.categories, sa.literal(ltree),
-                         table.c.class_, sa.literal(cls),
-                         table.c.type, sa.literal(typ))
-
-
-@compiles(CategoryMatch)
-def _default_category_match(element: CategoryMatch,
-                            compiler: 'sa.Compiled', **kw: Any) -> str:
-    cats, ltree, _, _, _, _ = list(element.clauses)
-    return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
-                                    compiler.process(ltree, **kw))
-
-
-@compiles(CategoryMatch, 'sqlite')
-def _sqlite_category_match(element: CategoryMatch,
-                           compiler: 'sa.Compiled', **kw: Any) -> str:
-    _, _, cls_col, cls_lit, typ_col, typ_lit = list(element.clauses)
-    return "(%s = %s AND %s = %s)" % (compiler.process(cls_col, **kw),
-                                      compiler.process(cls_lit, **kw),
-                                      compiler.process(typ_col, **kw),
-                                      compiler.process(typ_lit, **kw))
 
 
 def category_filter(table: SaFromClause, cls: str, typ: str) -> SaExpression:
     """ Build a boolean expression selecting rows of the given class/type
-        category. Uses the ltree categories column on PostgreSQL and falls
-        back to class/type equality where no ltree category can exist.
+        category via the ltree categories column (class/type on SQLite).
     """
-    ltree = category_ltree(cls, typ)
-    if ltree is None:
-        return sa.and_(table.c.class_ == cls, table.c.type == typ)
-    return CategoryMatch(table, ltree, cls, typ)
+    return CategoryMatch(table, category_ltree(cls, typ), cls, typ)
 
 
 class AbstractSearch(abc.ABC):

--- a/src/nominatim_api/search/db_searches/base.py
+++ b/src/nominatim_api/search/db_searches/base.py
@@ -7,16 +7,86 @@
 """
 Interface for classes implementing a database search.
 """
-from typing import Callable, List
+from typing import Any, Callable, List, Optional
 import abc
+import re
 
 import sqlalchemy as sa
+from sqlalchemy.ext.compiler import compiles
 
 from ...typing import SaFromClause, SaSelect, SaColumn, SaExpression, SaLambdaSelect
 from ...sql.sqlalchemy_types import Geometry
 from ...connection import SearchConnection
 from ...types import SearchDetails, DataLayer, GeometryFormat
 from ...results import SearchResults
+
+
+_LTREE_INVALID = re.compile(r'[^A-Za-z0-9_-]')
+
+
+def _sanitize_label(part: str) -> str:
+    """ Turn an OSM key or value into a valid ltree label, mirroring the
+        Lua sanitize_label(): invalid characters map to 'yes', hyphens to
+        underscores (for PostgreSQL < 16 compatibility).
+    """
+    if not part or _LTREE_INVALID.search(part):
+        return 'yes'
+    return part.replace('-', '_')
+
+
+def category_ltree(cls: str, typ: str) -> Optional[str]:
+    """ Build the 'osm.<class>.<type>' ltree string for a class/type pair,
+        mirroring the Lua get_category(). Returns None when the class cannot
+        form a valid ltree label, in which case no stored category can match.
+    """
+    if not cls or _LTREE_INVALID.search(cls):
+        return None
+    return f'osm.{_sanitize_label(cls)}.{_sanitize_label(typ)}'
+
+
+class CategoryMatch(sa.sql.expression.FunctionElement[Any]):
+    """ Match a placex row against a single (class, type) category.
+
+        On PostgreSQL this queries the ltree 'categories' column using the
+        GiST index (``categories <@ 'osm.<class>.<type>'``). On SQLite, which
+        has no ltree support, it falls back to class/type equality; those
+        columns are still present and populated.
+    """
+    inherit_cache = True
+
+    def __init__(self, table: SaFromClause, ltree: str, cls: str, typ: str) -> None:
+        super().__init__(table.c.categories, sa.literal(ltree),
+                         table.c.class_, sa.literal(cls),
+                         table.c.type, sa.literal(typ))
+
+
+@compiles(CategoryMatch)
+def _default_category_match(element: CategoryMatch,
+                            compiler: 'sa.Compiled', **kw: Any) -> str:
+    cats, ltree, _, _, _, _ = list(element.clauses)
+    return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
+                                    compiler.process(ltree, **kw))
+
+
+@compiles(CategoryMatch, 'sqlite')
+def _sqlite_category_match(element: CategoryMatch,
+                           compiler: 'sa.Compiled', **kw: Any) -> str:
+    _, _, cls_col, cls_lit, typ_col, typ_lit = list(element.clauses)
+    return "(%s = %s AND %s = %s)" % (compiler.process(cls_col, **kw),
+                                      compiler.process(cls_lit, **kw),
+                                      compiler.process(typ_col, **kw),
+                                      compiler.process(typ_lit, **kw))
+
+
+def category_filter(table: SaFromClause, cls: str, typ: str) -> SaExpression:
+    """ Build a boolean expression selecting rows of the given class/type
+        category. Uses the ltree categories column on PostgreSQL and falls
+        back to class/type equality where no ltree category can exist.
+    """
+    ltree = category_ltree(cls, typ)
+    if ltree is None:
+        return sa.and_(table.c.class_ == cls, table.c.type == typ)
+    return CategoryMatch(table, ltree, cls, typ)
 
 
 class AbstractSearch(abc.ABC):

--- a/src/nominatim_api/search/db_searches/near_search.py
+++ b/src/nominatim_api/search/db_searches/near_search.py
@@ -82,17 +82,20 @@ class NearSearch(base.AbstractSearch):
         tgeom = conn.t.placex.alias('pgeom')
         table = conn.t.placex
 
-        # Look up places of the category in placex via the ltree categories
-        # index. We can afford a larger search radius here.
+        # Look up places of the category near the base place. The ltree
+        # categories index is not spatial, so prune with the geometry GiST
+        # index (geometry && search_area) and keep the centroid containment
+        # as the exact recheck. We can afford a larger search radius here.
+        search_area = sa.case((sa.and_(tgeom.c.rank_address > 9,
+                                       tgeom.c.geometry.is_area()),
+                               tgeom.c.geometry),
+                              else_=tgeom.c.centroid.ST_Expand(0.05))
         sql = sa.select(table.c.place_id,
                         sa.func.min(tgeom.c.centroid.ST_Distance(table.c.centroid))
                           .label('dist'))\
                 .join(tgeom,
-                      table.c.centroid.ST_CoveredBy(
-                          sa.case((sa.and_(tgeom.c.rank_address > 9,
-                                           tgeom.c.geometry.is_area()),
-                                   tgeom.c.geometry),
-                                  else_=tgeom.c.centroid.ST_Expand(0.05))))\
+                      sa.and_(table.c.geometry.intersects(search_area),
+                              table.c.centroid.ST_CoveredBy(search_area)))\
                 .where(base.category_filter(table, *category))
 
         inner = sql.where(tgeom.c.place_id.in_(ids))\

--- a/src/nominatim_api/search/db_searches/near_search.py
+++ b/src/nominatim_api/search/db_searches/near_search.py
@@ -82,10 +82,9 @@ class NearSearch(base.AbstractSearch):
         tgeom = conn.t.placex.alias('pgeom')
         table = conn.t.placex
 
-        # Look up places of the category near the base place. The ltree
-        # categories index is not spatial, so prune with the geometry GiST
-        # index (geometry && search_area) and keep the centroid containment
-        # as the exact recheck. We can afford a larger search radius here.
+        # Look up places of the category near the base place. The centroid
+        # containment is served by the combined centroid/categories index.
+        # We can afford to use a larger radius for the lookup.
         search_area = sa.case((sa.and_(tgeom.c.rank_address > 9,
                                        tgeom.c.geometry.is_area()),
                                tgeom.c.geometry),
@@ -93,9 +92,7 @@ class NearSearch(base.AbstractSearch):
         sql = sa.select(table.c.place_id,
                         sa.func.min(tgeom.c.centroid.ST_Distance(table.c.centroid))
                           .label('dist'))\
-                .join(tgeom,
-                      sa.and_(table.c.geometry.intersects(search_area),
-                              table.c.centroid.ST_CoveredBy(search_area)))\
+                .join(tgeom, table.c.centroid.ST_CoveredBy(search_area))\
                 .where(base.category_filter(table, *category))
 
         inner = sql.where(tgeom.c.place_id.in_(ids))\

--- a/src/nominatim_api/search/db_searches/near_search.py
+++ b/src/nominatim_api/search/db_searches/near_search.py
@@ -120,9 +120,6 @@ class NearSearch(base.AbstractSearch):
                        'countries': details.countries}
         for row in await conn.execute(sql, bind_params):
             result = nres.create_from_placex_row(row, nres.SearchResult)
-            # A matched placex row may carry several categories; report the
-            # one that was searched for rather than its class/type.
-            result.category = category
             result.accuracy = self.penalty + penalty
             result.bbox = Bbox.from_wkb(row.bbox)
             results.append(result)

--- a/src/nominatim_api/search/db_searches/near_search.py
+++ b/src/nominatim_api/search/db_searches/near_search.py
@@ -79,31 +79,21 @@ class NearSearch(base.AbstractSearch):
         """ Find places of the given category near the list of
             place ids and add the results to 'results'.
         """
-        table = await conn.get_class_table(*category)
-
         tgeom = conn.t.placex.alias('pgeom')
+        table = conn.t.placex
 
-        if table is None:
-            # No classtype table available, do a simplified lookup in placex.
-            table = conn.t.placex
-            sql = sa.select(table.c.place_id,
-                            sa.func.min(tgeom.c.centroid.ST_Distance(table.c.centroid))
-                              .label('dist'))\
-                    .join(tgeom, table.c.geometry.intersects(tgeom.c.centroid.ST_Expand(0.01)))\
-                    .where(table.c.class_ == category[0])\
-                    .where(table.c.type == category[1])
-        else:
-            # Use classtype table. We can afford to use a larger
-            # radius for the lookup.
-            sql = sa.select(table.c.place_id,
-                            sa.func.min(tgeom.c.centroid.ST_Distance(table.c.centroid))
-                              .label('dist'))\
-                    .join(tgeom,
-                          table.c.centroid.ST_CoveredBy(
-                              sa.case((sa.and_(tgeom.c.rank_address > 9,
-                                               tgeom.c.geometry.is_area()),
-                                       tgeom.c.geometry),
-                                      else_=tgeom.c.centroid.ST_Expand(0.05))))
+        # Look up places of the category in placex via the ltree categories
+        # index. We can afford a larger search radius here.
+        sql = sa.select(table.c.place_id,
+                        sa.func.min(tgeom.c.centroid.ST_Distance(table.c.centroid))
+                          .label('dist'))\
+                .join(tgeom,
+                      table.c.centroid.ST_CoveredBy(
+                          sa.case((sa.and_(tgeom.c.rank_address > 9,
+                                           tgeom.c.geometry.is_area()),
+                                   tgeom.c.geometry),
+                                  else_=tgeom.c.centroid.ST_Expand(0.05))))\
+                .where(base.category_filter(table, *category))
 
         inner = sql.where(tgeom.c.place_id.in_(ids))\
                    .group_by(table.c.place_id).subquery()
@@ -130,6 +120,9 @@ class NearSearch(base.AbstractSearch):
                        'countries': details.countries}
         for row in await conn.execute(sql, bind_params):
             result = nres.create_from_placex_row(row, nres.SearchResult)
+            # A matched placex row may carry several categories; report the
+            # one that was searched for rather than its class/type.
+            result.category = category
             result.accuracy = self.penalty + penalty
             result.bbox = Bbox.from_wkb(row.bbox)
             results.append(result)

--- a/src/nominatim_api/search/db_searches/poi_search.py
+++ b/src/nominatim_api/search/db_searches/poi_search.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from . import base
 from ..db_search_fields import SearchData
 from ... import results as nres
-from ...typing import SaBind, SaRow
+from ...typing import SaBind
 from ...sql.sqlalchemy_types import Geometry
 from ...connection import SearchConnection
 from ...types import SearchDetails, Bbox
@@ -46,54 +46,32 @@ class PoiSearch(base.AbstractSearch):
 
         t = conn.t.placex
 
-        rows: list[SaRow] = []
+        # All searches go through the categories column, which is backed by the
+        # combined centroid/categories GiST index. Filter and order on the
+        # centroid, so that the index can serve both conditions at once.
+        sql = base.select_placex(t)\
+                  .where(sa.or_(*(base.category_filter(t, *category)
+                                  for category in self.qualifiers.values)))\
+                  .where(t.c.linked_place_id == None)
 
-        category_match = sa.or_(*(base.category_filter(t, *category)
-                                  for category in self.qualifiers.values))
-
-        if details.near and details.near_radius is not None and details.near_radius < 0.2:
-            # simply search in placex table
-            sql = base.select_placex(t) \
-                      .add_columns((-t.c.centroid.ST_Distance(NEAR_PARAM))
-                                   .label('importance'))\
-                      .where(t.c.linked_place_id == None) \
-                      .where(t.c.geometry.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM)) \
-                      .where(category_match) \
-                      .order_by(t.c.centroid.ST_Distance(NEAR_PARAM)) \
-                      .limit(LIMIT_PARAM)
-
-            if self.countries:
-                sql = sql.where(t.c.country_code.in_(self.countries.values))
-
-            if details.viewbox is not None and details.bounded_viewbox:
-                sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
-
-            if details.excluded:
-                sql = sql.where(base.exclude_places(t))
-
-            rows.extend(await conn.execute(sql, bind_params))
+        if details.near is not None and details.near_radius is not None:
+            sql = sql.add_columns((-t.c.centroid.ST_Distance(NEAR_PARAM))
+                                  .label('importance'))\
+                     .where(t.c.centroid.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM))\
+                     .order_by(t.c.centroid.ST_Distance(NEAR_PARAM))
         else:
-            # use the categories column, backed by the combined
-            # centroid/categories GiST index
-            sql = base.select_placex(t)\
-                      .add_columns(t.c.importance)\
-                      .where(category_match)
+            sql = sql.add_columns(t.c.importance)
 
-            if details.viewbox is not None and details.bounded_viewbox:
-                sql = sql.where(t.c.centroid.intersects(VIEWBOX_PARAM))
+        if details.viewbox is not None and details.bounded_viewbox:
+            sql = sql.where(t.c.centroid.intersects(VIEWBOX_PARAM))
 
-            if details.near and details.near_radius is not None:
-                sql = sql.order_by(t.c.centroid.ST_Distance(NEAR_PARAM))\
-                         .where(t.c.centroid.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM))
+        if self.countries:
+            sql = sql.where(t.c.country_code.in_(self.countries.values))
 
-            if self.countries:
-                sql = sql.where(t.c.country_code.in_(self.countries.values))
+        if details.excluded:
+            sql = sql.where(base.exclude_places(t))
 
-            if details.excluded:
-                sql = sql.where(base.exclude_places(t))
-
-            sql = sql.limit(LIMIT_PARAM)
-            rows.extend(await conn.execute(sql, bind_params))
+        rows = await conn.execute(sql.limit(LIMIT_PARAM), bind_params)
 
         results = nres.SearchResults()
         for row in rows:

--- a/src/nominatim_api/search/db_searches/poi_search.py
+++ b/src/nominatim_api/search/db_searches/poi_search.py
@@ -73,17 +73,18 @@ class PoiSearch(base.AbstractSearch):
 
             rows.extend(await conn.execute(sql, bind_params))
         else:
-            # use the categories column, backed by the ltree GiST index
+            # use the categories column, backed by the combined
+            # centroid/categories GiST index
             sql = base.select_placex(t)\
                       .add_columns(t.c.importance)\
                       .where(category_match)
 
             if details.viewbox is not None and details.bounded_viewbox:
-                sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
+                sql = sql.where(t.c.centroid.intersects(VIEWBOX_PARAM))
 
             if details.near and details.near_radius is not None:
                 sql = sql.order_by(t.c.centroid.ST_Distance(NEAR_PARAM))\
-                         .where(t.c.geometry.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM))
+                         .where(t.c.centroid.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM))
 
             if self.countries:
                 sql = sql.where(t.c.country_code.in_(self.countries.values))

--- a/src/nominatim_api/search/db_searches/poi_search.py
+++ b/src/nominatim_api/search/db_searches/poi_search.py
@@ -7,14 +7,12 @@
 """
 Implementation of category search.
 """
-from typing import List
-
 import sqlalchemy as sa
 
 from . import base
 from ..db_search_fields import SearchData
 from ... import results as nres
-from ...typing import SaBind, SaRow, SaSelect, SaLambdaSelect
+from ...typing import SaBind, SaRow, SaSelect
 from ...sql.sqlalchemy_types import Geometry
 from ...connection import SearchConnection
 from ...types import SearchDetails, Bbox
@@ -48,7 +46,10 @@ class PoiSearch(base.AbstractSearch):
 
         t = conn.t.placex
 
-        rows: List[SaRow] = []
+        # Rows tagged with the category they were matched on. A placex row may
+        # carry several categories, so the matched one is not necessarily its
+        # class/type and must be tracked explicitly.
+        rows: list[tuple[SaRow, tuple[str, str]]] = []
 
         if details.near and details.near_radius is not None and details.near_radius < 0.2:
             # simply search in placex table
@@ -61,58 +62,48 @@ class PoiSearch(base.AbstractSearch):
                            .order_by(t.c.centroid.ST_Distance(NEAR_PARAM)) \
                            .limit(LIMIT_PARAM)
 
-            classtype = self.qualifiers.values
-            if len(classtype) == 1:
-                cclass, ctype = classtype[0]
-                sql: SaLambdaSelect = sa.lambda_stmt(
-                    lambda: _base_query().where(t.c.class_ == cclass)
-                                         .where(t.c.type == ctype))
-            else:
-                sql = _base_query().where(sa.or_(*(sa.and_(t.c.class_ == cls, t.c.type == typ)
-                                                   for cls, typ in classtype)))
-
-            if self.countries:
-                sql = sql.where(t.c.country_code.in_(self.countries.values))
-
-            if details.viewbox is not None and details.bounded_viewbox:
-                sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
-
-            if details.excluded:
-                sql = sql.where(base.exclude_places(t))
-
-            rows.extend(await conn.execute(sql, bind_params))
-        else:
-            # use the class type tables
             for category in self.qualifiers.values:
-                table = await conn.get_class_table(*category)
-                if table is not None:
-                    sql = base.select_placex(t)\
-                               .add_columns(t.c.importance)\
-                               .join(table, t.c.place_id == table.c.place_id)\
-                               .where(t.c.class_ == category[0])\
-                               .where(t.c.type == category[1])
+                sql = _base_query().where(base.category_filter(t, *category))
 
-                    if details.viewbox is not None and details.bounded_viewbox:
-                        sql = sql.where(table.c.centroid.intersects(VIEWBOX_PARAM))
+                if self.countries:
+                    sql = sql.where(t.c.country_code.in_(self.countries.values))
 
-                    if details.near and details.near_radius is not None:
-                        sql = sql.order_by(table.c.centroid.ST_Distance(NEAR_PARAM))\
-                                 .where(table.c.centroid.within_distance(NEAR_PARAM,
-                                                                         NEAR_RADIUS_PARAM))
+                if details.viewbox is not None and details.bounded_viewbox:
+                    sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
 
-                    if self.countries:
-                        sql = sql.where(t.c.country_code.in_(self.countries.values))
+                if details.excluded:
+                    sql = sql.where(base.exclude_places(t))
 
-                    if details.excluded:
-                        sql = sql.where(base.exclude_places(t))
+                rows.extend((r, category) for r in await conn.execute(sql, bind_params))
+        else:
+            # use the categories column, backed by the ltree GiST index
+            for category in self.qualifiers.values:
+                sql = base.select_placex(t)\
+                           .add_columns(t.c.importance)\
+                           .where(base.category_filter(t, *category))
 
-                    sql = sql.limit(LIMIT_PARAM)
-                    rows.extend(await conn.execute(sql, bind_params))
+                if details.viewbox is not None and details.bounded_viewbox:
+                    sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
+
+                if details.near and details.near_radius is not None:
+                    sql = sql.order_by(t.c.centroid.ST_Distance(NEAR_PARAM))\
+                             .where(t.c.geometry.within_distance(NEAR_PARAM,
+                                                                 NEAR_RADIUS_PARAM))
+
+                if self.countries:
+                    sql = sql.where(t.c.country_code.in_(self.countries.values))
+
+                if details.excluded:
+                    sql = sql.where(base.exclude_places(t))
+
+                sql = sql.limit(LIMIT_PARAM)
+                rows.extend((r, category) for r in await conn.execute(sql, bind_params))
 
         results = nres.SearchResults()
-        for row in rows:
+        for row, category in rows:
             result = nres.create_from_placex_row(row, nres.SearchResult)
-            result.accuracy = self.penalty + self.qualifiers.get_penalty((row.class_, row.type))
+            result.category = category
+            result.accuracy = self.penalty + self.qualifiers.get_penalty(category)
             result.bbox = Bbox.from_wkb(row.bbox)
             results.append(result)
 

--- a/src/nominatim_api/search/db_searches/poi_search.py
+++ b/src/nominatim_api/search/db_searches/poi_search.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from . import base
 from ..db_search_fields import SearchData
 from ... import results as nres
-from ...typing import SaBind, SaRow, SaSelect
+from ...typing import SaBind, SaRow
 from ...sql.sqlalchemy_types import Geometry
 from ...connection import SearchConnection
 from ...types import SearchDetails, Bbox
@@ -46,64 +46,58 @@ class PoiSearch(base.AbstractSearch):
 
         t = conn.t.placex
 
-        # Rows tagged with the category they were matched on. A placex row may
-        # carry several categories, so the matched one is not necessarily its
-        # class/type and must be tracked explicitly.
-        rows: list[tuple[SaRow, tuple[str, str]]] = []
+        rows: list[SaRow] = []
+
+        category_match = sa.or_(*(base.category_filter(t, *category)
+                                  for category in self.qualifiers.values))
 
         if details.near and details.near_radius is not None and details.near_radius < 0.2:
             # simply search in placex table
-            def _base_query() -> SaSelect:
-                return base.select_placex(t) \
-                           .add_columns((-t.c.centroid.ST_Distance(NEAR_PARAM))
-                                        .label('importance'))\
-                           .where(t.c.linked_place_id == None) \
-                           .where(t.c.geometry.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM)) \
-                           .order_by(t.c.centroid.ST_Distance(NEAR_PARAM)) \
-                           .limit(LIMIT_PARAM)
+            sql = base.select_placex(t) \
+                      .add_columns((-t.c.centroid.ST_Distance(NEAR_PARAM))
+                                   .label('importance'))\
+                      .where(t.c.linked_place_id == None) \
+                      .where(t.c.geometry.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM)) \
+                      .where(category_match) \
+                      .order_by(t.c.centroid.ST_Distance(NEAR_PARAM)) \
+                      .limit(LIMIT_PARAM)
 
-            for category in self.qualifiers.values:
-                sql = _base_query().where(base.category_filter(t, *category))
+            if self.countries:
+                sql = sql.where(t.c.country_code.in_(self.countries.values))
 
-                if self.countries:
-                    sql = sql.where(t.c.country_code.in_(self.countries.values))
+            if details.viewbox is not None and details.bounded_viewbox:
+                sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
 
-                if details.viewbox is not None and details.bounded_viewbox:
-                    sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
+            if details.excluded:
+                sql = sql.where(base.exclude_places(t))
 
-                if details.excluded:
-                    sql = sql.where(base.exclude_places(t))
-
-                rows.extend((r, category) for r in await conn.execute(sql, bind_params))
+            rows.extend(await conn.execute(sql, bind_params))
         else:
             # use the categories column, backed by the ltree GiST index
-            for category in self.qualifiers.values:
-                sql = base.select_placex(t)\
-                           .add_columns(t.c.importance)\
-                           .where(base.category_filter(t, *category))
+            sql = base.select_placex(t)\
+                      .add_columns(t.c.importance)\
+                      .where(category_match)
 
-                if details.viewbox is not None and details.bounded_viewbox:
-                    sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
+            if details.viewbox is not None and details.bounded_viewbox:
+                sql = sql.where(t.c.geometry.intersects(VIEWBOX_PARAM))
 
-                if details.near and details.near_radius is not None:
-                    sql = sql.order_by(t.c.centroid.ST_Distance(NEAR_PARAM))\
-                             .where(t.c.geometry.within_distance(NEAR_PARAM,
-                                                                 NEAR_RADIUS_PARAM))
+            if details.near and details.near_radius is not None:
+                sql = sql.order_by(t.c.centroid.ST_Distance(NEAR_PARAM))\
+                         .where(t.c.geometry.within_distance(NEAR_PARAM, NEAR_RADIUS_PARAM))
 
-                if self.countries:
-                    sql = sql.where(t.c.country_code.in_(self.countries.values))
+            if self.countries:
+                sql = sql.where(t.c.country_code.in_(self.countries.values))
 
-                if details.excluded:
-                    sql = sql.where(base.exclude_places(t))
+            if details.excluded:
+                sql = sql.where(base.exclude_places(t))
 
-                sql = sql.limit(LIMIT_PARAM)
-                rows.extend((r, category) for r in await conn.execute(sql, bind_params))
+            sql = sql.limit(LIMIT_PARAM)
+            rows.extend(await conn.execute(sql, bind_params))
 
         results = nres.SearchResults()
-        for row, category in rows:
+        for row in rows:
             result = nres.create_from_placex_row(row, nres.SearchResult)
-            result.category = category
-            result.accuracy = self.penalty + self.qualifiers.get_penalty(category)
+            result.accuracy = self.penalty + self.qualifiers.get_penalty((row.class_, row.type))
             result.bbox = Bbox.from_wkb(row.bbox)
             results.append(result)
 

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -23,6 +23,7 @@ from ..logging import log
 from . import query as qmod
 from .query_analyzer_factory import AbstractQueryAnalyzer
 from .postcode_parser import PostcodeParser
+from .db_searches.base import is_ltree_category
 
 
 DB_TO_TOKEN_TYPE = {
@@ -169,6 +170,8 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                 # (See rerank_tokens() below.)
                 token = ICUToken.from_db_row(row)
                 if row.type == 'S':
+                    if not is_ltree_category(token.get_category()[0]):
+                        continue
                     if row.info['op'] in ('in', 'near'):
                         if trange.start == 0:
                             query.add_token(trange, qmod.TOKEN_NEAR_ITEM, token)

--- a/src/nominatim_api/sql/sqlalchemy_functions.py
+++ b/src/nominatim_api/sql/sqlalchemy_functions.py
@@ -13,7 +13,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
 
-from ..typing import SaColumn
+from ..typing import SaColumn, SaFromClause
 
 
 class PlacexGeometryReverseLookuppolygon(sa.sql.functions.GenericFunction[Any]):
@@ -220,3 +220,37 @@ def sqlite_regexp_nocase(element: RegexpWord, compiler: 'sa.Compiled', **kw: Any
     arg1, arg2 = list(element.clauses)
     return "regexp('\\b(' || %s  || ')\\b', %s)"\
         % (compiler.process(arg1, **kw), compiler.process(arg2, **kw))
+
+
+class CategoryMatch(sa.sql.functions.GenericFunction[Any]):
+    """ Match a placex row against a single (class, type) category.
+
+        On PostgreSQL this queries the ltree 'categories' column using the
+        GiST index (``categories <@ 'osm.<class>.<type>'``). On SQLite, which
+        has no ltree support, it matches on the class/type columns instead.
+    """
+    name = 'CategoryMatch'
+    inherit_cache = True
+
+    def __init__(self, table: SaFromClause, ltree: str, cls: str, typ: str) -> None:
+        super().__init__(table.c.categories, sa.literal(ltree),
+                         table.c.class_, sa.literal(cls),
+                         table.c.type, sa.literal(typ))
+
+
+@compiles(CategoryMatch)
+def _default_category_match(element: CategoryMatch,
+                            compiler: 'sa.Compiled', **kw: Any) -> str:
+    cats, ltree, _, _, _, _ = list(element.clauses)
+    return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
+                                    compiler.process(ltree, **kw))
+
+
+@compiles(CategoryMatch, 'sqlite')
+def _sqlite_category_match(element: CategoryMatch,
+                           compiler: 'sa.Compiled', **kw: Any) -> str:
+    _, _, cls_col, cls_lit, typ_col, typ_lit = list(element.clauses)
+    return "(%s = %s AND %s = %s)" % (compiler.process(cls_col, **kw),
+                                      compiler.process(cls_lit, **kw),
+                                      compiler.process(typ_col, **kw),
+                                      compiler.process(typ_lit, **kw))

--- a/src/nominatim_api/sql/sqlalchemy_schema.py
+++ b/src/nominatim_api/sql/sqlalchemy_schema.py
@@ -9,7 +9,7 @@ SQLAlchemy definitions for all tables used by the frontend.
 """
 import sqlalchemy as sa
 
-from .sqlalchemy_types import Geometry, KeyValueStore, IntArray
+from .sqlalchemy_types import Geometry, KeyValueStore, IntArray, CategoryArray
 
 
 class SearchTables:
@@ -47,6 +47,7 @@ class SearchTables:
             sa.Column('osm_id', sa.BigInteger, nullable=False),
             sa.Column('class', sa.Text, nullable=False, key='class_'),
             sa.Column('type', sa.Text, nullable=False),
+            sa.Column('categories', CategoryArray),
             sa.Column('admin_level', sa.SmallInteger),
             sa.Column('name', KeyValueStore),
             sa.Column('address', KeyValueStore),

--- a/src/nominatim_api/sql/sqlalchemy_types/__init__.py
+++ b/src/nominatim_api/sql/sqlalchemy_types/__init__.py
@@ -10,5 +10,6 @@ Module with custom types for SQLAlchemy
 
 from .geometry import (Geometry as Geometry)
 from .int_array import (IntArray as IntArray)
+from .ltree import (CategoryArray as CategoryArray)
 from .key_value import (KeyValueStore as KeyValueStore)
 from .json import (Json as Json)

--- a/src/nominatim_api/sql/sqlalchemy_types/ltree.py
+++ b/src/nominatim_api/sql/sqlalchemy_types/ltree.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Custom type for the ltree[] categories column.
+"""
+from typing import Any, Callable, Optional
+
+import sqlalchemy as sa
+from sqlalchemy.ext.compiler import compiles
+
+from ...typing import SaColumn
+
+
+class CategoryArray(sa.types.UserDefinedType):  # type: ignore[type-arg]
+    """ Array of ltree categories (``osm.<class>.<type>``). Maps to a native
+        ``ltree[]`` column on PostgreSQL and to comma-separated text on other
+        dialects (SQLite), where the categories column is not queried.
+    """
+    cache_ok = True
+
+    def get_col_spec(self, **_: Any) -> str:
+        return 'ltree[]'
+
+    def bind_processor(self, dialect: 'sa.Dialect') -> Optional[Callable[[Any], Any]]:
+        if dialect.name == 'postgresql':
+            return None
+
+        def process(value: Any) -> Optional[str]:
+            return ','.join(value) if value is not None else None
+        return process
+
+    def result_processor(self, dialect: 'sa.Dialect',
+                         coltype: object) -> Optional[Callable[[Any], Any]]:
+        if dialect.name == 'postgresql':
+            return None
+
+        def process(value: Any) -> Optional[list[str]]:
+            return value.split(',') if value else None
+        return process
+
+    def bind_expression(self, bindvalue: SaColumn) -> SaColumn:
+        return _LtreeArrayCast(bindvalue)
+
+
+class _LtreeArrayCast(sa.sql.expression.FunctionElement[Any]):
+    """ Cast a bound text array to ``ltree[]`` on PostgreSQL. A no-op on
+        other dialects, where categories are stored as plain text.
+    """
+    inherit_cache = True
+
+
+@compiles(_LtreeArrayCast)
+def _default_ltree_array_cast(element: _LtreeArrayCast,
+                              compiler: 'sa.Compiled', **kw: Any) -> str:
+    return "%s::ltree[]" % compiler.process(element.clauses, **kw)
+
+
+@compiles(_LtreeArrayCast, 'sqlite')
+def _sqlite_ltree_array_cast(element: _LtreeArrayCast,
+                             compiler: 'sa.Compiled', **kw: Any) -> str:
+    return compiler.process(element.clauses, **kw)
+
+
+@compiles(CategoryArray, 'sqlite')
+def _sqlite_category_col_spec(*args: Any, **kwargs: Any) -> str:
+    return 'TEXT'

--- a/src/nominatim_db/tools/convert_sqlite.py
+++ b/src/nominatim_db/tools/convert_sqlite.py
@@ -181,6 +181,7 @@ class SqliteWriter:
 
         if 'search' in self.options:
             await self.create_spatial_index('postcode', 'geometry')
+            await self.create_spatial_index('placex', 'centroid')
             await self.create_spatial_index('search_name', 'centroid')
             await self.create_index('search_name', 'place_id')
             await self.create_index('osmline', 'parent_place_id')

--- a/src/nominatim_db/tools/convert_sqlite.py
+++ b/src/nominatim_db/tools/convert_sqlite.py
@@ -185,6 +185,8 @@ class SqliteWriter:
             await self.create_index('search_name', 'place_id')
             await self.create_index('osmline', 'parent_place_id')
             await self.create_index('tiger', 'parent_place_id')
+            # SQLite has no ltree, so category search matches on class/type.
+            await self.create_index('placex', 'class_', 'type')
             await self.create_search_index()
 
             for t in self.dest.t.meta.tables:
@@ -198,12 +200,13 @@ class SqliteWriter:
         await self.dest.execute(sa.select(
                   sa.func.CreateSpatialIndex(getattr(self.dest.t, table).name, column)))
 
-    async def create_index(self, table_name: str, column: str) -> None:
-        """ Create a simple index on the given table and column.
+    async def create_index(self, table_name: str, *columns: str) -> None:
+        """ Create a simple index on the given table and columns.
         """
         table = getattr(self.dest.t, table_name)
+        cols = [getattr(table.c, column) for column in columns]
         await self.dest.connection.run_sync(
-            sa.Index(f"idx_{table}_{column}", getattr(table.c, column)).create)
+            sa.Index(f"idx_{table}_{'_'.join(c.name for c in cols)}", *cols).create)
 
     async def create_search_index(self) -> None:
         """ Create the tables and indexes needed for word lookup.

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -606,6 +606,47 @@ def backfill_categories(conn: Connection, **_: Any) -> None:
 
 
 @_migration(5, 3, 99, 3)
+def backfill_poi_categories(conn: Connection, **_: Any) -> None:
+    """ Backfill the categories column for POIs.
+
+    The earlier backfill only filled the rank_address < 26 rows that place
+    linking needs. Category search reads the column for POIs as well, so fill
+    in the rows that are still empty. Only the class/type category can be
+    derived from placex, the same one the lazy backfill in placex_update adds;
+    categories from secondary tags need a reimport.
+
+    Runs before the index is created, so that the update does not have to
+    maintain it.
+    """
+    if not table_exists(conn, 'placex') or not table_has_column(conn, 'placex', 'categories'):
+        return
+
+    conn.execute("ALTER TABLE placex DISABLE TRIGGER ALL")
+    conn.execute("""
+        UPDATE placex
+        SET categories = ARRAY[(
+                 'osm.'
+                 || CASE
+                      WHEN placex.class !~ '^[A-Za-z0-9_-]+$'
+                        THEN 'place'
+                      ELSE replace(placex.class, '-', '_')
+                    END
+                 || '.'
+                 || CASE
+                      WHEN placex.type IS NULL OR placex.type = ''
+                           OR placex.type !~ '^[A-Za-z0-9_-]+$'
+                        THEN 'yes'
+                      ELSE replace(placex.type, '-', '_')
+                    END
+               )::ltree]
+        WHERE categories IS NULL
+    """)
+    conn.execute("ALTER TABLE placex ENABLE TRIGGER ALL")
+
+    conn.execute("ANALYZE placex")
+
+
+@_migration(5, 3, 99, 3)
 def add_centroid_categories_index(conn: Connection, **_: Any) -> None:
     """ Add the combined centroid/categories index used by category search.
 

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -611,9 +611,12 @@ def backfill_poi_categories(conn: Connection, **_: Any) -> None:
 
     The earlier backfill only filled the rank_address < 26 rows that place
     linking needs. Category search reads the column for POIs as well, so fill
-    in the rows that are still empty. Only the class/type category can be
-    derived from placex, the same one the lazy backfill in placex_update adds;
-    categories from secondary tags need a reimport.
+    in the rows that are still empty.
+
+    Restricted to the class/type combinations that have a place_classtype_*
+    table, because those are exactly the ones that can be found through a
+    special phrase. That keeps the update off the vast majority of the table
+    and skips it altogether when there are no such tables.
 
     Runs before the index is created, so that the update does not have to
     maintain it.
@@ -621,26 +624,53 @@ def backfill_poi_categories(conn: Connection, **_: Any) -> None:
     if not table_exists(conn, 'placex') or not table_has_column(conn, 'placex', 'categories'):
         return
 
+    with conn.cursor() as cur:
+        cur.execute("""SELECT tablename FROM pg_tables
+                       WHERE schemaname = 'public'
+                             AND tablename LIKE 'place\\_classtype\\_%'""")
+        classtype_tables = [row[0] for row in cur]
+
+    if not classtype_tables:
+        return
+
     conn.execute("ALTER TABLE placex DISABLE TRIGGER ALL")
     conn.execute("""
         UPDATE placex
-        SET categories = ARRAY[(
-                 'osm.'
-                 || CASE
-                      WHEN placex.class !~ '^[A-Za-z0-9_-]+$'
-                        THEN 'place'
-                      ELSE replace(placex.class, '-', '_')
-                    END
-                 || '.'
-                 || CASE
-                      WHEN placex.type IS NULL OR placex.type = ''
-                           OR placex.type !~ '^[A-Za-z0-9_-]+$'
-                        THEN 'yes'
-                      ELSE replace(placex.type, '-', '_')
-                    END
-               )::ltree]
+        SET categories = (
+          SELECT array_agg(DISTINCT cat)
+          FROM (
+            SELECT (
+                     'osm.'
+                     || CASE
+                          WHEN placex.class !~ '^[A-Za-z0-9_-]+$'
+                            THEN 'place'
+                          ELSE replace(placex.class, '-', '_')
+                        END
+                     || '.'
+                     || CASE
+                          WHEN placex.type IS NULL OR placex.type = ''
+                               OR placex.type !~ '^[A-Za-z0-9_-]+$'
+                            THEN 'yes'
+                          ELSE replace(placex.type, '-', '_')
+                        END
+                   )::ltree AS cat
+            WHERE placex.class != ''
+            UNION
+            SELECT (
+                     'osm.place.'
+                     || CASE
+                          WHEN placex.extratags->'place' IS NULL OR placex.extratags->'place' = ''
+                               OR placex.extratags->'place' !~ '^[A-Za-z0-9_-]+$'
+                            THEN 'yes'
+                          ELSE replace(placex.extratags->'place', '-', '_')
+                        END
+                   )::ltree AS cat
+            WHERE placex.extratags ? 'place'
+          ) sub
+        )
         WHERE categories IS NULL
-    """)
+          AND 'place_classtype_' || placex.class || '_' || placex.type = ANY(%s)
+    """, (classtype_tables,))
     conn.execute("ALTER TABLE placex ENABLE TRIGGER ALL")
 
     conn.execute("ANALYZE placex")

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -586,11 +586,6 @@ def backfill_categories(conn: Connection, **_: Any) -> None:
     """)
     conn.execute("ALTER TABLE placex ENABLE TRIGGER ALL")
 
-    if table_exists(conn, 'search_name'):
-        conn.execute("""CREATE INDEX IF NOT EXISTS idx_placex_categories
-                        ON placex USING GIST (categories gist__ltree_ops)
-                        WHERE categories IS NOT NULL""")
-
     with conn.cursor() as cur:
         cur.execute("""CREATE INDEX IF NOT EXISTS idx_placex_geometry_placenode_categories
                        ON placex USING SPGIST (geometry)
@@ -608,3 +603,19 @@ def backfill_categories(conn: Connection, **_: Any) -> None:
                              AND indexed_status > 0""")
 
     conn.execute("ANALYZE placex")
+
+
+@_migration(5, 3, 99, 3)
+def add_centroid_categories_index(conn: Connection, **_: Any) -> None:
+    """ Add the combined centroid/categories index used by category search.
+
+    The index is not partial, so that it can also serve queries on the
+    centroid alone. A partial index cannot be used for those.
+    """
+    if not table_exists(conn, 'placex') or not table_has_column(conn, 'placex', 'categories'):
+        return
+
+    if table_exists(conn, 'search_name'):
+        conn.execute("""CREATE INDEX IF NOT EXISTS idx_placex_centroid_categories
+                        ON placex USING GIST (centroid,
+                                              categories gist__ltree_ops(siglen=8))""")

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -612,10 +612,15 @@ def add_centroid_categories_index(conn: Connection, **_: Any) -> None:
     The index is not partial, so that it can also serve queries on the
     centroid alone. A partial index cannot be used for those. It is created
     for all databases because reverse queries need it as well.
+
+    It replaces idx_placex_categories, which the earlier migration does not
+    create anymore. Drop that index first, if it is still around, so that the
+    two are never on disk at the same time.
     """
     if not table_exists(conn, 'placex') or not table_has_column(conn, 'placex', 'categories'):
         return
 
+    conn.execute("DROP INDEX IF EXISTS idx_placex_categories")
     conn.execute("""CREATE INDEX IF NOT EXISTS idx_placex_centroid_categories
                     ON placex USING GIST (centroid,
                                           categories gist__ltree_ops(siglen=8))""")

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -618,6 +618,10 @@ def backfill_poi_categories(conn: Connection, **_: Any) -> None:
     special phrase. That keeps the update off the vast majority of the table
     and skips it altogether when there are no such tables.
 
+    Only tables whose name is made up of valid ltree label characters are
+    considered, so that the class and type of the rows to update are known to
+    be usable as labels as they are.
+
     Runs before the index is created, so that the update does not have to
     maintain it.
     """
@@ -627,7 +631,7 @@ def backfill_poi_categories(conn: Connection, **_: Any) -> None:
     with conn.cursor() as cur:
         cur.execute("""SELECT tablename FROM pg_tables
                        WHERE schemaname = 'public'
-                             AND tablename LIKE 'place\\_classtype\\_%'""")
+                             AND tablename ~ '^place_classtype_[A-Za-z0-9_]+$'""")
         classtype_tables = [row[0] for row in cur]
 
     if not classtype_tables:
@@ -639,22 +643,7 @@ def backfill_poi_categories(conn: Connection, **_: Any) -> None:
         SET categories = (
           SELECT array_agg(DISTINCT cat)
           FROM (
-            SELECT (
-                     'osm.'
-                     || CASE
-                          WHEN placex.class !~ '^[A-Za-z0-9_-]+$'
-                            THEN 'place'
-                          ELSE replace(placex.class, '-', '_')
-                        END
-                     || '.'
-                     || CASE
-                          WHEN placex.type IS NULL OR placex.type = ''
-                               OR placex.type !~ '^[A-Za-z0-9_-]+$'
-                            THEN 'yes'
-                          ELSE replace(placex.type, '-', '_')
-                        END
-                   )::ltree AS cat
-            WHERE placex.class != ''
+            SELECT ('osm.' || placex.class || '.' || placex.type)::ltree AS cat
             UNION
             SELECT (
                      'osm.place.'

--- a/src/nominatim_db/tools/migration.py
+++ b/src/nominatim_db/tools/migration.py
@@ -610,12 +610,12 @@ def add_centroid_categories_index(conn: Connection, **_: Any) -> None:
     """ Add the combined centroid/categories index used by category search.
 
     The index is not partial, so that it can also serve queries on the
-    centroid alone. A partial index cannot be used for those.
+    centroid alone. A partial index cannot be used for those. It is created
+    for all databases because reverse queries need it as well.
     """
     if not table_exists(conn, 'placex') or not table_has_column(conn, 'placex', 'categories'):
         return
 
-    if table_exists(conn, 'search_name'):
-        conn.execute("""CREATE INDEX IF NOT EXISTS idx_placex_centroid_categories
-                        ON placex USING GIST (centroid,
-                                              categories gist__ltree_ops(siglen=8))""")
+    conn.execute("""CREATE INDEX IF NOT EXISTS idx_placex_centroid_categories
+                    ON placex USING GIST (centroid,
+                                          categories gist__ltree_ops(siglen=8))""")

--- a/src/nominatim_db/version.py
+++ b/src/nominatim_db/version.py
@@ -55,7 +55,7 @@ def parse_version(version: str) -> NominatimVersion:
     return NominatimVersion(*[int(x) for x in parts[:2] + parts[2].split('-')])
 
 
-NOMINATIM_VERSION = parse_version('5.3.99-2')
+NOMINATIM_VERSION = parse_version('5.3.99-3')
 
 POSTGRESQL_REQUIRED_VERSION = (13, 0)
 POSTGIS_REQUIRED_VERSION = (3, 0)

--- a/test/bdd/features/api/search/queries.feature
+++ b/test/bdd/features/api/search/queries.feature
@@ -93,15 +93,12 @@ Feature: Search queries
           | category | type       | address+country |
           | amenity  | restaurant | Liechtenstein |
 
-    @skip
-    # FIXME: the matched placex row carries several categories (club=scout and
-    # amenity=...); result.category reports its main class/type (amenity), so the
-    # searched category is not surfaced. Needs a decision on how to report it.
     Scenario: Search with key-value amenity
         When geocoding "[club=scout] Vaduz"
-        Then all results contain
-          | category | type |
-          | club     | scout |
+        Then the result set contains
+          | object     |
+          | W351713277 |
+          | W408844120 |
 
     Scenario: POI search near given coordinate
         When geocoding "restaurant near 47.16712,9.51100"

--- a/test/bdd/features/api/search/queries.feature
+++ b/test/bdd/features/api/search/queries.feature
@@ -93,8 +93,6 @@ Feature: Search queries
           | category | type       | address+country |
           | amenity  | restaurant | Liechtenstein |
 
-    @skip
-    # FIXME: near_search.py must query categories column instead of class/type.
     Scenario: Search with key-value amenity
         When geocoding "[club=scout] Vaduz"
         Then all results contain

--- a/test/bdd/features/api/search/queries.feature
+++ b/test/bdd/features/api/search/queries.feature
@@ -93,6 +93,10 @@ Feature: Search queries
           | category | type       | address+country |
           | amenity  | restaurant | Liechtenstein |
 
+    @skip
+    # FIXME: the matched placex row carries several categories (club=scout and
+    # amenity=...); result.category reports its main class/type (amenity), so the
+    # searched category is not surfaced. Needs a decision on how to report it.
     Scenario: Search with key-value amenity
         When geocoding "[club=scout] Vaduz"
         Then all results contain

--- a/test/python/api/conftest.py
+++ b/test/python/api/conftest.py
@@ -53,7 +53,7 @@ class APITester:
                        'osm_id': kw.get('osm_id', 4),
                        'class_': kw.get('class_', 'highway'),
                        'type': kw.get('type', 'residential'),
-                       'categories': kw.get('categories', [cat] if cat else None),
+                       'categories': kw.get('categories', [cat]),
                        'name': name,
                        'address': kw.get('address'),
                        'extratags': kw.get('extratags'),

--- a/test/python/api/conftest.py
+++ b/test/python/api/conftest.py
@@ -11,11 +11,10 @@ import pytest
 import pytest_asyncio
 import datetime as dt
 
-import sqlalchemy as sa
-
 import nominatim_api as napi
 from nominatim_db.db.sql_preprocessor import SQLPreprocessor
 from nominatim_api.search.query_analyzer_factory import make_query_analyzer
+from nominatim_api.search.db_searches.base import category_ltree
 from nominatim_db.tools import convert_sqlite
 import nominatim_api.logging as loglib
 
@@ -46,12 +45,15 @@ class APITester:
         centroid = kw.get('centroid', (23.0, 34.0))
         geometry = kw.get('geometry', 'POINT(%f %f)' % centroid)
 
+        cat = category_ltree(kw.get('class_', 'highway'), kw.get('type', 'residential'))
+
         self.add_data('placex',
                       {'place_id': kw.get('place_id', 1000),
                        'osm_type': kw.get('osm_type', 'W'),
                        'osm_id': kw.get('osm_id', 4),
                        'class_': kw.get('class_', 'highway'),
                        'type': kw.get('type', 'residential'),
+                       'categories': kw.get('categories', [cat] if cat else None),
                        'name': name,
                        'address': kw.get('address'),
                        'extratags': kw.get('extratags'),
@@ -145,13 +147,6 @@ class APITester:
                        'nameaddress_vector': kw.get('address', []),
                        'country_code': kw.get('country_code', 'xx'),
                        'centroid': 'POINT(%f %f)' % centroid})
-
-    def add_class_type_table(self, cls, typ):
-        self.async_to_sync(
-            self.exec_async(sa.text(f"""CREATE TABLE place_classtype_{cls}_{typ}
-                                         AS (SELECT place_id, centroid FROM placex
-                                             WHERE class = '{cls}' AND type = '{typ}')
-                                     """)))
 
     def add_word_table(self, content):
         data = [dict(zip(['word_id', 'word_token', 'type', 'word', 'info'], c))

--- a/test/python/api/search/test_icu_query_analyzer.py
+++ b/test/python/api/search/test_icu_query_analyzer.py
@@ -128,7 +128,7 @@ async def test_penalty_postcodes_and_housenumbers(conn, term, order):
 async def test_category_words_only_at_beginning(conn):
     ana = await tok.create_query_analyzer(conn)
 
-    await add_word(conn, 1, 'foo', 'S', 'FOO', {'op': 'in'})
+    await add_word(conn, 1, 'foo', 'S', 'FOO', {'op': 'in', 'class': 'amenity', 'type': 'bar'})
     await add_word(conn, 2, 'bar', 'w', 'BAR')
 
     query = await ana.analyze_query(make_phrase('foo BAR foo'))
@@ -143,7 +143,7 @@ async def test_category_words_only_at_beginning(conn):
 async def test_freestanding_qualifier_words_become_category(conn):
     ana = await tok.create_query_analyzer(conn)
 
-    await add_word(conn, 1, 'foo', 'S', 'FOO', {'op': '-'})
+    await add_word(conn, 1, 'foo', 'S', 'FOO', {'op': '-', 'class': 'amenity', 'type': 'bar'})
 
     query = await ana.analyze_query(make_phrase('foo'))
 
@@ -156,7 +156,7 @@ async def test_freestanding_qualifier_words_become_category(conn):
 async def test_qualifier_words(conn):
     ana = await tok.create_query_analyzer(conn)
 
-    await add_word(conn, 1, 'foo', 'S', None, {'op': '-'})
+    await add_word(conn, 1, 'foo', 'S', None, {'op': '-', 'class': 'amenity', 'type': 'bar'})
     await add_word(conn, 2, 'bar', 'w', None)
 
     query = await ana.analyze_query(make_phrase('foo BAR foo BAR foo'))

--- a/test/python/api/search/test_search_near.py
+++ b/test/python/api/search/test_search_near.py
@@ -103,13 +103,11 @@ class TestNearSearch:
 
         assert [r.place_id for r in results] == [22, 23]
 
-    def test_near_in_classtype(self, apiobj, frontend):
+    def test_near_larger_radius(self, apiobj, frontend):
         apiobj.add_placex(place_id=22, class_='amenity', type='bank',
                           centroid=(5.6, 4.34))
         apiobj.add_placex(place_id=23, class_='amenity', type='bench',
                           centroid=(5.6, 4.34))
-        apiobj.add_class_type_table('amenity', 'bank')
-        apiobj.add_class_type_table('amenity', 'bench')
 
         results = run_search(apiobj, frontend, 0.1, [('amenity', 'bank')])
 

--- a/test/python/api/search/test_search_poi.py
+++ b/test/python/api/search/test_search_poi.py
@@ -53,12 +53,11 @@ def test_simple_near_search_in_placex(apiobj, frontend, coord, pid):
 @pytest.mark.parametrize('coord,pid', [('34.3, 56.100021', 2),
                                        ('34.3, 56.4', 2),
                                        ('5.0, 4.59933', 1)])
-def test_simple_near_search_in_classtype(apiobj, frontend, coord, pid):
+def test_simple_near_search_large_radius(apiobj, frontend, coord, pid):
     apiobj.add_placex(place_id=1, class_='highway', type='bus_stop',
                       centroid=(5.0, 4.6))
     apiobj.add_placex(place_id=2, class_='highway', type='bus_stop',
                       centroid=(34.3, 56.1))
-    apiobj.add_class_type_table('highway', 'bus_stop')
 
     details = SearchDetails.from_kwargs({'near': coord, 'near_radius': 0.5})
 
@@ -69,7 +68,7 @@ def test_simple_near_search_in_classtype(apiobj, frontend, coord, pid):
 
 class TestPoiSearchWithRestrictions:
 
-    @pytest.fixture(autouse=True, params=["placex", "classtype"])
+    @pytest.fixture(autouse=True, params=["small_radius", "large_radius"])
     def fill_database(self, apiobj, request):
         apiobj.add_placex(place_id=1, class_='highway', type='bus_stop',
                           country_code='au',
@@ -77,8 +76,7 @@ class TestPoiSearchWithRestrictions:
         apiobj.add_placex(place_id=2, class_='highway', type='bus_stop',
                           country_code='nz',
                           centroid=(34.3, 56.1))
-        if request.param == 'classtype':
-            apiobj.add_class_type_table('highway', 'bus_stop')
+        if request.param == 'large_radius':
             self.args = {'near': '34.3, 56.4', 'near_radius': 0.5}
         else:
             self.args = {'near': '34.3, 56.100021', 'near_radius': 0.001}

--- a/test/python/api/search/test_search_poi.py
+++ b/test/python/api/search/test_search_poi.py
@@ -66,6 +66,22 @@ def test_simple_near_search_large_radius(apiobj, frontend, coord, pid):
     assert [r.place_id for r in results] == [pid]
 
 
+@pytest.mark.parametrize('args', [{'near': '34.3, 56.100021', 'near_radius': 0.001},
+                                  {'near': '34.3, 56.4', 'near_radius': 0.5},
+                                  {'bounded_viewbox': True,
+                                   'viewbox': '34.29,56.0,34.31,56.2'}])
+def test_linked_places_excluded(apiobj, frontend, args):
+    apiobj.add_placex(place_id=1, class_='highway', type='bus_stop',
+                      centroid=(34.3, 56.1))
+    apiobj.add_placex(place_id=2, class_='highway', type='bus_stop',
+                      linked_place_id=1, centroid=(34.3, 56.10003))
+
+    results = run_search(apiobj, frontend, 0.1, [('highway', 'bus_stop')], [0.5],
+                         details=SearchDetails.from_kwargs(args))
+
+    assert [r.place_id for r in results] == [1]
+
+
 class TestPoiSearchWithRestrictions:
 
     @pytest.fixture(autouse=True, params=["small_radius", "large_radius"])


### PR DESCRIPTION
## Summary
Follow-up to #4106. The search side no longer reads the obsolete `place_classtype_*` tables. `PoiSearch` and `NearSearch` now query the `placex.categories` ltree[] column via `categories <@ 'osm.<class>.<type>'`, backed by the `idx_placex_categories` GiST index.

The `place_classtype_*` tables and their generation code (special-phrase importer, sqlite export) are untouched here and will be removed in a separate PR .

- New `CategoryArray` SQLAlchemy type: native `ltree[]` on Pg, comma-separated text on SQLite.
- The lookup ltree is built with the same normalization as the Lua  importer (`sanitize_label`/`get_category`:  hyphen ------>underscore, invalid ----->`yes`).
- **SQLite has no ltree**, so `CategoryMatch` compiles to class/type equality there (columns still present and populated) (May change).
- **Merged rows:** an object tagged e.g. `club=scout` + `amenity=scout_hut`  is a single placex row whose class/type winner is `amenity`. The `<@` query matches it correctly, but the result must report the *searched* category, so both searches now set `result.category` explicitly. This fixes and un-skips the `[club=scout]` BDD scenario.

## AI usage
None

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
