### PR TITLE
Fix 4172 drop unwanted categories

### DIFF
--- a/lib-sql/functions/place_triggers.sql
+++ b/lib-sql/functions/place_triggers.sql
@@ -110,7 +110,8 @@ BEGIN
       SELECT * INTO search_rank, address_rank
         FROM compute_place_rank(existingplacex.country_code,
                                 CASE WHEN is_area THEN 'A' ELSE NEW.osm_type END,
-                                NEW.categories, NEW.admin_level,
+                                drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
+                                NEW.name,NEW.extratags, is_area), NEW.admin_level,
                                 (NEW.extratags->'capital') = 'yes',
                                 NEW.address->'postcode');
 

--- a/lib-sql/functions/place_triggers.sql
+++ b/lib-sql/functions/place_triggers.sql
@@ -110,12 +110,14 @@ BEGIN
       SELECT * INTO search_rank, address_rank
         FROM compute_place_rank(existingplacex.country_code,
                                 CASE WHEN is_area THEN 'A' ELSE NEW.osm_type END,
-                                drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
-                                NEW.name,NEW.extratags, is_area), NEW.admin_level,
+                                drop_unwanted_categories(NEW.categories, NEW.osm_type,
+                                                         NEW.admin_level, NEW.name,
+                                                         NEW.extratags, is_area),
+                                NEW.admin_level,
                                 (NEW.extratags->'capital') = 'yes',
                                 NEW.address->'postcode');
 
-      existing_is_area := ST_GeometryType(existingplacex.geometry) in ('ST_Polygon','ST_MultiPolygon');
+      existing_is_area := ST_GeometryType(existingplacex.geometry) in ('ST_Polygon', 'ST_MultiPolygon');
 
       IF (address_rank BETWEEN 4 and 27
           AND (existingplacex.rank_address <= 0 OR existingplacex.rank_address > 27))

--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -689,7 +689,8 @@ BEGIN
     SELECT * INTO NEW.rank_search, NEW.rank_address
       FROM compute_place_rank(NEW.country_code,
                               CASE WHEN is_area THEN 'A' ELSE NEW.osm_type END,
-                              NEW.categories, NEW.admin_level,
+                              drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
+                              NEW.name,NEW.extratags, is_area), NEW.admin_level,
                               (NEW.extratags->'capital') = 'yes',
                               NEW.address->'postcode');
     -- a country code make no sense below rank 4 (country)
@@ -722,6 +723,7 @@ CREATE OR REPLACE FUNCTION placex_update()
   AS $$
 DECLARE
   i INTEGER;
+  is_area BOOLEAN;
   location RECORD;
 {% if db.middle_db_format == '1' %}
   relation_members TEXT[];
@@ -840,14 +842,15 @@ BEGIN
   END IF;
   {% if debug %}RAISE WARNING 'Country updated: "%"', NEW.country_code;{% endif %}
 
-
+  is_area := ST_GeometryType(NEW.geometry) IN ('ST_Polygon','ST_MultiPolygon');
   -- recompute the ranks, they might change when linking changes
   SELECT * INTO NEW.rank_search, NEW.rank_address
     FROM compute_place_rank(NEW.country_code,
                             CASE WHEN ST_GeometryType(NEW.geometry)
                                         IN ('ST_Polygon','ST_MultiPolygon')
                             THEN 'A' ELSE NEW.osm_type END,
-                            NEW.categories, NEW.admin_level,
+                            drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
+                              NEW.name,NEW.extratags, is_area), NEW.admin_level,
                             (NEW.extratags->'capital') = 'yes',
                             NEW.address->'postcode');
   -- Short-cut out for linked places. Note that this must happen after the

--- a/lib-sql/functions/placex_triggers.sql
+++ b/lib-sql/functions/placex_triggers.sql
@@ -689,8 +689,10 @@ BEGIN
     SELECT * INTO NEW.rank_search, NEW.rank_address
       FROM compute_place_rank(NEW.country_code,
                               CASE WHEN is_area THEN 'A' ELSE NEW.osm_type END,
-                              drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
-                              NEW.name,NEW.extratags, is_area), NEW.admin_level,
+                              drop_unwanted_categories(NEW.categories, NEW.osm_type,
+                                                       NEW.admin_level, NEW.name,
+                                                       NEW.extratags, is_area),
+                              NEW.admin_level,
                               (NEW.extratags->'capital') = 'yes',
                               NEW.address->'postcode');
     -- a country code make no sense below rank 4 (country)
