### PR TITLE
Fix 500 error on category search without matching results

### DIFF
--- a/src/nominatim_api/search/geocoder.py
+++ b/src/nominatim_api/search/geocoder.py
@@ -175,6 +175,9 @@ class ForwardGeocoder:
         """ Remove badly matching results, sort by ranking and
             limit to the configured number of results.
         """
+        if not results:
+            return results
+
         results.sort(key=lambda r: (r.ranking, 0 if r.bbox is None else -r.bbox.area))
 
         final = SearchResults()
@@ -271,7 +274,7 @@ class ForwardGeocoder:
         if phrases:
             query, searches = await self.build_searches(phrases)
 
-            if query:
+            if searches:
                 searches = [wrap_near_search(categories, s) for s in searches[:50]]
                 results = await self.execute_searches(query, searches)
                 results = self.pre_filter_results(results)

--- a/test/bdd/features/api/search/queries.feature
+++ b/test/bdd/features/api/search/queries.feature
@@ -113,6 +113,16 @@ Feature: Search queries
           | category | type |
           | leisure  | firepit |
 
+    # github #4148
+    Scenario Outline: Key/value search without any match returns no results
+        When geocoding "<query>"
+        Then exactly 0 results are returned
+
+        Examples:
+          | query                   |
+          | [amenity=xyzxyz] Vaduz  |
+          | [amenity=xyzxyz] Berlin |
+
     Scenario: POI search in a bounded viewbox
         When geocoding "restaurants"
           | viewbox                           | bounded |


### PR DESCRIPTION
## Summary
Fixes #4148.

A `/search` request using the `[key=value]` category syntax together with a near-phrase returned a 500 error whenever the search legitimately found nothing:

```
curl -G "https://nominatim.openstreetmap.org/search" \
  --data-urlencode "q=[amenity=xyzxyz] Berlin" --data-urlencode "format=json"
{"title": "500 Internal Server Error"}
```

There turned out to be two independent `IndexError`s on this code path, both in `ForwardGeocoder.lookup_pois()`:


* `sort_and_cut_results()` accessed `results[0]` without checking that any results were found. This is the regression reported in the issue; the `if results:` guard was lost in 87a8c246.
* `execute_searches()` accessed `searches[0]` when the near-phrase produced no  search interpretations at all. `lookup_pois()` guarded this with `if query:`,  which is always true because `QueryStruct` defines neither `__bool__` nor  `__len__`. Replaced with `if searches:`, which is what `lookup()` already  does.

Which of the two triggers depends on whether the near-phrase is known to the tokenizer, so both need fixing for the query in the issue to work everywhere. `lookup()` was never affected: it calls `sort_and_cut_results()` under `if len(results) > 1:` and `execute_searches()` under `if searches:`.

Adds a BDD scenario in `test/bdd/features/api/search/queries.feature` covering both cases: a near-phrase that exists in the test data (`Vaduz`) and one that does not (`Berlin`).



## AI usage
<!-- Please list where and to what extent AI was used. -->
None

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
