### PR TITLE
Add category filters to the search API

### DIFF
--- a/src/nominatim_api/core.py
+++ b/src/nominatim_api/core.py
@@ -711,6 +711,16 @@ class NominatimAPI:
               categories (list[tuple]): Restrict search to places of the given
                 categories. The category is the main OSM tag assigned to each
                 place. An empty list (the default) disables this filter.
+              include (list[list[str]]): Restrict search to places matching the
+                given hierarchical categories, e.g. `osm.amenity.restaurant`.
+                A place must match at least one category of every group and
+                matches a category when it is assigned the category itself or
+                one of its descendants. An empty list (the default) disables
+                this filter.
+              exclude (list[list[str]]): Drop places matching the given
+                hierarchical categories from the results. A place is dropped
+                when it matches all categories of any of the groups. An empty
+                list (the default) disables this filter.
               geometry_output (enum): Add the full geometry of the place to the result.
                 Multiple formats may be selected. Note that geometries can become
                 quite large. (Default: none)
@@ -829,6 +839,16 @@ class NominatimAPI:
               categories (list[tuple]): Restrict search to places of the given
                 categories. The category is the main OSM tag assigned to each
                 place. An empty list (the default) disables this filter.
+              include (list[list[str]]): Restrict search to places matching the
+                given hierarchical categories, e.g. `osm.amenity.restaurant`.
+                A place must match at least one category of every group and
+                matches a category when it is assigned the category itself or
+                one of its descendants. An empty list (the default) disables
+                this filter.
+              exclude (list[list[str]]): Drop places matching the given
+                hierarchical categories from the results. A place is dropped
+                when it matches all categories of any of the groups. An empty
+                list (the default) disables this filter.
               geometry_output (enum): Add the full geometry of the place to the result.
                 Multiple formats may be selected. Note that geometries can become
                 quite large. (Default: none)

--- a/src/nominatim_api/search/db_searches/address_search.py
+++ b/src/nominatim_api/search/db_searches/address_search.py
@@ -74,6 +74,8 @@ async def _get_placex_housenumbers(conn: SearchConnection,
     sql = base.select_placex(t).add_columns(t.c.importance)\
                                .where(t.c.place_id.in_(place_ids))
 
+    sql = base.filter_by_category(sql, t, details)
+
     if details.geometry_output:
         sql = base.add_geometry_columns(sql, t.c.geometry, details)
 
@@ -210,6 +212,14 @@ class AddressSearch(base.AbstractSearch):
 
         sql = base.select_placex(t).join(tsearch, t.c.place_id == tsearch.c.place_id)
 
+        # The category filter must not restrict the query itself: the rows
+        # here are the parents used to find the housenumbers and only become
+        # a result of their own when no housenumber was found. Carry the
+        # match along as a column and apply it when collecting the results.
+        catfilter = base.category_restriction(t, details)
+        if catfilter is not None:
+            sql = sql.add_columns(catfilter.label('cat_match'))
+
         if details.geometry_output:
             sql = base.add_geometry_columns(sql, t.c.geometry, details)
 
@@ -269,7 +279,9 @@ class AddressSearch(base.AbstractSearch):
                     if n.isdecimal() and len(n) < 8]
         interpol_sql: SaColumn
         tiger_sql: SaColumn
