### PR TITLE
Add `clean_multilingual_names` Sanitizer

### DIFF
--- a/docs/customize/Sanitizers.md
+++ b/docs/customize/Sanitizers.md
@@ -46,6 +46,14 @@ To learn about how to add your own custom sanitizer, see the section on
         heading_level: 6
         docstring_section_style: spacy
 
+### clean-multilingual-names
+
+::: nominatim_db.tokenizer.sanitizers.clean_multilingual_names
+    options:
+        members: False
+        heading_level: 6
+        docstring_section_style: spacy
+
 ### clean-postcodes
 
 ::: nominatim_db.tokenizer.sanitizers.clean_postcodes

--- a/settings/sanitizers.yaml
+++ b/settings/sanitizers.yaml
@@ -25,6 +25,9 @@
   convert-to-address: yes
   default-pattern: "[A-Z0-9- ]{3,12}"
 - step: clean-tiger-tags
+- step: clean-multilingual-names
+  delimiters: ['/', '-', ' ']
+  filter-kind: ['name']
 - step: split-name-list
   delimiters: ;
 - step: affix-expansion

--- a/src/nominatim_db/tokenizer/sanitizers/clean_multilingual_names.py
+++ b/src/nominatim_db/tokenizer/sanitizers/clean_multilingual_names.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Sanitizer that removes name tags which are a simple concatenation of
+language-specific name tags.
+
+In areas where multiple languages are spoken, OSM often has a `name` tag
+which contains all language variants joined by a delimiter (e.g.
+``name=Rue du Marché aux Poulets - Kiekenmarkt``). These language variants
+also appear in separate tags like ``name:fr`` and ``name:nl``. The
+combined name is redundant and adds noise to the search index.
+
+This sanitizer detects when a bare ``name`` tag (i.e. one without a
+language suffix) consists entirely of a concatenation of names that are
+already present in language-specific name tags, and removes it. Exact
+duplicates are also considered redundant and removed, even when no
+concatenation is involved.
+
+Different delimiters used within a single name, i.e. ``Foo / Bar - Baz``
+is recognised as a concatenation as well. A trailing/leading delimiter is ignored, i.e.
+``- Foo - Bar - `` is still recognised.
+
+Arguments:
+    delimiters: A list of delimiter strings to try when checking if the
+                name is a concatenation.
+                (default: ``["/", "-", " "]``)
+
+    filter-kind: Define which 'kind' of names are considered for
+                 removal. Takes a string or list of strings where each
+                 string is a regular expression.
+                 (default: ``name``)
+"""
+import re
+from typing import Sequence
+
+from .base import ProcessInfo, SanitizerFunc
+from .config import SanitizerConfig
+
+
+def create(config: SanitizerConfig) -> SanitizerFunc:
+    """ Create a function to remove multilingual concatenated names.
+    """
+    delimiters: Sequence[str] = config.get_string_list('delimiters',
+                                                       ['/', '-', ' '])
+    filter_kind = config.get_filter('filter-kind', ['name'])
+
+    # Suffix having less than 4 letters before ending or being followed by a non-letter
+    # (eg. `name:en`, `name:fr-CA`, `name:zh-Hans`) is considered a valid language code.
+    illegal_lang_pattern = re.compile('(?:^[A-Za-z]{4,}.*)')
+
+    delim_alts = [r'\s*' + re.escape(d) + r'\s*' for d in delimiters]
+    delim_pattern = re.compile('(?:' + '|'.join(delim_alts) + ')')
+
+    def _is_concatenated(name_value: str, lang_names: set[str]) -> bool:
+        """ Check if name_value can be fully decomposed into values
+            from lang_names, optionally separated by delimiters.
+        """
+
+        lang_names_by_length = sorted(lang_names, key=len, reverse=True)
+        name_pattern = re.compile(
+            '(?:' + '|'.join(re.escape(n) for n in lang_names_by_length) + ')'
+        )
+
+        idx = 0
+        m = delim_pattern.match(name_value, idx)
+        if m:
+            idx = m.end()
+
+        while idx < len(name_value):
+            m = name_pattern.match(name_value, idx)
+            if not m:
+                return False
+            idx = m.end()
+
+            if idx < len(name_value):
+                m = delim_pattern.match(name_value, idx)
+                if not m:
+                    return False
+                idx = m.end()
+
+        return True
+
+    def _process(obj: ProcessInfo) -> None:
+        if not obj.names:
+            return
+
+        # Collect language-specific name values for each kind.
+        # A language-specific name has the same kind but a non-empty suffix.
+        lang_names_by_kind: dict[str, set[str]] = {}
+        for name in obj.names:
+            if name.suffix and not illegal_lang_pattern.match(name.suffix) \
+               and filter_kind(name.kind):
+                lang_names_by_kind.setdefault(name.kind, set()).add(name.name)
+
+        if not lang_names_by_kind:
+            return
+
+        obj.names = [name for name in obj.names
+                     if not (name.suffix is None
+                             and name.kind in lang_names_by_kind
+                             and _is_concatenated(name.name, lang_names_by_kind[name.kind]))]
+
+    return _process

--- a/test/python/tokenizer/sanitizers/test_clean_multilingual_names.py
+++ b/test/python/tokenizer/sanitizers/test_clean_multilingual_names.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of Nominatim. (https://nominatim.org)
+#
+# Copyright (C) 2026 by the Nominatim developer community.
+# For a full list of authors see the git log.
+"""
+Tests for the sanitizer that removes multilingual concatenated names.
+"""
+import pytest
+
+from nominatim_db.config import Configuration
+from nominatim_db.data.place_info import PlaceInfo
+from nominatim_db.tokenizer.place_sanitizer import PlaceSanitizer
+
+
+@pytest.fixture
+def run_sanitizer(def_config):
+    def _run(extra_args=None, **kwargs):
+        place = PlaceInfo({'name': {k.replace('_', ':'): v
+                                    for k, v in kwargs.items()},
+                           'country_code': 'be', 'rank_address': 26})
+
+        sanitizer_args = {'step': 'clean-multilingual-names'}
+        if extra_args:
+            sanitizer_args.update(extra_args)
+
+        PlaceSanitizer([sanitizer_args], def_config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix or '')
+                       for p in place.searchable_names])
+
+    return _run
+
+
+class TestDelimiter:
+    """ Test removal with some common delimiters used worlwide.
+    """
+
+    def test_hyphen_delimiter(self, run_sanitizer):
+        res = run_sanitizer(name='गढ़वा - Garhwa - گڑھوا',
+                            name_hi='गढ़वा',
+                            name_en='Garhwa',
+                            name_ur='گڑھوا')
+
+        assert ('गढ़वा - Garhwa - گڑھوا', 'name', '') not in res
+        assert ('गढ़वा', 'name', 'hi') in res
+        assert ('Garhwa', 'name', 'en') in res
+        assert ('گڑھوا', 'name', 'ur') in res
+
+    def test_slash_delimiter(self, run_sanitizer):
+        res = run_sanitizer(name='Rue de la Gare / Stationsstraat/Bahnhofstraße',
+                            name_fr='Rue de la Gare',
+                            name_nl='Stationsstraat',
+                            name_de='Bahnhofstraße')
+
+        assert ('Rue de la Gare / Stationsstraat/Bahnhofstraße', 'name', '') not in res
+        assert ('Rue de la Gare', 'name', 'fr') in res
+        assert ('Stationsstraat', 'name', 'nl') in res
+        assert ('Bahnhofstraße', 'name', 'de') in res
+
+    def test_space_delimiter(self, run_sanitizer):
+        res = run_sanitizer(name='Oran ⵡⴻⵀⵔⴰⵏ وهران',
+                            name_en='Oran',
+                            name_ber='ⵡⴻⵀⵔⴰⵏ',
+                            name_ar='وهران',
+                            name_be='Аран')
+
+        assert ('Oran ⵡⴻⵀⵔⴰⵏ وهران', 'name', '') not in res
+        assert ('Oran', 'name', 'en') in res
+        assert ('ⵡⴻⵀⵔⴰⵏ', 'name', 'ber') in res
+        assert ('وهران', 'name', 'ar') in res
+        assert ('Аран', 'name', 'be') in res
+
+    def test_space_delimiter_multiword_name(self, run_sanitizer):
+        res = run_sanitizer(name='Baarin Left Banner ᠪᠠᠭᠠᠷᠢᠨ ᠵᠡᠭᠦᠨ 巴林左旗',
+                            name_en='Baarin Left Banner',
+                            name_mn='ᠪᠠᠭᠠᠷᠢᠨ ᠵᠡᠭᠦᠨ',
+                            name_zh='巴林左旗')
+
+        assert ('Baarin Left Banner ᠪᠠᠭᠠᠷᠢᠨ ᠵᠡᠭᠦᠨ 巴林左旗', 'name', '') not in res
+        assert ('Baarin Left Banner', 'name', 'en') in res
+        assert ('ᠪᠠᠭᠠᠷᠢᠨ ᠵᠡᠭᠦᠨ', 'name', 'mn') in res
+        assert ('巴林左旗', 'name', 'zh') in res
+
+    def test_mixed_delimiters(self, run_sanitizer):
+        res = run_sanitizer(name='गढ़वा /Garhwa - گڑھوا',
+                            name_hi='गढ़वा',
+                            name_en='Garhwa',
+                            name_ur='گڑھوا')
+
+        assert ('गढ़वा /Garhwa - گڑھوا', 'name', '') not in res
+
+    def test_name_equals_single_lang_name(self, run_sanitizer):
+        res = run_sanitizer(name='New York City',
+                            name_en='New York City',
+                            name_fr='Ville de New York')
+
+        assert ('New York City', 'name', '') not in res
+
+    def test_name_does_not_match_any_pattern(self, run_sanitizer):
+        res = run_sanitizer(name='Some Unique Name',
+                            name_fr='Rue du Poulet',
+                            name_nl='Kiekenstraat')
+
+        assert ('Some Unique Name', 'name', '') in res
+
+    def test_partial_match(self, run_sanitizer):
+        res = run_sanitizer(name='Rue du Poulet - Unknown',
+                            name_fr='Rue du Poulet',
+                            name_nl='Kiekenstraat')
+
+        assert ('Rue du Poulet - Unknown', 'name', '') in res
+
+    def test_custom_delimiter(self, run_sanitizer):
+        res = run_sanitizer(extra_args={'delimiters': ['|']},
+                            name='गढ़वा|Garhwa | گڑھوا',
+                            name_hi='गढ़वा',
+                            name_en='Garhwa',
+                            name_ur='گڑھوا')
+
+        assert ('गढ़वा|Garhwa | گڑھوا', 'name', '') not in res
+
+    def test_delimeter_in_name(self, run_sanitizer):
+        res = run_sanitizer(name='Berchem-Sainte-Agathe - Sint-Agatha-Berchem',
+                            name_ar='بيرشيم سانت أغاث',
+                            name_fr='Berchem-Sainte-Agathe',
+                            name_la='Berchemium Agathae',
+                            name_li='Sint-Agatha-Berchem',
+                            name_nl='Sint-Agatha-Berchem',
+                            name_ru='Беркем-Сент-Агат')
+
+        assert ('Berchem-Sainte-Agathe - Sint-Agatha-Berchem', 'name', '') not in res
+        assert ('بيرشيم سانت أغاث', 'name', 'ar') in res
+        assert ('Berchem-Sainte-Agathe', 'name', 'fr') in res
+        assert ('Berchemium Agathae', 'name', 'la') in res
+        assert ('Sint-Agatha-Berchem', 'name', 'li') in res
+        assert ('Sint-Agatha-Berchem', 'name', 'nl') in res
+        assert ('Беркем-Сент-Агат', 'name', 'ru') in res
+
+    def test_leading_or_trailing_delimiter(self, run_sanitizer):
+        res = run_sanitizer(name='/ Foo - Bar - ',
+                            name_fr='Foo',
+                            name_es='Bar')
+
+        assert ('/ Foo - Bar -', 'name', '') not in res
+        assert ('Foo', 'name', 'fr') in res
+        assert ('Bar', 'name', 'es') in res
+
+    def test_longest_match_priority(self, run_sanitizer):
+        """ Test that overlapping substrings in language names do not break
+            the concatenation check due to premature regex matching.
+        """
+        res = run_sanitizer(name='New - New York',
+                            name_fr='New',
+                            name_en='New York')
+
+        assert ('New - New York', 'name', '') not in res
+        assert ('New', 'name', 'fr') in res
+        assert ('New York', 'name', 'en') in res
+
+    def test_non_language_suffix_ignored(self, run_sanitizer):
+        res = run_sanitizer(name='Old Town Hall',
+                            name_prefix='Old Town',
+                            name_suffix='Hall')
+
+        assert ('Old Town Hall', 'name', '') in res
+
+    def test_three_letter_language_used(self, run_sanitizer):
+        # A language code followed by a script variant is a valid suffix.
+        res = run_sanitizer(name='臺北 - Taipei',
+                            name_zh_Hant='臺北',
+                            name_en='Taipei')
+
+        assert ('臺北 - Taipei', 'name', '') not in res
+
+
+class TestFilterKind:
+    """ Test with custom filter-kind configuration.
+    """
+
+    def test_filter_kind_ref(self, run_sanitizer):
+        place = PlaceInfo({'name': {'name': 'गढ़वा - Garhwa',
+                                    'name:fr': 'गढ़वा',
+                                    'name:nl': 'Garhwa',
+                                    'ref': 'A - B',
+                                    'ref:fr': 'A',
+                                    'ref:nl': 'B'},
+                           'country_code': 'be', 'rank_address': 26})
+
+        # When filter-kind is set to 'ref', only ref names are processed.
+        cfg = Configuration(None)
+        PlaceSanitizer([{'step': 'clean-multilingual-names',
+                         'filter-kind': 'ref'}], cfg).process_names(place)
+
+        names = [(p.name, p.kind, p.suffix or '') for p in place.searchable_names]
+        # 'name' bare tag should be kept (not matched by filter-kind)
+        assert ('गढ़वा - Garhwa', 'name', '') in names
+        # 'ref' bare tag should be removed
+        assert ('A - B', 'ref', '') not in names
+
+    def test_alt_name_not_affected_by_default(self, run_sanitizer):
+        place = PlaceInfo({'name': {'name': 'गढ़वा - Garhwa',
+                                    'name:fr': 'गढ़वा',
+                                    'name:nl': 'Garhwa',
+                                    'alt_name': 'Baz - Qux',
+                                    'alt_name:fr': 'Baz',
+                                    'alt_name:nl': 'Qux'},
+                           'country_code': 'be', 'rank_address': 26})
+
+        cfg = Configuration(None)
+        PlaceSanitizer([{'step': 'clean-multilingual-names'}], cfg).process_names(place)
+
+        names = [(p.name, p.kind, p.suffix or '') for p in place.searchable_names]
+        assert ('गढ़वा - Garhwa', 'name', '') not in names
+        assert ('गढ़वा', 'name', 'fr') in names
+        assert ('Garhwa', 'name', 'nl') in names
+        # alt_name kind, doesn't match default filter-kind='name'.
+        assert ('Baz - Qux', 'alt_name', '') in names
+        assert ('Baz', 'alt_name', 'fr') in names
+        assert ('Qux', 'alt_name', 'nl') in names


### PR DESCRIPTION
Closes #4125

## Summary
Adds a new sanitizer, `clean_multilingual_names`, to detect and remove redundant base name tags that are simple concatenations of language-specific tags.

Default delimiters used: ["/", " - ", " — " ";", " "].


## AI usage
Unit tests were extensively co-authored with AI assistance.


## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
