### PR TITLE
Make POIs on unnamed streets searchable by address #4133

### DIFF
--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -409,6 +409,7 @@ DECLARE
 
   addr_item RECORD;
   addr_place RECORD;
+  parent_place RECORD;
   parent_address_place_ids BIGINT[];
 BEGIN
   nameaddress_vector := '{}'::INTEGER[];
@@ -417,6 +418,24 @@ BEGIN
     INTO parent_name_vector, parent_address_vector
     FROM search_name s
     WHERE s.place_id = parent_place_id;
+
+  IF parent_address_vector is null
+     AND (token_get_name_search_tokens(token_info) is not null
+          OR token_get_housenumber_search_tokens(token_info) is not null)
+  THEN
+    parent_name_vector := '{}'::INTEGER[];
+    parent_address_vector := '{}'::INTEGER[];
+
+    FOR parent_place IN
+      SELECT s.name_vector
+        FROM place_addressline pa
+        JOIN search_name s ON s.place_id = pa.address_place_id
+       WHERE pa.place_id = parent_place_id
+    LOOP
+      parent_address_vector := array_merge(parent_address_vector,
+                                           parent_place.name_vector);
+    END LOOP;
+  END IF;
 
   FOR addr_item IN
     SELECT ranks.*, key,

--- a/test/bdd/features/db/import/search_name.feature
+++ b/test/bdd/features/db/import/search_name.feature
@@ -315,6 +315,32 @@ Feature: Creation of search terms
          | object |
          | N1     |
 
+    Scenario: Named POIs on unnamed streets can be found by address
+        Given the grid
+         | 100 |    |   |   |    | 101 |
+         |     |    | 1 |   |    |     |
+         | 103 | 10 |   |   | 11 | 102 |
+        And the places
+         | osm | class | type  | name       | housenr |
+         | N1  | place | house | Blue house | 23      |
+        And the places
+         | osm | class   | type        | name+name    | geometry |
+         | R1  | place   | city        | Strange Town | (100,101,102,103,100) |
+        And the places
+         | osm | class   | type        | geometry |
+         | W1  | highway | residential | 10,1,11  |
+        And the ways
+         | id | nodes   |
+         | 1  | 10,1,11 |
+        When importing
+        Then placex contains
+         | object | parent_place_id |
+         | N1     | W1              |
+        When geocoding "Blue house, Strange Town"
+        Then the result set contains
+         | object |
+         | N1     |
+
     Scenario: Some addr: tags are added to address
         Given the grid
          |    | 2 | 3 |    |


### PR DESCRIPTION
## summary

Fixes #4133
When a POI is parented to an unnamed street (e.g. a node sitting on an unnamed residential way), the POI only shows up when searching by its own name. The `nameaddress_vector` in the `search_name` table stays empty because the parent street has no entry in `search_name`, so address terms are never inherited.

This means searching for "Blue house, Strange Town" doesn't return the POI even though it's inside the Strange Town boundary.

## Fix

In `create_poi_search_terms`, when the parent has no `search_name` row (`parent_address_vector IS NULL`) and the POI is searchable (has name or housenumber), look up the parent's address objects in `place_addressline`, get their `name_vector` entries from `search_name`, and merge them into the POI's address terms.

## Testing

- Added a BDD test scenario in `test/bdd/features/db/import/search_name.feature` that places a named POI on an unnamed street inside a city polygon and verifies geocoding by name + city returns the correct result.
- Verified locally: `make tests` passes with no regressions.

## Checklist

- [x] Tests pass locally
- [x] Single issue addressed (#4133)
- [x] No unrelated changes mixed in
 
## proof 

<img width="797" height="501" alt="kkkk" src="https://github.com/user-attachments/assets/ef0933b0-16fa-43e4-8a37-e0f0ea756519" />
