### PR TITLE
fix Czech address levels for municipality subdivisions

### DIFF
--- a/settings/address-levels.json
+++ b/settings/address-levels.json
@@ -143,12 +143,8 @@
 { "countries": [ "cz" ],
   "tags" : {
       "boundary" : {
-          "administrative5": 12,
-          "administrative6": [13, 0],
-          "administrative7": [14, 0],
-          "administrative8": 14,
-          "administrative9": 15,
-          "administrative10": 16
+          "administrative6": [11, 0],
+          "administrative7": [12, 0]
       }
   }
 },


### PR DESCRIPTION
## Summary

The `cz` section of `settings/address-levels.json`, added in 51576b4, places two
sub-municipal boundary levels inside the address rank range that
`docs/customize/Ranking.md` documents as *city*:

| admin_level | Czech term | what it is | rank_address today | documented band |
|---|---|---|---|---|
| 8 | obec | municipality | 14 | city (13–16) |
| 9 | městská část / městský obvod | borough of a statutory city | 15 | city (13–16) |
| 10 | část obce | part of a municipality | 16 | city (13–16) |

Address parts are filled most-specific-first, so whichever of the three is most
specific takes the *city* slot and the municipality itself is pushed out of it.

**A verified example.** The address node *Husova 12* in Beroun has no
`addr:city`, so the city has to come from the boundary hierarchy. The address
rows of its parent street are:

```
rank  8   boundary=administrative   Středočeský kraj
rank 12   boundary=administrative   okres Beroun
rank 16   boundary=administrative   Zavadilka      (r20750210, admin_level=10)
rank 20   place=suburb              Zavadilka
```

There is no rank 14 row, and even when the `admin_level=8` boundary of Beroun
(`r442333`) is present, rank 16 wins. So the *city* of this address resolves to
*Zavadilka*, a part of Beroun, instead of *Beroun*.

This is not a rare shape. On a Prague + Central Bohemia extract, of 541
`admin_level=10` boundaries **321 end up at `rank_address = 16`**. The rest are
linked to place nodes and inherit a rank from those, which is why the problem
shows up irregularly rather than everywhere. Among those boundaries there are
`admin_level=10` names as generic as *Jih* and *Sever* (South and North), and a
*Žižkov* — which is also the name of a well-known district of Prague. As a
*city* value those are actively misleading.

Nominatim's own address output keys parts by place type, so this is not very
visible in Nominatim itself. It becomes visible in consumers that follow the
documented rank → address-part mapping: Photon maps ranks 13–16 to the
GeocodeJSON `city` field, so for Czech addresses it returns a part of a
municipality as the city.

### Why the defaults are right for Czechia

The search rank table in the documentation describes the three Czech levels
almost literally:

| Czech level | default rank | documentation |
|---|---|---|
| obec | 16 | *cities, municipalities, islands* — 15 km |
| městská část | 18 | *towns, boroughs* — 4 km |
| část obce | 20 | *hamlets, farms, neighbourhoods* — 1 km |

A *část obce* with an assumed extent of 15 km, which rank 16 implies, is off by
more than an order of magnitude. So instead of moving the Czech values around,
this PR drops them and lets the defaults apply.

### What the original commit was for, and what is kept

51576b4 was needed because Czechia uses two boundary levels for purely
administrative districts that nobody would put in an address:

* `admin_level=6` — *SO ORP*, the administrative district of a municipality
  with extended powers. In the same Prague + Central Bohemia sample: 76 *SO ORP*
  relations plus the 22 administrative districts of Prague
  (*SO Praha 1* … *SO Praha 22*).
* `admin_level=7` — *SO POÚ*, the district of a municipality with an authorised
  office. 127 relations in the same area.

Both keep `rank_address = 0`, so that part of the commit is preserved unchanged
and neither level enters an address. Their search ranks move from 13/14 to
11/12, out of the *cities, municipalities* extent band and into *counties*,
which is much closer to their actual size and keeps them ordered below okres
(10) and above obec (16).

The `administrative5` override is dropped so that okres falls back to the
default 10. That stays inside the county band (10–12), so its position in the
address does not change.

Resulting hierarchy for Czechia:

| admin_level | Czech term | rank_search | rank_address | address part |
|---|---|---|---|---|
| 4 | kraj | 8 | 8 | state |
| 5 | okres | 10 | 10 | county |
| 6 | SO ORP | 11 | 0 | — |
| 7 | SO POÚ | 12 | 0 | — |
| 8 | obec | 16 | 16 | city |
| 9 | městská část | 18 | 18 | suburb |
| 10 | část obce | 20 | 20 | suburb |

### Scope

One country section, −6 / +2 lines of configuration. No test references these
values.

## AI usage

The change itself — which Czech levels to keep and which ranks to use — is my
own, based on how the Czech administrative hierarchy actually works. I used an
AI assistant while writing this pull request description and while wording the
patch and commit message, and I have read and checked every line of both. No
code was generated; the change is two lines of configuration.

I have not ticked the *tested* box: the change only takes effect on a fresh
import, and the installation I can verify it on is a Prague + Central Bohemia
extract, not a full-planet Nominatim. The rank values above were read out of
that installation's `placex` (which is where the 541 / 321 and the Beroun
example come from), and I can post the before / after from that installation
once we re-index.

## Contributor guidelines (mandatory)

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [ ] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description