### PR TITLE
Remove srp from languages for Montenegro

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1124,7 +1124,7 @@ md:
 # Montenegro (Crna Gora / Црна Гора)
 me:
     partition: 180
-    languages: srp, sr, hr, bs, sq
+    languages: sr, hr, bs, sq
     names: !include country-names/me.yaml
     postcode:
       pattern: "ddddd"


### PR DESCRIPTION
It's just the 3-letter code for the already existing sr.
