### PR TITLE
Switch nearest road/place search to KNN

### DIFF
--- a/lib-sql/functions/partition-functions.sql
+++ b/lib-sql/functions/partition-functions.sql
@@ -161,12 +161,13 @@ BEGIN
 
 {% for partition in db.partitions %}
   IF in_partition = {{ partition }} THEN
-    SELECT place_id FROM search_name_{{ partition }}
+    SELECT CASE WHEN token_matches_street(token_info, name_vector) THEN place_id ELSE NULL END
       INTO parent
-      WHERE token_matches_street(token_info, name_vector)
-            AND centroid && ST_Expand(point, 0.015)
+      FROM search_name_{{ partition }}
+      WHERE (token_matches_street(token_info, name_vector)
+             OR ST_Distance(centroid, point) > 0.1)
             AND address_rank between 26 and 27
-      ORDER BY ST_Distance(centroid, point) ASC limit 1;
+      ORDER BY centroid <-> point LIMIT 1;
     RETURN parent;
   END IF;
 {% endfor %}
@@ -190,13 +191,13 @@ BEGIN
 
 {% for partition in db.partitions %}
   IF in_partition = {{ partition }} THEN
-    SELECT place_id
+    SELECT CASE WHEN token_matches_place(token_info, name_vector) THEN place_id ELSE NULL END
       INTO parent
       FROM search_name_{{ partition }}
-      WHERE token_matches_place(token_info, name_vector)
-            AND centroid && ST_Expand(point, 0.04)
+      WHERE (token_matches_place(token_info, name_vector)
+             OR ST_Distance(centroid, point) > 0.1)
             AND address_rank between 16 and 25
-      ORDER BY ST_Distance(centroid, point) ASC limit 1;
+      ORDER BY centroid <-> point LIMIT 1;
     RETURN parent;
   END IF;
 {% endfor %}

--- a/lib-sql/functions/partition-functions.sql
+++ b/lib-sql/functions/partition-functions.sql
@@ -298,7 +298,7 @@ BEGIN
         ORDER BY geometry <-> point
         LIMIT 1
     LOOP
-      IF r.dist < 0.1 THEN
+      IF r.dist < 0.06 THEN
         RETURN r.place_id;
       END IF;
       RETURN NULL;

--- a/lib-sql/functions/partition-functions.sql
+++ b/lib-sql/functions/partition-functions.sql
@@ -287,21 +287,20 @@ CREATE OR REPLACE FUNCTION getNearestRoadPlaceId(in_partition INTEGER, point GEO
   AS $$
 DECLARE
   r RECORD;
-  search_diameter FLOAT;
 BEGIN
 
 {% for partition in db.partitions %}
   IF in_partition = {{ partition }} THEN
-    search_diameter := 0.00005;
-    WHILE search_diameter < 0.1 LOOP
-      FOR r IN
-        SELECT place_id FROM location_road_{{ partition }}
-          WHERE ST_DWithin(geometry, point, search_diameter)
-          ORDER BY ST_Distance(geometry, point) ASC limit 1
-      LOOP
+    FOR r IN
+      SELECT place_id, ST_Distance(geometry, point) as dist
+        FROM location_road_{{ partition }}
+        ORDER BY geometry <-> point
+        LIMIT 1
+    LOOP
+      IF r.dist < 0.1 THEN
         RETURN r.place_id;
-      END LOOP;
-      search_diameter := search_diameter * 2;
+      END IF;
+      RETURN NULL;
     END LOOP;
     RETURN NULL;
   END IF;

--- a/lib-sql/functions/ranking.sql
+++ b/lib-sql/functions/ranking.sql
@@ -97,9 +97,9 @@ BEGIN
   ELSIF rank_search < 24 THEN
     RETURN 0.02;
   ELSIF rank_search < 26 THEN
-    RETURN 0.002;
+    RETURN 0.005;
   ELSIF rank_search < 28 THEN
-    RETURN 0.001;
+    RETURN 0.002;
   END IF;
 
   RETURN 0;


### PR DESCRIPTION
Switches to using the `ORDER BY .. <->` operator for searching the nearest road or place. This will make Postgis use a KNN search, which in most cases is much faster than a bbox+distance-order.  This means we can increase the search radius and get rid of loop in the nearest road search which increased the search distance. Shaves off around 2.5 hours for a planet import.

Matching streets are now searched with a radius of 0.1. This might lead to false positives in case where the mapping is wrong or incomplete. Lets see if there are any complaints.

I've decreased the radius to search for any nearest street. It's better to do the full address computation than attach to a very far away street.

Finally increased slightly the invalidation radius when streets are changed. This should catch a couple more house numbers.

Closes #4174.