### PR TITLE
Make POIs on unnamed streets searchable by address

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -409,6 +409,7 @@ DECLARE
 
   addr_item RECORD;
   addr_place RECORD;
+  parent_place RECORD;
   parent_address_place_ids BIGINT[];
 BEGIN
   nameaddress_vector := '{}'::INTEGER[];
@@ -417,6 +418,24 @@ BEGIN
     INTO parent_name_vector, parent_address_vector
     FROM search_name s
     WHERE s.place_id = parent_place_id;
+
+  IF parent_address_vector is null
+     AND (token_get_name_search_tokens(token_info) is not null
+          OR token_get_housenumber_search_tokens(token_info) is not null)
+  THEN
+    parent_name_vector := '{}'::INTEGER[];
+    parent_address_vector := '{}'::INTEGER[];
+
+    FOR parent_place IN
+      SELECT s.name_vector
+        FROM place_addressline pa
+        JOIN search_name s ON s.place_id = pa.address_place_id
+       WHERE pa.place_id = parent_place_id
+    LOOP
+      parent_address_vector := array_merge(parent_address_vector,
+                                           parent_place.name_vector);
+    END LOOP;
+  END IF;
 
   FOR addr_item IN
     SELECT ranks.*, key,

--- a/test/bdd/features/db/import/search_name.feature
+++ b/test/bdd/features/db/import/search_name.feature
@@ -315,6 +315,32 @@ Feature: Creation of search terms
          | object |
          | N1     |
 
+    Scenario: Named POIs on unnamed streets can be found by address
+        Given the grid
+         | 100 |    |   |   |    | 101 |
+         |     |    | 1 |   |    |     |
+         | 103 | 10 |   |   | 11 | 102 |
+        And the places
+         | osm | class | type  | name       | housenr |
+         | N1  | place | house | Blue house | 23      |
+        And the places
+         | osm | class   | type        | name+name    | geometry |
+         | R1  | place   | city        | Strange Town | (100,101,102,103,100) |
+        And the places
+         | osm | class   | type        | geometry |
+         | W1  | highway | residential | 10,1,11  |
+        And the ways
+         | id | nodes   |
+         | 1  | 10,1,11 |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W1              |
+        When geocoding "Blue house, Strange Town"
+        Then the result set contains
+         | object |
+         | N1     |
+
     Scenario: Some addr: tags are added to address
         Given the grid
          |    | 2 | 3 |    |


### PR DESCRIPTION
## summary

Fixes #4133

POIs that are parented to an unnamed street do not inherit any address terms because the parent street has no entry in the search_name table. The nameaddress_vector in the search_name table stays empty and the POI can only be found by its own name.
When the parent has no search terms, look up the address objects of the parent in place_addressline, take their name_vector entries from search_name and merge them into the address terms of the POI.
Adds a BDD test that verifies a named POI on an unnamed street inside a city is found when searching for the name together with the city.

## AI usage 
used for reviewing the changes i made 
