### PR TITLE
Add restrictions to length of search queries

### DIFF
--- a/settings/query_preprocessing.yaml
+++ b/settings/query_preprocessing.yaml
@@ -1,1 +1,5 @@
+- step: regex-replace
+  replacements:
+      - pattern: '^.{500,}$'
+        replace: ''
 - step: split_japanese_phrases

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -20,6 +20,7 @@ from ..typing import SaRow
 from ..sql.sqlalchemy_types import Json
 from ..connection import SearchConnection
 from ..logging import log
+from ..errors import UsageError
 from . import query as qmod
 from .query_analyzer_factory import AbstractQueryAnalyzer
 from .postcode_parser import PostcodeParser
@@ -157,6 +158,8 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
             return query
 
         self.split_query(query)
+        if query.num_token_slots() > 50:
+            raise UsageError('Query is too long.')
         log().var_dump('Transliterated query',
                        lambda: ''.join(f"{n.btype}{n.term_lookup}" for n in query.nodes)
                                + ' / '

--- a/src/nominatim_api/search/icu_tokenizer.py
+++ b/src/nominatim_api/search/icu_tokenizer.py
@@ -246,7 +246,7 @@ class ICUQueryAnalyzer(AbstractQueryAnalyzer):
                     if word:
                         if trans := self.transliterator.transliterate(word):
                             for term, term_word in self.split_transliteration(trans, word):
-                                if term:
+                                if term and len(term) < 256:
                                     query.add_node(breakchar, phrase.ptype, term, term_word)
                                     breakchar = qmod.BREAK_TOKEN
                     breakchar = None

--- a/src/nominatim_api/search/query.py
+++ b/src/nominatim_api/search/query.py
@@ -418,6 +418,8 @@ class QueryStruct:
                 if last_node.btype == BREAK_PHRASE:
                     break
                 word = f"{word} {last_node.term_lookup}"
+                if len(word) > 255:
+                    break
                 words[word].append(TokenRange(first, last))
 
         return words


### PR DESCRIPTION
This adds a hard limit of 255 characters per term and 50 terms per query to search queries. The former limit comes from the maximum length of tags in OSM, so there cannot be names longer than that. The latter protects the SQL queries from becoming to long.

The acceptable queries can still be quite long, so to protect a default Nominatim installation a bit more, this also adds a query preprocessor that rejects any queries longer than 500 characters. You can change this in your installation.