### PR TITLE
Fix copy-paste bug in Geometry_IsAreaLike name and typos

### DIFF
--- a/src/nominatim_api/result_formatting.py
+++ b/src/nominatim_api/result_formatting.py
@@ -104,7 +104,7 @@ def load_format_dispatcher(api_name: str, project_dir: Optional[Path]) -> Format
     if project_dir is not None:
         priv_module = project_dir / 'api' / api_name / 'format.py'
         if priv_module.is_file():
-            spec = importlib.util.spec_from_file_location(f'api.{api_name},format',
+            spec = importlib.util.spec_from_file_location(f'api.{api_name}.format',
                                                           str(priv_module))
             if spec:
                 module = importlib.util.module_from_spec(spec)

--- a/src/nominatim_api/search/db_search_fields.py
+++ b/src/nominatim_api/search/db_search_fields.py
@@ -126,7 +126,7 @@ class WeightedCategories:
         return default
 
     def sql_restrict(self, table: SaFromClause) -> SaExpression:
-        """ Return an SQLAlcheny expression that restricts the
+        """ Return an SQLAlchemy expression that restricts the
             class and type columns of the given table to the values
             in the list.
             Must not be used with an empty list.
@@ -260,7 +260,7 @@ class SearchData:
             self.countries = WeightedStrings(list(countries.keys()), list(countries.values()))
 
     def set_qualifiers(self, tokens: List[Token]) -> None:
-        """ Set the qulaifier field from the given tokens.
+        """ Set the qualifier field from the given tokens.
         """
         if tokens:
             categories: Dict[Tuple[str, str], float] = {}

--- a/src/nominatim_api/sql/sqlalchemy_types/geometry.py
+++ b/src/nominatim_api/sql/sqlalchemy_types/geometry.py
@@ -63,7 +63,7 @@ def _sqlite_is_line_like(element: Geometry_IsLineLike,
 class Geometry_IsAreaLike(sa.sql.expression.FunctionElement[Any]):
     """ Check if the geometry is a polygon or multipolygon.
     """
-    name = 'Geometry_IsLineLike'
+    name = 'Geometry_IsAreaLike'
     inherit_cache = True
 
 


### PR DESCRIPTION
## Summary

Four small fixes across the codebase:

1. **`geometry.py`**: `Geometry_IsAreaLike` had `name = 'Geometry_IsLineLike'` — a copy-paste error from the class defined 21 lines above. Fixed to `'Geometry_IsAreaLike'`.

2. **`result_formatting.py`**: Module name f-string used a comma instead of a dot (`api.{api_name},format` → `api.{api_name}.format`). While `spec_from_file_location` primarily uses the file path, the incorrect name could cause subtle module identification issues.

3. **`db_search_fields.py`**: Two docstring typos fixed:
   - `SQLAlcheny` → `SQLAlchemy` (line 129)
   - `qulaifier` → `qualifier` (line 263)

## Testing

- Verified the `Geometry_IsAreaLike.name` attribute now matches its class name
- Verified the module name f-string now uses correct dot notation
- Verified both docstring typos are corrected