### PR TITLE
Require PostgreSQL 13 as minimum version

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,7 +41,7 @@ jobs:
                 include:
                     - flavour: ubuntu-22
                       ubuntu: 22
-                      postgresql: 12
+                      postgresql: 13
                       lua: '5.1'
                       dependencies: pip
                       python: '3.9'

--- a/docs/admin/Installation.md
+++ b/docs/admin/Installation.md
@@ -24,7 +24,7 @@ and can't offer support.
 
 For running Nominatim:
 
-  * [PostgreSQL](https://www.postgresql.org) (12+ will work, 13+ strongly recommended)
+  * [PostgreSQL](https://www.postgresql.org) (13+)
   * [PostGIS](https://postgis.net) (3.0+ will work, 3.2+ strongly recommended)
   * [osm2pgsql](https://osm2pgsql.org) (1.8+)
   * [Python 3](https://www.python.org/) (3.9+, 3.10+ in case of Windows)

--- a/docs/develop/Database-Layout.md
+++ b/docs/develop/Database-Layout.md
@@ -164,9 +164,8 @@ Next to the main search tables, there is a set of secondary helper tables used
 to compute the address relations between places. These tables are partitioned.
 Each country is assigned a partition number in the country_name table (see
 below) and the data is then split between a set of tables, one for each
-partition. Note that Nominatim still manually manages partitioned tables.
-Native support for partitions in PostgreSQL only became usable with version 13.
-It will be a little while before Nominatim drops support for older versions.
+partition. Note that Nominatim still manually manages partitioned tables
+instead of using PostgreSQL's native partitioning.
 
 ![address tables](address-tables.svg)
 

--- a/src/nominatim_db/version.py
+++ b/src/nominatim_db/version.py
@@ -57,7 +57,7 @@ def parse_version(version: str) -> NominatimVersion:
 
 NOMINATIM_VERSION = parse_version('5.3.99-2')
 
-POSTGRESQL_REQUIRED_VERSION = (12, 0)
+POSTGRESQL_REQUIRED_VERSION = (13, 0)
 POSTGIS_REQUIRED_VERSION = (3, 0)
 OSM2PGSQL_REQUIRED_VERSION = (1, 8)
 


### PR DESCRIPTION
## Summary
<!-- Describe the purpose of your pull request and, if present, link to existing issues. -->

The combined centroid/categories GiST index in #4146 uses `gist__ltree_ops(siglen=8)`. Operator class parameters were introduced in pg 13, so on 12 the index creation fails with `syntax error at or near "("`. Without the parameter the index falls back to the 28-byte default signature and inflates considerably, so after discussions we are dropping support for 12.

## AI usage
<!-- Please list where and to what extent AI was used. -->

NONE

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