-        if numerals and \
+        # Interpolations and Tiger data carry no categories, so they cannot
+        # satisfy an include filter.
+        if numerals and not details.include and \
            (not self.qualifiers or ('place', 'house') in self.qualifiers.values):
             # Housenumbers from interpolations
             interpol_sql = _make_interpolation_subquery(conn.t.osmline, inner,
@@ -339,6 +351,7 @@ class AddressSearch(base.AbstractSearch):
                 # filter conditions.
                 if (not details.excluded or result.place_id not in details.excluded_place_ids)\
                    and (not self.qualifiers or result.category in self.qualifiers.values)\
+                   and (catfilter is None or row.cat_match)\
                    and result.rank_address >= details.min_rank:
                     result.accuracy += 1.0  # penalty for missing housenumber
                     results.append(result)

--- a/src/nominatim_api/search/db_searches/base.py
+++ b/src/nominatim_api/search/db_searches/base.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 from ...typing import SaFromClause, SaSelect, SaColumn, SaExpression, SaLambdaSelect
 from ...sql.sqlalchemy_types import Geometry
-from ...sql.sqlalchemy_functions import CategoryMatch, CategoryContains
+from ...sql.sqlalchemy_functions import CategoryMatch
 from ...connection import SearchConnection
 from ...types import SearchDetails, DataLayer, GeometryFormat
 from ...results import SearchResults
@@ -53,9 +53,9 @@ def category_ltree(cls: str, typ: str) -> str:
 
 def category_filter(table: SaFromClause, cls: str, typ: str) -> SaExpression:
     """ Build a boolean expression selecting rows of the given class/type
-        category via the ltree categories column (class/type on SQLite).
+        category via the categories column.
     """
-    return CategoryMatch(table, category_ltree(cls, typ), cls, typ)
+    return CategoryMatch(table, category_ltree(cls, typ))
 
 
 def category_restriction(table: SaFromClause,
@@ -69,10 +69,10 @@ def category_restriction(table: SaFromClause,
     terms: list[SaExpression] = []
 
     for group in details.include:
-        terms.append(sa.or_(*(CategoryContains(table, cat) for cat in group)))
+        terms.append(sa.or_(*(CategoryMatch(table, cat) for cat in group)))
 
     for group in details.exclude:
-        terms.append(sa.not_(sa.and_(*(CategoryContains(table, cat) for cat in group))))
+        terms.append(sa.not_(sa.and_(*(CategoryMatch(table, cat) for cat in group))))
 
     if not terms:
         return None

--- a/src/nominatim_api/search/db_searches/base.py
+++ b/src/nominatim_api/search/db_searches/base.py
@@ -7,7 +7,7 @@
 """
 Interface for classes implementing a database search.
 """
-from typing import Callable, List
+from typing import Callable, List, Optional
 import abc
 import re
 
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 from ...typing import SaFromClause, SaSelect, SaColumn, SaExpression, SaLambdaSelect
 from ...sql.sqlalchemy_types import Geometry
-from ...sql.sqlalchemy_functions import CategoryMatch
+from ...sql.sqlalchemy_functions import CategoryMatch, CategoryContains
 from ...connection import SearchConnection
 from ...types import SearchDetails, DataLayer, GeometryFormat
 from ...results import SearchResults
@@ -56,6 +56,37 @@ def category_filter(table: SaFromClause, cls: str, typ: str) -> SaExpression:
         category via the ltree categories column (class/type on SQLite).
     """
     return CategoryMatch(table, category_ltree(cls, typ), cls, typ)
+
+
+def category_restriction(table: SaFromClause,
+                         details: SearchDetails) -> Optional[SaExpression]:
+    """ Build a boolean expression for the include/exclude category filters.
+
+        A row must match at least one category of every include group and
+        must not match all categories of any of the exclude groups. Returns
+        None when no category filters are requested.
+    """
+    terms: list[SaExpression] = []
+
+    for group in details.include:
+        terms.append(sa.or_(*(CategoryContains(table, cat) for cat in group)))
+
+    for group in details.exclude:
+        terms.append(sa.not_(sa.and_(*(CategoryContains(table, cat) for cat in group))))
+
+    if not terms:
+        return None
+
+    return sa.and_(*terms)
+
+
+def filter_by_category(sql: SaSelect, t: SaFromClause,
+                       details: SearchDetails) -> SaSelect:
+    """ Apply the include/exclude category filters, if applicable.
+    """
+    restriction = category_restriction(t, details)
+
+    return sql if restriction is None else sql.where(restriction)
 
 
 class AbstractSearch(abc.ABC):

--- a/src/nominatim_api/search/db_searches/country_search.py
+++ b/src/nominatim_api/search/db_searches/country_search.py
@@ -44,6 +44,7 @@ class CountrySearch(base.AbstractSearch):
         if details.excluded:
             sql = sql.where(base.exclude_places(t))
 
+        sql = base.filter_by_category(sql, t, details)
         sql = base.filter_by_area(sql, t, details)
 
         bind_params = {
@@ -77,6 +78,11 @@ class CountrySearch(base.AbstractSearch):
         # usually are in the first batch of results and it is not possible
         # to exclude these fallbacks.
         if details.excluded:
+            return nres.SearchResults()
+
+        # The fallback tables carry no categories, so there is no way to tell
+        # if the country would satisfy the include filter.
+        if details.include:
             return nres.SearchResults()
 
         t = conn.t.country_name

--- a/src/nominatim_api/search/db_searches/near_search.py
+++ b/src/nominatim_api/search/db_searches/near_search.py
@@ -104,6 +104,7 @@ class NearSearch(base.AbstractSearch):
                                    .order_by(inner.c.dist)
 
         sql = sql.where(base.no_index(t.c.rank_address).between(MIN_RANK_PARAM, MAX_RANK_PARAM))
+        sql = base.filter_by_category(sql, t, details)
         if details.countries:
             sql = sql.where(t.c.country_code.in_(COUNTRIES_PARAM))
         if details.excluded:

--- a/src/nominatim_api/search/db_searches/place_search.py
+++ b/src/nominatim_api/search/db_searches/place_search.py
@@ -183,6 +183,7 @@ class PlaceSearch(base.AbstractSearch):
                  .where(t.c.indexed_status == 0)
         if self.qualifiers:
             sql = sql.where(self.qualifiers.sql_restrict(t))
+        sql = base.filter_by_category(sql, t, details)
         if details.layers is not None:
             sql = sql.where(base.filter_by_layer(t, details.layers))
 

--- a/src/nominatim_api/search/db_searches/poi_search.py
+++ b/src/nominatim_api/search/db_searches/poi_search.py
@@ -68,6 +68,8 @@ class PoiSearch(base.AbstractSearch):
         if self.countries:
             sql = sql.where(t.c.country_code.in_(self.countries.values))
 
+        sql = base.filter_by_category(sql, t, details)
+
         if details.excluded:
             sql = sql.where(base.exclude_places(t))
 

--- a/src/nominatim_api/search/db_searches/postcode_search.py
+++ b/src/nominatim_api/search/db_searches/postcode_search.py
@@ -39,6 +39,11 @@ class PostcodeSearch(base.AbstractSearch):
                      details: SearchDetails) -> nres.SearchResults:
         """ Find results for the search in the database.
         """
+        # Postcodes carry no categories, so they can never satisfy an
+        # include filter.
+        if details.include:
+            return nres.SearchResults()
+
         t = conn.t.postcode
         pcs = self.postcodes.values
 

--- a/src/nominatim_api/server/asgi_adaptor.py
+++ b/src/nominatim_api/server/asgi_adaptor.py
@@ -30,16 +30,11 @@ class ASGIAdaptor(abc.ABC):
             not provided, return the 'default' value.
         """
 
+    @abc.abstractmethod
     def get_all(self, name: str) -> list[str]:
         """ Return all values of an input parameter that was repeated in the
             request. Returns an empty list when the parameter was not provided.
-
-            This default implementation only ever returns the first value.
-            Adaptors that can access repeated parameters should override it.
         """
-        value = self.get(name)
-
-        return [] if value is None else [value]
 
     @abc.abstractmethod
     def get_header(self, name: str, default: Optional[str] = None) -> Optional[str]:

--- a/src/nominatim_api/server/asgi_adaptor.py
+++ b/src/nominatim_api/server/asgi_adaptor.py
@@ -30,6 +30,17 @@ class ASGIAdaptor(abc.ABC):
             not provided, return the 'default' value.
         """
 
+    def get_all(self, name: str) -> list[str]:
+        """ Return all values of an input parameter that was repeated in the
+            request. Returns an empty list when the parameter was not provided.
+
+            This default implementation only ever returns the first value.
+            Adaptors that can access repeated parameters should override it.
+        """
+        value = self.get(name)
+
+        return [] if value is None else [value]
+
     @abc.abstractmethod
     def get_header(self, name: str, default: Optional[str] = None) -> Optional[str]:
         """ Return a HTTP header parameter as a string. If the parameter was

--- a/src/nominatim_api/server/falcon/server.py
+++ b/src/nominatim_api/server/falcon/server.py
@@ -77,6 +77,9 @@ class ParamWrapper(ASGIAdaptor):
     def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
         return self.request.get_param(name, default=default)
 
+    def get_all(self, name: str) -> list[str]:
+        return self.request.get_param_as_list(name, default=[])
+
     def get_header(self, name: str, default: Optional[str] = None) -> Optional[str]:
         return self.request.get_header(name, default=default)
 

--- a/src/nominatim_api/server/starlette/server.py
+++ b/src/nominatim_api/server/starlette/server.py
@@ -42,6 +42,9 @@ class ParamWrapper(ASGIAdaptor):
     def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
         return self.request.query_params.get(name, default)
 
+    def get_all(self, name: str) -> list[str]:
+        return list(self.request.query_params.getlist(name))
+
     def get_header(self, name: str, default: Optional[str] = None) -> Optional[str]:
         return self.request.headers.get(name, default)
 

--- a/src/nominatim_api/sql/sqlalchemy_functions.py
+++ b/src/nominatim_api/sql/sqlalchemy_functions.py
@@ -223,48 +223,14 @@ def sqlite_regexp_nocase(element: RegexpWord, compiler: 'sa.Compiled', **kw: Any
 
 
 class CategoryMatch(sa.sql.functions.GenericFunction[Any]):
-    """ Match a placex row against a single (class, type) category.
-
-        On PostgreSQL this queries the ltree 'categories' column using the
-        GiST index (``categories <@ 'osm.<class>.<type>'``). On SQLite, which
-        has no ltree support, it matches on the class/type columns instead.
-    """
-    name = 'CategoryMatch'
-    inherit_cache = True
-
-    def __init__(self, table: SaFromClause, ltree: str, cls: str, typ: str) -> None:
-        super().__init__(table.c.categories, sa.literal(ltree),
-                         table.c.class_, sa.literal(cls),
-                         table.c.type, sa.literal(typ))
-
-
-@compiles(CategoryMatch)
-def _default_category_match(element: CategoryMatch,
-                            compiler: 'sa.Compiled', **kw: Any) -> str:
-    cats, ltree, _, _, _, _ = list(element.clauses)
-    return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
-                                    compiler.process(ltree, **kw))
-
-
-@compiles(CategoryMatch, 'sqlite')
-def _sqlite_category_match(element: CategoryMatch,
-                           compiler: 'sa.Compiled', **kw: Any) -> str:
-    _, _, cls_col, cls_lit, typ_col, typ_lit = list(element.clauses)
-    return "(%s = %s AND %s = %s)" % (compiler.process(cls_col, **kw),
-                                      compiler.process(cls_lit, **kw),
-                                      compiler.process(typ_col, **kw),
-                                      compiler.process(typ_lit, **kw))
-
-
-class CategoryContains(sa.sql.functions.GenericFunction[Any]):
     """ Match a placex row against a category or any of its descendants.
 
-        On PostgreSQL this is the ltree containment operator
-        (``categories <@ '<category>'``). On SQLite, where the categories
-        are stored as a comma-separated text, the same is emulated with a
-        substring search.
+        On PostgreSQL this queries the ltree 'categories' column using the
+        GiST index (``categories <@ '<category>'``). On SQLite, where the
+        categories are stored as a comma-separated text, the same is
+        emulated with a substring search.
     """
-    name = 'CategoryContains'
+    name = 'CategoryMatch'
     inherit_cache = True
 
     def __init__(self, table: SaFromClause, category: str) -> None:
@@ -275,17 +241,17 @@ class CategoryContains(sa.sql.functions.GenericFunction[Any]):
                          sa.literal(f',{category},'), sa.literal(f',{category}.'))
 
 
-@compiles(CategoryContains)
-def _default_category_contains(element: CategoryContains,
-                               compiler: 'sa.Compiled', **kw: Any) -> str:
+@compiles(CategoryMatch)
+def _default_category_match(element: CategoryMatch,
+                            compiler: 'sa.Compiled', **kw: Any) -> str:
     cats, category, _, _ = list(element.clauses)
     return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
                                     compiler.process(category, **kw))
 
 
-@compiles(CategoryContains, 'sqlite')
-def _sqlite_category_contains(element: CategoryContains,
-                              compiler: 'sa.Compiled', **kw: Any) -> str:
+@compiles(CategoryMatch, 'sqlite')
+def _sqlite_category_match(element: CategoryMatch,
+                           compiler: 'sa.Compiled', **kw: Any) -> str:
     cats, _, exact, descendants = list(element.clauses)
     # The categories are padded with the separator on both sides, so that
     # the needles match only on a full label boundary: ',<category>,' is an

--- a/src/nominatim_api/sql/sqlalchemy_functions.py
+++ b/src/nominatim_api/sql/sqlalchemy_functions.py
@@ -254,3 +254,43 @@ def _sqlite_category_match(element: CategoryMatch,
                                       compiler.process(cls_lit, **kw),
                                       compiler.process(typ_col, **kw),
                                       compiler.process(typ_lit, **kw))
+
+
+class CategoryContains(sa.sql.functions.GenericFunction[Any]):
+    """ Match a placex row against a category or any of its descendants.
+
+        On PostgreSQL this is the ltree containment operator
+        (``categories <@ '<category>'``). On SQLite, where the categories
+        are stored as a comma-separated text, the same is emulated with a
+        substring search.
+    """
+    name = 'CategoryContains'
+    inherit_cache = True
+
+    def __init__(self, table: SaFromClause, category: str) -> None:
+        # The needles for the SQLite variant are precomputed here because
+        # SQLAlchemy 1.4 binds a parameter only once per statement, even
+        # when it is rendered more than once.
+        super().__init__(table.c.categories, sa.literal(category),
+                         sa.literal(f',{category},'), sa.literal(f',{category}.'))
+
+
+@compiles(CategoryContains)
+def _default_category_contains(element: CategoryContains,
+                               compiler: 'sa.Compiled', **kw: Any) -> str:
+    cats, category, _, _ = list(element.clauses)
+    return "(%s <@ (%s)::ltree)" % (compiler.process(cats, **kw),
+                                    compiler.process(category, **kw))
+
+
+@compiles(CategoryContains, 'sqlite')
+def _sqlite_category_contains(element: CategoryContains,
+                              compiler: 'sa.Compiled', **kw: Any) -> str:
+    cats, _, exact, descendants = list(element.clauses)
+    # The categories are padded with the separator on both sides, so that
+    # the needles match only on a full label boundary: ',<category>,' is an
+    # exact hit, ',<category>.' one of its descendants.
+    haystack = "(',' || %s || ',')" % compiler.process(cats, **kw)
+    return "(instr(%s, %s) > 0 OR instr(%s, %s) > 0)" \
+           % (haystack, compiler.process(exact, **kw),
+              haystack, compiler.process(descendants, **kw))

--- a/src/nominatim_api/sql/sqlalchemy_types/ltree.py
+++ b/src/nominatim_api/sql/sqlalchemy_types/ltree.py
@@ -36,7 +36,14 @@ class CategoryArray(sa.types.UserDefinedType):  # type: ignore[type-arg]
     def result_processor(self, dialect: 'sa.Dialect',
                          coltype: object) -> Optional[Callable[[Any], Any]]:
         if dialect.name == 'postgresql':
-            return None
+            def process_pg(value: Any) -> Optional[list[str]]:
+                # ltree[] is unknown to the driver, so it hands out the
+                # literal text representation of the array.
+                if value is None or isinstance(value, list):
+                    return value
+                value = value.strip('{}')
+                return value.split(',') if value else []
+            return process_pg
 
         def process(value: Any) -> Optional[list[str]]:
             return value.split(',') if value else None

--- a/src/nominatim_api/types.py
+++ b/src/nominatim_api/types.py
@@ -517,6 +517,36 @@ def format_categories(categories: List[Tuple[str, str]]) -> List[Tuple[str, str]
     return categories
 
 
+CATEGORY_RE = re.compile(r'[A-Za-z0-9_-]{1,255}(\.[A-Za-z0-9_-]{1,255})+')
+
+
+def format_category_filters(filters: Any) -> list[list[str]]:
+    """ Parse category filters into a list of groups of categories.
+
+        Each entry of 'filters' is a comma-separated list of categories which
+        together form one group. A category must consist of at least two
+        dot-separated labels. Hyphens are folded to underscores because the
+        categories are stored that way (see the Lua sanitize_label()).
+    """
+    if isinstance(filters, str):
+        filters = [filters]
+
+    result = []
+    for group in filters:
+        if not isinstance(group, str):
+            raise UsageError("Category filters must be strings.")
+        categories = []
+        for category in group.split(','):
+            category = category.strip()
+            if not CATEGORY_RE.fullmatch(category):
+                raise UsageError(f"Invalid category '{category}'. A category must consist"
+                                 " of at least two labels separated by dots.")
+            categories.append(category.replace('-', '_'))
+        result.append(categories)
+
+    return result
+
+
 TParam = TypeVar('TParam', bound='LookupDetails')
 
 
@@ -659,6 +689,23 @@ class SearchDetails(LookupDetails):
                                                           metadata={'transform': format_categories})
     """ Restrict search to places with one of the given class/type categories.
         An empty list (the default) will disable this filter.
+    """
+
+    include: list[list[str]] = \
+        dataclasses.field(default_factory=list,
+                          metadata={'transform': format_category_filters})
+    """ Restrict search to places matching the given categories. A place must
+        match at least one category of every group and matches a category when
+        it is assigned the category itself or one of its descendants. An empty
+        list (the default) will disable this filter.
+    """
+
+    exclude: list[list[str]] = \
+        dataclasses.field(default_factory=list,
+                          metadata={'transform': format_category_filters})
+    """ Drop places matching the given categories from the results. A place is
+        dropped when it matches all categories of any of the groups. An empty
+        list (the default) will disable this filter.
     """
 
     viewbox_x2: Optional[Bbox] = None

--- a/src/nominatim_api/types.py
+++ b/src/nominatim_api/types.py
@@ -517,7 +517,7 @@ def format_categories(categories: List[Tuple[str, str]]) -> List[Tuple[str, str]
     return categories
 
 
-CATEGORY_RE = re.compile(r'[A-Za-z0-9_-]{1,255}(\.[A-Za-z0-9_-]{1,255})+')
+CATEGORY_RE = re.compile(r'[A-Za-z0-9_]{1,255}(\.[A-Za-z0-9_]{1,255})+')
 
 
 def format_category_filters(filters: Any) -> list[list[str]]:
@@ -525,8 +525,7 @@ def format_category_filters(filters: Any) -> list[list[str]]:
 
         Each entry of 'filters' is a comma-separated list of categories which
         together form one group. A category must consist of at least two
-        dot-separated labels. Hyphens are folded to underscores because the
-        categories are stored that way (see the Lua sanitize_label()).
+        dot-separated labels made up of letters, digits and underscores.
     """
     if isinstance(filters, str):
         filters = [filters]
@@ -541,7 +540,7 @@ def format_category_filters(filters: Any) -> list[list[str]]:
             if not CATEGORY_RE.fullmatch(category):
                 raise UsageError(f"Invalid category '{category}'. A category must consist"
                                  " of at least two labels separated by dots.")
-            categories.append(category.replace('-', '_'))
+            categories.append(category)
         result.append(categories)
 
     return result

--- a/src/nominatim_api/v1/server_glue.py
+++ b/src/nominatim_api/v1/server_glue.py
@@ -346,6 +346,8 @@ async def search_endpoint(api: NominatimAPIAsync, params: ASGIAdaptor) -> Any:
     details['viewbox'] = params.get('viewbox', None) or params.get('viewboxlbrt', None)
     details['bounded_viewbox'] = params.get_bool('bounded', False)
     details['dedupe'] = params.get_bool('dedupe', True)
+    details['include'] = params.get_all('include')
+    details['exclude'] = params.get_all('exclude')
 
     max_results = max(1, min(50, params.get_int('limit', 10)))
     details['max_results'] = (max_results + min(10, max_results)

--- a/src/nominatim_db/tools/convert_sqlite.py
+++ b/src/nominatim_db/tools/convert_sqlite.py
@@ -165,7 +165,7 @@ class SqliteWriter:
             await self.create_index('search_name', 'place_id')
             await self.create_index('osmline', 'parent_place_id')
             await self.create_index('tiger', 'parent_place_id')
-            # SQLite has no ltree, so category search matches on class/type.
+            # Used by the qualifier restriction of the name searches.
             await self.create_index('placex', 'class_', 'type')
             await self.create_search_index()
 

--- a/test/bdd/features/api/search/params.feature
+++ b/test/bdd/features/api/search/params.feature
@@ -446,6 +446,30 @@ Feature: Search queries
           | osm.building.yes |
         Then exactly 0 results are returned
 
+    Scenario: Repeated include parameters must all match
+        When geocoding "Boccia Club"
+          | param   | value                     |
+          | include | osm.leisure.sports_centre |
+          | include | osm.building.yes          |
+        Then more than 0 results are returned
+        When geocoding "Boccia Club"
+          | param   | value                     |
+          | include | osm.leisure.sports_centre |
+          | include | osm.amenity.cafe          |
+        Then exactly 0 results are returned
+
+    Scenario: Repeated exclude parameters drop results matching any of them
+        When geocoding "Boccia Club"
+          | param   | value            |
+          | exclude | osm.amenity.cafe |
+          | exclude | osm.building.yes |
+        Then exactly 0 results are returned
+        When geocoding "Boccia Club"
+          | param   | value             |
+          | exclude | osm.amenity.cafe  |
+          | exclude | osm.tourism.hotel |
+        Then more than 0 results are returned
+
     Scenario Outline: Invalid categories are rejected
         When sending v1/search
           | q | <param> |

--- a/test/bdd/features/api/search/params.feature
+++ b/test/bdd/features/api/search/params.feature
@@ -407,3 +407,53 @@ Feature: Search queries
           | polygon_text | geotext            |
           | polygon_svg  | svg                |
           | polygon_kml  | geokml             |
+
+    Scenario: Restrict results to a category
+        When geocoding "Boccia Club"
+          | include |
+          | osm.leisure.sports_centre |
+        Then more than 0 results are returned
+        When geocoding "Boccia Club"
+          | include |
+          | osm.amenity.cafe |
+        Then exactly 0 results are returned
+
+    Scenario: A category matches all its descendants
+        When geocoding "Boccia Club"
+          | include |
+          | osm.leisure |
+        Then more than 0 results are returned
+        When geocoding "Boccia Club"
+          | include |
+          | osm.tourism |
+        Then exactly 0 results are returned
+
+    Scenario: A place matches any of its categories
+        When geocoding "Boccia Club"
+          | include |
+          | osm.building.yes |
+        Then more than 0 results are returned
+
+    Scenario: Comma-separated categories match any of them
+        When geocoding "Boccia Club"
+          | include |
+          | osm.amenity.cafe,osm.leisure.sports_centre |
+        Then more than 0 results are returned
+
+    Scenario: Exclude drops results of the given category
+        When geocoding "Boccia Club"
+          | exclude |
+          | osm.building.yes |
+        Then exactly 0 results are returned
+
+    Scenario Outline: Invalid categories are rejected
+        When sending v1/search
+          | q | <param> |
+          | Boccia Club | <value> |
+        Then a HTTP 400 is returned
+
+        Examples:
+          | param   | value |
+          | include | osm |
+          | include | |
+          | exclude | osm.amenity;cafe |

--- a/test/bdd/utils/api_runner.py
+++ b/test/bdd/utils/api_runner.py
@@ -29,9 +29,15 @@ class APIRunner:
 
         if datatable:
             if datatable[0] == ['param', 'value']:
-                base_params.update(datatable[1:])
+                rows = datatable[1:]
             else:
-                base_params.update(zip(datatable[0], datatable[1]))
+                rows = list(zip(datatable[0], datatable[1]))
+
+            # A parameter listed more than once is sent as a repeated parameter.
+            params = {}
+            for name, value in rows:
+                params.setdefault(name, []).append(value)
+            base_params.update(params)
 
         return self.run(endpoint, base_params, http_headers)
 
@@ -44,7 +50,7 @@ class APIRunner:
 
             async with falcon.testing.ASGIConductor(app) as conductor:
                 response = await conductor.get("/" + endpoint, params=params,
-                                               headers=http_headers)
+                                               params_csv=False, headers=http_headers)
 
             return APIResponse(endpoint, response.status_code,
                                response.text, response.headers)

--- a/test/python/api/fake_adaptor.py
+++ b/test/python/api/fake_adaptor.py
@@ -38,9 +38,7 @@ class FakeAdaptor(glue.ASGIAdaptor):
         return self.params.get(name, default)
 
     def get_all(self, name):
-        value = self.params.get(name)
-        if value is None:
-            return []
+        value = self.params.get(name, [])
         return value if isinstance(value, list) else [value]
 
     def get_header(self, name, default=None):

--- a/test/python/api/fake_adaptor.py
+++ b/test/python/api/fake_adaptor.py
@@ -37,6 +37,12 @@ class FakeAdaptor(glue.ASGIAdaptor):
     def get(self, name, default=None):
         return self.params.get(name, default)
 
+    def get_all(self, name):
+        value = self.params.get(name)
+        if value is None:
+            return []
+        return value if isinstance(value, list) else [value]
+
     def get_header(self, name, default=None):
         return self.headers.get(name, default)
 

--- a/test/python/api/search/test_search_poi.py
+++ b/test/python/api/search/test_search_poi.py
@@ -118,3 +118,71 @@ class TestPoiSearchWithRestrictions:
                              details=SearchDetails.from_kwargs(args))
 
         assert [r.place_id for r in results] == [2]
+
+
+class TestCategoryFilters:
+
+    @pytest.fixture(autouse=True)
+    def fill_database(self, apiobj):
+        # A restaurant that is also a hotel.
+        apiobj.add_placex(place_id=1, class_='amenity', type='restaurant',
+                          categories=['osm.amenity.restaurant', 'osm.tourism.hotel'],
+                          centroid=(10.0, 10.0))
+        # A plain restaurant.
+        apiobj.add_placex(place_id=2, class_='amenity', type='restaurant',
+                          categories=['osm.amenity.restaurant'],
+                          centroid=(10.0, 10.0))
+        # A restaurant that is also a fast food place.
+        apiobj.add_placex(place_id=3, class_='amenity', type='restaurant',
+                          categories=['osm.amenity.restaurant', 'osm.amenity.fast_food'],
+                          centroid=(10.0, 10.0))
+
+    def run(self, apiobj, frontend, **kwargs):
+        results = run_search(apiobj, frontend, 0.1, [('amenity', 'restaurant')],
+                             details=SearchDetails.from_kwargs(kwargs))
+        return sorted(r.place_id for r in results)
+
+    def test_no_filter(self, apiobj, frontend):
+        assert self.run(apiobj, frontend) == [1, 2, 3]
+
+    def test_include_exact(self, apiobj, frontend):
+        assert self.run(apiobj, frontend, include=['osm.tourism.hotel']) == [1]
+
+    @pytest.mark.parametrize('category,expected', [('osm.amenity', [1, 2, 3]),
+                                                   ('osm.tourism', [1])])
+    def test_include_matches_descendants(self, apiobj, frontend, category, expected):
+        assert self.run(apiobj, frontend, include=[category]) == expected
+
+    @pytest.mark.parametrize('category', ['osm.amenity.fast', 'osm.amen.restaurant'])
+    def test_include_does_not_match_partial_label(self, apiobj, frontend, category):
+        assert self.run(apiobj, frontend, include=[category]) == []
+
+    def test_include_comma_is_or(self, apiobj, frontend):
+        assert self.run(apiobj, frontend,
+                        include=['osm.tourism.hotel,osm.amenity.fast_food']) == [1, 3]
+
+    @pytest.mark.parametrize('categories,expected', [
+        (['osm.tourism.hotel', 'osm.amenity.fast_food'], []),
+        (['osm.amenity.restaurant', 'osm.tourism.hotel'], [1])])
+    def test_include_repeated_is_and(self, apiobj, frontend, categories, expected):
+        assert self.run(apiobj, frontend, include=categories) == expected
+
+    def test_exclude_exact(self, apiobj, frontend):
+        assert self.run(apiobj, frontend, exclude=['osm.tourism.hotel']) == [2, 3]
+
+    def test_exclude_matches_descendants(self, apiobj, frontend):
+        assert self.run(apiobj, frontend, exclude=['osm.amenity']) == []
+
+    @pytest.mark.parametrize('group,expected', [
+        ('osm.tourism.hotel,osm.amenity.fast_food', [1, 2, 3]),
+        ('osm.tourism.hotel,osm.amenity.restaurant', [2, 3])])
+    def test_exclude_comma_needs_all(self, apiobj, frontend, group, expected):
+        assert self.run(apiobj, frontend, exclude=[group]) == expected
+
+    def test_exclude_repeated_is_or(self, apiobj, frontend):
+        assert self.run(apiobj, frontend,
+                        exclude=['osm.tourism.hotel', 'osm.amenity.fast_food']) == [2]
+
+    def test_include_and_exclude(self, apiobj, frontend):
+        assert self.run(apiobj, frontend, include=['osm.amenity'],
+                        exclude=['osm.tourism.hotel']) == [2, 3]

--- a/test/python/api/test_api_types.py
+++ b/test/python/api/test_api_types.py
@@ -86,6 +86,51 @@ class TestFormatExcluded:
             typ.format_excluded(inp)
 
 
+class TestFormatCategoryFilters:
+
+    def test_empty(self):
+        assert typ.format_category_filters([]) == []
+
+    def test_single_string(self):
+        assert typ.format_category_filters('osm.amenity.restaurant') \
+               == [['osm.amenity.restaurant']]
+
+    def test_comma_separated_is_one_group(self):
+        assert typ.format_category_filters(['osm.amenity.cafe,osm.amenity.bar']) \
+               == [['osm.amenity.cafe', 'osm.amenity.bar']]
+
+    def test_repeated_parameter_makes_groups(self):
+        assert typ.format_category_filters(['osm.tourism.hotel', 'osm.amenity.restaurant']) \
+               == [['osm.tourism.hotel'], ['osm.amenity.restaurant']]
+
+    def test_surrounding_whitespace_ignored(self):
+        assert typ.format_category_filters([' osm.amenity.cafe , osm.amenity.bar ']) \
+               == [['osm.amenity.cafe', 'osm.amenity.bar']]
+
+    def test_hyphens_folded_to_underscores(self):
+        assert typ.format_category_filters(['osm.shop.car-repair']) \
+               == [['osm.shop.car_repair']]
+
+    def test_more_than_two_labels(self):
+        assert typ.format_category_filters(['osm.boundary.administrative.4']) \
+               == [['osm.boundary.administrative.4']]
+
+    @pytest.mark.parametrize('inp', ['osm', '', '.', 'osm.', '.amenity', 'osm..cafe',
+                                     'osm.amenity restaurant', 'osm.amenity;cafe',
+                                     'osm.amenity.' + 'x' * 256])
+    def test_invalid_category(self, inp):
+        with pytest.raises(UsageError, match='Invalid category'):
+            typ.format_category_filters([inp])
+
+    def test_invalid_category_in_group(self):
+        with pytest.raises(UsageError, match='Invalid category'):
+            typ.format_category_filters(['osm.amenity.cafe,osm'])
+
+    def test_non_string(self):
+        with pytest.raises(UsageError, match='must be strings'):
+            typ.format_category_filters([12])
+
+
 @pytest.mark.parametrize('inp,expected', [
     ('Pus:94110', typ.PostcodeRef('us', '94110')),
     ('Pgb:EH4_7EA', typ.PostcodeRef('gb', 'EH4 7EA')),

--- a/test/python/api/test_api_types.py
+++ b/test/python/api/test_api_types.py
@@ -107,16 +107,13 @@ class TestFormatCategoryFilters:
         assert typ.format_category_filters([' osm.amenity.cafe , osm.amenity.bar ']) \
                == [['osm.amenity.cafe', 'osm.amenity.bar']]
 
-    def test_hyphens_folded_to_underscores(self):
-        assert typ.format_category_filters(['osm.shop.car-repair']) \
-               == [['osm.shop.car_repair']]
-
     def test_more_than_two_labels(self):
         assert typ.format_category_filters(['osm.boundary.administrative.4']) \
                == [['osm.boundary.administrative.4']]
 
     @pytest.mark.parametrize('inp', ['osm', '', '.', 'osm.', '.amenity', 'osm..cafe',
                                      'osm.amenity restaurant', 'osm.amenity;cafe',
+                                     'osm.shop.car-repair',
                                      'osm.amenity.' + 'x' * 256])
     def test_invalid_category(self, inp):
         with pytest.raises(UsageError, match='Invalid category'):

--- a/test/python/api/test_server_glue_v1.py
+++ b/test/python/api/test_server_glue_v1.py
@@ -602,6 +602,34 @@ class TestSearchEndPointSearch:
             await glue.search_endpoint(napi.NominatimAPIAsync(), a)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize('params,include,exclude', [
+        ({}, [], []),
+        ({'include': 'osm.amenity.cafe'}, ['osm.amenity.cafe'], []),
+        ({'include': ['osm.tourism.hotel', 'osm.amenity.restaurant']},
+         ['osm.tourism.hotel', 'osm.amenity.restaurant'], []),
+        ({'exclude': ['osm.amenity.fast_food']}, [], ['osm.amenity.fast_food']),
+        ({'include': 'osm.amenity', 'exclude': 'osm.amenity.fast_food'},
+         ['osm.amenity'], ['osm.amenity.fast_food']),
+        ])
+    async def test_search_category_filters(self, monkeypatch, params, include, exclude):
+        details = {}
+
+        async def _search(self, query, **kwargs):
+            details.update(kwargs)
+            return napi.SearchResults()
+
+        monkeypatch.setattr(napi.NominatimAPIAsync, 'search', _search)
+
+        a = FakeAdaptor()
+        a.params['q'] = 'something'
+        a.params.update(params)
+
+        await glue.search_endpoint(napi.NominatimAPIAsync(), a)
+
+        assert details['include'] == include
+        assert details['exclude'] == exclude
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('dedupe,numres', [(True, 1), (False, 2)])
     async def test_search_dedupe(self, dedupe, numres):
         self.results = self.results * 2


### PR DESCRIPTION
## Summary
<!-- Describe the purpose of your pull request and, if present, link to existing issues. -->

Adds `include` and `exclude` to `/search`, filtering on the `categories` ltree column from #4106/#4146/#4163. Semantics followed [Photon's doc](https://github.com/komoot/photon/blob/master/docs/categories.md) + some stuff i thought out.

```
/search?q=restaurant+berlin&include=osm.amenity.restaurant
/search?q=berlin&include=osm.amenity                                    # matches descendants
/search?q=hilton&include=osm.tourism.hotel&include=osm.amenity.restaurant
/search?q=restaurants+in+berlin&exclude=osm.amenity.fast_food
```

| Form | Meaning |
|------|---------|
| `include=a.b` | place has `a.b` or a descendant of it |
| `include=a.b,c.d` | place has `a.b` **or** `c.d` |
| `include=a.b&include=c.d` | place has `a.b` **and** `c.d` |
| `exclude=a.b` | drop places having `a.b` |
| `exclude=a.b,c.d` | drop places having `a.b` **and** `c.d` |
| `exclude=a.b&exclude=c.d` | drop places having `a.b` **or** `c.d` |

Comma being OR for `include` and AND for `exclude` is Photon's behaviour: it falls out of De Morgan on their `should(mustNot(...))`. Note their `osm_tag=` is deprecated in favour of these, so I did not copy that syntax.

Invalid categories are a 400. A category needs at least two dot-separated labels, so `include=osm` is rejected. Hyphens are folded to underscores because the Lua importer stores them that way (Yk pg limitation and blh blh); without it `osm.shop.car-repair` would silently match nothing.

i decided to keep`SearchDetails.categories`  untouched and kept alongside. It is not redundant acc to me: it also restricts which special-phrase tokens are used (`56:427,444`), which `include` as a pure row filter cannot do.

The filter is applied to every search returning placex rows  - a parameter that silently does nothing on plain name queries seemed worse than none. Sources with no categories (postcodes, interpolations, TIGER, the country fallback tables) return nothing under `include`.



## AI usage
<!-- Please list where and to what extent AI was used. -->
I was getting out of creativity for tests...so test cases +  its params are done by ai. Also for some sqllite changes ai helped me.. im not sure its correct or not as i didnt test them.

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that follow our guidelines. A deliberate violation may result in a ban. -->

- [X] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [X] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [X] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
