### PR TITLE
disable debug=1 output by default

### DIFF
--- a/docs/api/Details.md
+++ b/docs/api/Details.md
@@ -133,6 +133,16 @@ a simple comma-separated list of language codes or have the same format
 as the ["Accept-Language" HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language).
 
 
+### Other
+
+| Parameter | Value  | Default |
+|-----------| -----  | ------- |
+| debug     | 0 or 1 | 0       |
+
+Output special developer debug information instead of the normal result.
+See [Debug output](Output.md#debug-output) for details.
+
+
 ## Examples
 
 ##### JSON

--- a/docs/api/Lookup.md
+++ b/docs/api/Lookup.md
@@ -141,9 +141,8 @@ address to identify your requests. See Nominatim's
 |-----------| -----  | ------- |
 | debug     | 0 or 1 | 0       |
 
-Output assorted developer debug information. Data on internals of Nominatim's
-"search loop" logic, and SQL queries. The output is HTML format.
-This overrides the specified machine readable format.
+Output special developer debug information instead of the normal result.
+See [Debug output](Output.md#debug-output) for details.
 
 
 ## Examples

--- a/docs/api/Output.md
+++ b/docs/api/Output.md
@@ -235,6 +235,22 @@ Additional information requested with `extratags=1`, `namedetails=1`, and
 `namedetails`, and `entrances` respectively.
 
 
+## Debug output
+
+| Parameter | Value  | Default |
+|-----------| -----  | ------- |
+| debug     | 0 or 1 | 0       |
+
+Adding `debug=1` to a query to the [/search](Search.md), [/reverse](Reverse.md),
+[/lookup](Lookup.md) or [/details](Details.md) endpoint switches the output to
+an HTML page with assorted developer debug information: how Nominatim parsed,
+understood and executed its database searches.
+
+Debug output is disabled by default. It is only available when the server
+administrator has enabled
+[`NOMINATIM_SERVE_DEBUG_OUTPUT`](../customize/Settings.md#nominatim_serve_debug_output).
+
+
 ## Notes on field values
 
 ### place_id is not a persistent id

--- a/docs/api/Reverse.md
+++ b/docs/api/Reverse.md
@@ -211,9 +211,8 @@ address to identify your requests. See Nominatim's
 |-----------| -----  | ------- |
 | debug     | 0 or 1 | 0       |
 
-Output assorted developer debug information. Data on internals of Nominatim's
-"search loop" logic, and SQL queries. The output is HTML format.
-This overrides the specified machine readable format.
+Output special developer debug information instead of the normal result.
+See [Debug output](Output.md#debug-output) for details.
 
 
 ## Examples

--- a/docs/api/Search.md
+++ b/docs/api/Search.md
@@ -316,9 +316,8 @@ ensures that all results are returned.
 |-----------| -----  | ------- |
 | debug     | 0 or 1 | 0       |
 
-Output assorted developer debug information. Data on internals of Nominatim's
-"search loop" logic, and SQL queries. The output is HTML format.
-This overrides the specified machine readable format.
+Output special developer debug information instead of the normal result.
+See [Debug output](Output.md#debug-output) for details.
 
 
 ## Examples

--- a/docs/customize/Result-Formatting.md
+++ b/docs/customize/Result-Formatting.md
@@ -120,6 +120,10 @@ special format that enables debug output via the command line (the same
 as the `debug=1` parameter enables for the server API). To not clash
 with this built-in function, you shouldn't name your own format 'debug'.
 
+Note that the `debug` format of the CLI is always available, while the
+`debug=1` parameter of the server API needs to be enabled explicitly with
+[NOMINATIM_SERVE_DEBUG_OUTPUT](Settings.md#nominatim_serve_debug_output).
+
 ### Content type of new formats
 
 All responses will be returned with the content type application/json by

--- a/docs/customize/Settings.md
+++ b/docs/customize/Settings.md
@@ -466,11 +466,26 @@ Return "Unable to geocode" instead.
 | **Description:**   | Enable serving via URLs with a .php suffix |
 | **Format:**        | boolean |
 | **Default:**       | yes |
-| **Comment:**       | Python frontend only |
 
 When enabled, then endpoints are reachable as `/<name>` as well as `/<name>.php`.
 This can be useful when you want to be backwards-compatible with previous
 versions of Nominatim.
+
+
+#### NOMINATIM_SERVE_DEBUG_OUTPUT
+
+| Summary            |                                                     |
+| --------------     | --------------------------------------------------- |
+| **Description:**   | Enable the HTML debug output |
+| **Format:**        | boolean |
+| **Default:**       | no |
+
+When enabled, requests to `/search`, `/reverse`, `/lookup` and `/details` with
+the parameter `debug=1` return an HTML page detailing how the query was
+parsed, understood and executed.
+
+The `debug` format of the command-line tool (`nominatim search --format debug`),
+which has a similar output (text instead of HTML), is always available.
 
 
 #### NOMINATIM_API_POOL_SIZE
@@ -480,7 +495,6 @@ versions of Nominatim.
 | **Description:**   | Number of parallel database connections per worker |
 | **Format:**        | number |
 | **Default:**       | 10 |
-| **Comment:**       | Python frontend only |
 
 Sets the maximum number of database connections available for a single instance
 of Nominatim. When configuring the maximum number of connections that your
@@ -496,7 +510,6 @@ For configuring the number of workers, refer to the section about
 | **Description:**   | Timeout for SQL queries to the database |
 | **Format:**        | number (seconds) |
 | **Default:**       | 10 |
-| **Comment:**       | Python frontend only |
 
 When this timeout is set, then all SQL queries that run longer than the
 specified numbers of seconds will be cancelled and the user receives a
@@ -514,7 +527,6 @@ of the library. A timeout can be manually set, if required.
 | **Description:**   | Timeout for search queries |
 | **Format:**        | number (seconds) |
 | **Default:**       | 60 |
-| **Comment:**       | Python frontend only |
 
 When this timeout is set, a search query will finish sending queries
 to the database after the timeout has passed and immediately return the

--- a/settings/env.defaults
+++ b/settings/env.defaults
@@ -153,6 +153,12 @@ NOMINATIM_POLYGON_OUTPUT_MAX_TYPES=1
 # under <endpoint>.php
 NOMINATIM_SERVE_LEGACY_URLS=yes
 
+# Enable the HTML debug output of the server.
+# When enabled, requests with the parameter debug=1 return an HTML page with
+# internal details of how Nominatim parsed, understood and executed its
+# searches including full SQL queries.
+NOMINATIM_SERVE_DEBUG_OUTPUT=no
+
 # Maximum number of DB connections a single API object can use.
 # When running Nominatim as a server, then this is the maximum number
 # of connections _per worker_.

--- a/src/nominatim_api/v1/server_glue.py
+++ b/src/nominatim_api/v1/server_glue.py
@@ -60,6 +60,9 @@ def setup_debugging(adaptor: ASGIAdaptor) -> bool:
         Return True when debugging was requested.
     """
     if adaptor.get_bool('debug', False):
+        if not adaptor.config().get_bool('SERVE_DEBUG_OUTPUT'):
+            adaptor.raise_error('Debug output is not enabled on this server.')
+
         loglib.set_log_output('html')
         adaptor.content_type = ct.CONTENT_HTML
         return True

--- a/test/bdd/features/api/details/simple.feature
+++ b/test/bdd/features/api/details/simple.feature
@@ -70,6 +70,7 @@ Feature: Object details
 
 
     Scenario Outline: Details debug output returns no errors
+        Given debug output is enabled
         When sending v1/details
           | osmtype | osmid | debug |
           | <type>  | <id>  | 1     |

--- a/test/bdd/features/api/reverse/v1_params.feature
+++ b/test/bdd/features/api/reverse/v1_params.feature
@@ -100,6 +100,7 @@ Feature: v1/reverse Parameter Tests
           | foo; evil |
 
     Scenario Outline: Reverse debug mode produces valid HTML
+        Given debug output is enabled
         When sending v1/reverse
           | lat   | lon   | debug |
           | <lat> | <lon> | 1 |

--- a/test/bdd/features/api/search/simple.feature
+++ b/test/bdd/features/api/search/simple.feature
@@ -169,6 +169,7 @@ Feature: Simple Tests
           | .*&countrycodes=pl%2Cbo&.* |
 
     Scenario Outline: Search debug output does not return errors
+        Given debug output is enabled
         When sending v1/search
           | q       | debug |
           | <query> | 1     |
@@ -183,3 +184,9 @@ Feature: Simple Tests
           | Landstr 27 Steinort, Triesenberg, 9495 |
           | 9497 |
           | restaurant in triesen |
+
+    Scenario: Search debug output is rejected when not enabled
+        When sending v1/search with format json
+          | q             | debug |
+          | Liechtenstein | 1     |
+        Then a HTTP 400 is returned

--- a/test/bdd/test_api.py
+++ b/test/bdd/test_api.py
@@ -103,6 +103,12 @@ def setup_connection_unknown_database(test_config_env):
     return test_config_env
 
 
+@given('debug output is enabled', target_fixture='test_config_env')
+def setup_debug_output_enabled(test_config_env):
+    test_config_env['NOMINATIM_SERVE_DEBUG_OUTPUT'] = 'yes'
+    return test_config_env
+
+
 @when(step_parse(r'sending v1/(?P<endpoint>\S+)(?: with format (?P<fmt>\S+))?'),
       target_fixture='api_response')
 def send_api_status(test_config_env, api_http_request_headers, pytestconfig,

--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -17,6 +17,16 @@ from fake_adaptor import FakeAdaptor, FakeError, FakeResponse
 import nominatim_api.v1.server_glue as glue
 import nominatim_api as napi
 import nominatim_api.logging as loglib
+from nominatim_api.config import Configuration
+
+
+def debug_config(enabled):
+    """ Return a configuration where the HTML debug output is explicitly
+        enabled or disabled.
+    """
+    return Configuration(None,
+                         environ={'NOMINATIM_SERVE_DEBUG_OUTPUT':
+                                  'yes' if enabled else 'no'})
 
 
 # ASGIAdaptor.get_int/bool()
@@ -106,6 +116,42 @@ def test_accepted_languages_header_over_default(monkeypatch):
     assert glue.get_accepted_languages(a) == 'de'
 
 
+# NOMINATIM_SERVE_DEBUG_OUTPUT enables debug=1
+
+@pytest.mark.parametrize('environ', [{}, {'NOMINATIM_SERVE_DEBUG_OUTPUT': 'no'}])
+def test_setup_debugging_rejected_when_disabled(environ):
+    a = FakeAdaptor(params={'debug': '1'},
+                    config=Configuration(None, environ=environ))
+
+    with pytest.raises(FakeError, match='^400 -- .*not enabled'):
+        glue.setup_debugging(a)
+
+
+def test_setup_debugging_enabled():
+    a = FakeAdaptor(params={'debug': '1'}, config=debug_config(True))
+
+    assert glue.setup_debugging(a)
+    assert a.content_type == 'text/html; charset=utf-8'
+
+
+@pytest.mark.parametrize('params', [{}, {'debug': '0'}])
+def test_setup_debugging_not_requested(params):
+    a = FakeAdaptor(params=params, config=debug_config(True))
+
+    assert not glue.setup_debugging(a)
+    assert a.content_type == 'text/plain; charset=utf-8'
+
+
+@pytest.mark.parametrize('content_type', ['application/json; charset=utf-8',
+                                          'text/xml; charset=utf-8'])
+def test_setup_debugging_rejection_keeps_output_format(content_type):
+    a = FakeAdaptor(params={'debug': '1'}, config=debug_config(False))
+    a.content_type = content_type
+
+    with pytest.raises(FakeError, match='(?s)^400 -- .*not enabled'):
+        glue.setup_debugging(a)
+
+
 # ASGIAdaptor.raise_error()
 
 class TestAdaptorRaiseError:
@@ -150,7 +196,7 @@ class TestAdaptorRaiseError:
 
 
 def test_raise_error_during_debug():
-    a = FakeAdaptor(params={'debug': '1'})
+    a = FakeAdaptor(params={'debug': '1'}, config=debug_config(True))
     glue.setup_debugging(a)
     loglib.log().section('Ongoing')
 
@@ -336,7 +382,8 @@ class TestDetailsEndpoint:
 
     @pytest.mark.asyncio
     async def test_details_with_debugging(self):
-        a = FakeAdaptor(params={'osmtype': 'N', 'osmid': '45', 'debug': '1'})
+        a = FakeAdaptor(params={'osmtype': 'N', 'osmid': '45', 'debug': '1'},
+                        config=debug_config(True))
 
         resp = await glue.details_endpoint(napi.NominatimAPIAsync(), a)
         content = ET.fromstring(resp.output)


### PR DESCRIPTION
## Summary
Disables the `&debug=1` HTML web output by default. Can we enabled in server configuration. It's useful for admins, will remain enabled on nominatim.openstreetmap.org, but most admins don't use it or might not even be aware of the feature.

This doesn't affect the CLI where `nominatim search ... --format=debug` is always enabled.

A small fix is removing "Python frontend only" from the configuration documentation. Nominatim only supports Python frontend anyway.

The `debug` parameter wasn't documented for the `/details` endpoint.

<img width="1046" height="1319" alt="image" src="https://github.com/user-attachments/assets/dfe44b9a-4fda-4403-ba38-d2681146d0b5" />

## AI usage
I wrote the server_glue changes which arguably are tiny. I had to rewrite most of the documentation text AI came up with (too verbose, repeated). AI wrote the tests but I cut it down to a minimum, too. I'm writing this PR description.

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