@@ -846,11 +848,11 @@ BEGIN
   -- recompute the ranks, they might change when linking changes
   SELECT * INTO NEW.rank_search, NEW.rank_address
     FROM compute_place_rank(NEW.country_code,
-                            CASE WHEN ST_GeometryType(NEW.geometry)
-                                        IN ('ST_Polygon','ST_MultiPolygon')
-                            THEN 'A' ELSE NEW.osm_type END,
-                            drop_unwanted_categories(NEW.categories, NEW.osm_type, NEW.admin_level,
-                              NEW.name,NEW.extratags, is_area), NEW.admin_level,
+                            CASE WHEN is_area THEN 'A' ELSE NEW.osm_type END,
+                            drop_unwanted_categories(NEW.categories, NEW.osm_type,
+                                                     NEW.admin_level, NEW.name,
+                                                     NEW.extratags, is_area),
+                            NEW.admin_level,
                             (NEW.extratags->'capital') = 'yes',
                             NEW.address->'postcode');
   -- Short-cut out for linked places. Note that this must happen after the

--- a/lib-sql/functions/ranking.sql
+++ b/lib-sql/functions/ranking.sql
@@ -7,6 +7,52 @@
 
 -- Functions related to search and address ranks
 
+-- function for removing the categories that shouldn't be taken into account while ranking.
+-- categories outside the osm.* tree are always kept.
+CREATE OR REPLACE FUNCTION drop_unwanted_categories(categories ltree[], osm_type TEXT,
+                                  admin_level SMALLINT, name HSTORE,
+                                  extratags HSTORE, is_area BOOLEAN)
+  RETURNS ltree[]
+  AS $$
+DECLARE
+  cat ltree;
+  cat_class TEXT;
+  result ltree[] := ARRAY[]::ltree[];
+BEGIN
+  IF categories IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  FOREACH cat IN ARRAY categories LOOP
+    IF cat::TEXT LIKE 'osm.%' THEN
+      cat_class :=subpath(cat,1,1)::TEXT;
+
+      -- our 1st condition - unnamed highway with area = yes
+      IF cat_class='highway'
+        AND is_area=TRUE AND name IS NULL
+        AND extratags IS NOT NULL AND extratags ? 'area'
+        AND extratags -> 'area' = 'yes'
+      THEN
+        CONTINUE;
+      END IF;
+
+      -- our 2nd and 3rd condition - bad Boundary
+      IF cat_class ='boundary' THEN
+        IF is_area=FALSE OR (admin_level<=4 AND osm_type='W')
+        THEN
+          CONTINUE;
+        END IF;
+      END IF;
+    END IF;
+
+    result:=array_append(result,cat);
+  END LOOP;
+
+  RETURN result;
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
 -- Check if a place is rankable at all.
 -- These really should be dropped at the lua level eventually.
 CREATE OR REPLACE FUNCTION is_rankable_place(osm_type TEXT, categories ltree[],
@@ -14,42 +60,18 @@ CREATE OR REPLACE FUNCTION is_rankable_place(osm_type TEXT, categories ltree[],
                                              extratags HSTORE, is_area BOOLEAN)
   RETURNS BOOLEAN
   AS $$
-DECLARE
-  cat ltree;
-  cat_class TEXT;
+
 BEGIN
   IF categories IS NULL THEN
     RETURN TRUE;
   END IF;
-  FOREACH cat IN ARRAY categories LOOP
-    -- Only check osm.* categories
-    IF cat ~ 'osm.*'::lquery THEN
-      cat_class := split_part(cat::text, '.', 2);
-
-      -- Check unnamed highway area
-      IF cat_class = 'highway' AND is_area AND name IS NULL
-         AND extratags ? 'area' AND extratags->'area' = 'yes'
-      THEN
-        CONTINUE;
-      END IF;
-
-      -- Check non-area boundary
-      IF cat_class = 'boundary' THEN
-        IF NOT is_area
-           OR (admin_level <= 4 AND osm_type = 'W')
-        THEN
-          CONTINUE;
-        END IF;
-      END IF;
-
-      RETURN TRUE;
-    END IF;
-  END LOOP;
-
-  RETURN FALSE;
+  RETURN array_length(drop_unwanted_categories(categories, osm_type, admin_level,
+                      name, extratags, is_area ),1)
+                      IS NOT NULL;
 END;
 $$
 LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
+
 
 
 -- Return an approximate search radius according to the search rank.

--- a/lib-sql/functions/ranking.sql
+++ b/lib-sql/functions/ranking.sql
@@ -7,11 +7,11 @@
 
 -- Functions related to search and address ranks
 
--- function for removing the categories that shouldn't be taken into account while ranking.
--- categories outside the osm.* tree are always kept.
+-- Function for removing the categories that shouldn't be taken into account while ranking.
+-- Categories outside the osm.* tree are always kept.
 CREATE OR REPLACE FUNCTION drop_unwanted_categories(categories ltree[], osm_type TEXT,
-                                  admin_level SMALLINT, name HSTORE,
-                                  extratags HSTORE, is_area BOOLEAN)
+                                                    admin_level SMALLINT, name HSTORE,
+                                                    extratags HSTORE, is_area BOOLEAN)
   RETURNS ltree[]
   AS $$
 DECLARE
