### PR TITLE
validate layer URL parameter values

### DIFF
--- a/src/nominatim_api/v1/server_glue.py
+++ b/src/nominatim_api/v1/server_glue.py
@@ -8,7 +8,7 @@
 Generic part of the server implementation of the v1 API.
 Combine with the scaffolding provided for the various Python ASGI frameworks.
 """
-from typing import Optional, Any, Type, Dict, cast, Sequence, Tuple
+from typing import Optional, Any, Type, Dict, Sequence, Tuple
 from functools import reduce
 import dataclasses
 from urllib.parse import urlencode
@@ -69,14 +69,30 @@ def setup_debugging(adaptor: ASGIAdaptor) -> bool:
 
 def get_layers(adaptor: ASGIAdaptor) -> Optional[DataLayer]:
     """ Return a parsed version of the layer parameter.
+
+        Returns None when the parameter is not given or contains no layer
+        names at all. Layer filtering is disabled in that case. Surrounding
+        whitespace is ignored. An unknown layer name results in a user error.
     """
     param = adaptor.get('layer', None)
     if param is None:
         return None
 
-    return cast(DataLayer,
-                reduce(DataLayer.__or__,
-                       (getattr(DataLayer, s.upper()) for s in param.split(','))))
+    layers = []
+    for name in param.split(','):
+        name = name.strip()
+        if not name:
+            continue
+        try:
+            layers.append(DataLayer[name.upper()])
+        except KeyError:
+            adaptor.raise_error("Parameter 'layer' must be a comma-separated list of: "
+                                + ', '.join(n.lower() for n in DataLayer.__members__))
+
+    if not layers:
+        return None
+
+    return reduce(DataLayer.__or__, layers)
 
 
 def parse_format(adaptor: ASGIAdaptor, result_type: Type[Any], default: str) -> str:

--- a/test/bdd/features/api/reverse/v1_params.feature
+++ b/test/bdd/features/api/reverse/v1_params.feature
@@ -182,3 +182,25 @@ Feature: v1/reverse Parameter Tests
           | format | outformat |
           | json   | json |
           | jsonv2 | json |
+
+    Scenario Outline: Unknown layers are rejected
+        When sending v1/reverse
+          | lat         | lon           | layer   |
+          | 47.14122383 | 9.52169581334 | <layer> |
+        Then a HTTP 400 is returned
+
+        Examples:
+          | layer |
+          | bogus |
+          | address,bogus |
+
+    Scenario Outline: An empty layer parameter disables layer filtering
+        When sending v1/reverse
+          | lat         | lon           | layer   |
+          | 47.14122383 | 9.52169581334 | <layer> |
+        Then a HTTP 200 is returned
+
+        Examples:
+          | layer |
+          |       |
+          | ,     |

--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -221,6 +221,35 @@ def test_build_response_jsonp_bad_format(param):
         glue.build_response(a, '{}')
 
 
+# get_layers()
+
+def test_get_layers_no_param():
+    assert glue.get_layers(FakeAdaptor()) is None
+
+
+@pytest.mark.parametrize('param,expected', [
+    ('address', napi.DataLayer.ADDRESS),
+    ('POI', napi.DataLayer.POI),
+    ('address,poi', napi.DataLayer.ADDRESS | napi.DataLayer.POI),
+    ('  address , poi ', napi.DataLayer.ADDRESS | napi.DataLayer.POI),
+    ('address,address', napi.DataLayer.ADDRESS),
+    ('address,', napi.DataLayer.ADDRESS)])
+def test_get_layers_success(param, expected):
+    assert glue.get_layers(FakeAdaptor(params={'layer': param})) == expected
+
+
+@pytest.mark.parametrize('param', ['', ' ', ',', ' , '])
+def test_get_layers_empty_disables_filter(param):
+    assert glue.get_layers(FakeAdaptor(params={'layer': param})) is None
+
+
+@pytest.mark.parametrize('param', ['bogus', 'address,bogus', 'name', '_name_',
+                                   'address poi', '<script>'])
+def test_get_layers_invalid_value(param):
+    with pytest.raises(FakeError, match='^400 -- .*must be a comma-separated list'):
+        glue.get_layers(FakeAdaptor(params={'layer': param}))
+
+
 # status_endpoint()
 
 class TestStatusEndpoint:


### PR DESCRIPTION
## Summary
Fixes https://github.com/osm-search/Nominatim/issues/4154
- empty layer value gets ignored
- unknown layer value causes HTTP 400 error with relevant error message
- works with the comma-separated list, too

## AI usage
LLM plus manual review and testing. I'm not too familiar with enums in Python and I wouldn't have used `reduce` but comparing with https://github.com/osm-search/Nominatim/blob/96960b436388c28bec1536d533f55570ae3863ec/src/nominatim_db/clicmd/api.py#L107-L115 that's similar to the CLI code. I cut the suggested test cases in half.

## Contributor guidelines (mandatory)

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