@@ -25,27 +25,27 @@ BEGIN
 
   FOREACH cat IN ARRAY categories LOOP
     IF cat::TEXT LIKE 'osm.%' THEN
-      cat_class :=subpath(cat,1,1)::TEXT;
+      cat_class := subpath(cat, 1, 1)::TEXT;
 
-      -- our 1st condition - unnamed highway with area = yes
-      IF cat_class='highway'
-        AND is_area=TRUE AND name IS NULL
+      -- Check unnamed highway area
+      IF cat_class = 'highway'
+        AND is_area AND name IS NULL
         AND extratags IS NOT NULL AND extratags ? 'area'
-        AND extratags -> 'area' = 'yes'
+        AND extratags->'area' = 'yes'
       THEN
         CONTINUE;
       END IF;
 
-      -- our 2nd and 3rd condition - bad Boundary
-      IF cat_class ='boundary' THEN
-        IF is_area=FALSE OR (admin_level<=4 AND osm_type='W')
+      -- Check non-area boundary
+      IF cat_class = 'boundary' THEN
+        IF NOT is_area OR (admin_level <= 4 AND osm_type = 'W')
         THEN
           CONTINUE;
         END IF;
       END IF;
     END IF;
 
-    result:=array_append(result,cat);
+    result := array_append(result, cat);
   END LOOP;
 
   RETURN result;
@@ -60,13 +60,12 @@ CREATE OR REPLACE FUNCTION is_rankable_place(osm_type TEXT, categories ltree[],
                                              extratags HSTORE, is_area BOOLEAN)
   RETURNS BOOLEAN
   AS $$
-
 BEGIN
   IF categories IS NULL THEN
     RETURN TRUE;
   END IF;
   RETURN array_length(drop_unwanted_categories(categories, osm_type, admin_level,
-                      name, extratags, is_area ),1)
+                      name, extratags, is_area), 1)
                       IS NOT NULL;
 END;
 $$

--- a/test/bdd/features/db/import/rank_computation.feature
+++ b/test/bdd/features/db/import/rank_computation.feature
@@ -306,3 +306,13 @@ Feature: Rank assignment
           | W1     | N10     |
           | W2     | N10     |
           | W2     | N11     |
+
+
+    Scenario: Boundary categories are ignored for ranking on non-area objects
+        Given the named places
+          | osm | class    | type           | admin | categories                                      | geometry |
+          | W20 | boundary | administrative | 4     | osm.waterway.river, osm.boundary.administrative | 1 1, 2 2 |
+        When importing
+        Then placex contains
+          | object | rank_search | rank_address |
+          | W20    | 19          | 0 |


### PR DESCRIPTION
## Summary

While the `is_rankable_place()` already excluded certain highway and boundary categories, it did not actually remove the problem category from the array. Instead, it simply decided to continue processing if the unwanted category was found via `CONTINUE`. This resulted in the `compute_place_rank()` seeing the unwanted category and assigning a rank.

The fix makes the `drop_unwanted_categories()` handle the filtering of the array, removing any problematic categories and passing what remains to the ranking function. Now the `is_rankable_place()` becomes a very simple function, just checking whether there is anything remaining after the filtration, without changing the filtration rules themselves.

Before, there were three calls to `compute_place_rank()` from `NEW.categories`, that did not filter the array first — `placex_insert()`, `placex_update()` and `place_insert()`. Now they all use the filtered array.

As noted above, this solution remains minimal, leaving `NEW.categories` array untouched and not changing the object class/type.

Issue : #4172


## AI usage
<!-- Please list where and to what extent AI was used. -->
Used an AI assistant to help navigate the codebase, discuss the approach,
and Testing.

## Contributor guidelines (mandatory)
<!-- We only accept pull requests that folslow our guidelines. A deliberate violation may result in a ban. -->

- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
