### PR TITLE
keep secondary main tags in extratags

### DIFF
--- a/lib-lua/themes/nominatim/init.lua
+++ b/lib-lua/themes/nominatim/init.lua
@@ -696,18 +696,12 @@ else
 end
 
 -- Build extratags for a merged row: filter via EXTRATAGS_FILTER,
--- remove sibling main tags (they belong in categories, not extratags),
--- then add any required extratags (wikipedia, wikidata, etc.).
-local function build_extratags(place, k, v)
+-- remove the winning main tag (it belongs in class/type, not extratags),
+-- keeping any secondary main tags, then add any required extratags.
+local function build_extratags(place, k, v, main_class)
     local extra = EXTRATAGS_FILTER(place, k, v) or {}
-    for ek, ev in pairs(extra) do
-        local ktable = MAIN_KEYS[ek]
-        if ktable ~= nil then
-            local transform = ktable[ev] or ktable[1]
-            if type(transform) == 'function' then
-                extra[ek] = nil
-            end
-        end
+    if main_class ~= nil then
+        extra[main_class] = nil
     end
     for tk, tv in pairs(place.object.tags) do
         if REQUIRED_EXTRATAGS_FILTER(tk, tv) and extra[tk] == nil then
@@ -807,8 +801,7 @@ function module.process_tags(o)
         end
     end
 
-    -- Build extratags once after the loop (filters out main keys automatically)
-    merged_extratags = build_extratags(o, nil, nil)
+    merged_extratags = build_extratags(o, nil, nil, main_class)
 
     -- Handle tag-based fallback: always add category, set class/type only if sole producer
     if tag_fallback ~= nil then

--- a/test/bdd/features/osm2pgsql/import/custom_style.feature
+++ b/test/bdd/features/osm2pgsql/import/custom_style.feature
@@ -83,6 +83,26 @@ Feature: Import with custom styles by osm2pgsql
             | N3     | tourism | 'amenity': 'yes' | osm.tourism.hotel                        |
             | N4     | amenity | -                | osm.tourism.hotel, osm.amenity.telephone |
 
+    Scenario: Secondary main tags are kept in extratags
+        Given the lua style file
+            """
+            local flex = require('import-extratags')
+
+            flex.set_main_tags{
+                amenity = 'always',
+                tourism = 'always'
+            }
+            """
+        When loading osm data
+            """
+            n1 Ttourism=hotel,amenity=telephone x0 y0
+            n2 Tamenity=telephone,tourism=museum x0 y0
+            """
+        Then place contains exactly
+            | object | class   | type       | extratags!dict      | categories                               |
+            | N1     | amenity | telephone  | 'tourism': 'hotel'  | osm.tourism.hotel, osm.amenity.telephone |
+            | N2     | amenity | telephone  | 'tourism': 'museum' | osm.amenity.telephone, osm.tourism.museum |
+
     Scenario: Ignore some tags
         Given the lua style file
             """

--- a/test/bdd/features/osm2pgsql/import/simple.feature
+++ b/test/bdd/features/osm2pgsql/import/simple.feature
@@ -61,4 +61,18 @@ Feature: Import of simple objects by osm2pgsql
            | street  |
            | address |
            | full    |
-           | extratags |
+
+    Scenario: Tags used by Nominatim internally are always imported with extratags
+        Given the lua style file
+            """
+            local flex = require('import-extratags')
+            """
+        When loading osm data
+            """
+            n1 Tboundary=administrative,place=city,name=Foo,wikipedia:de=Foo
+            n2 Tplace=hamlet,wikidata=Q1234321,name=Bar
+            """
+        Then place contains exactly
+           | object | class    | extratags!dict                            | categories!set                                  |
+           | N1     | boundary | 'place': 'city', 'wikipedia:de': 'Foo'   | 'osm.boundary.administrative', 'osm.place.city' |
+           | N2     | place    | 'wikidata': 'Q1234321'                   | 'osm.place.hamlet'                              |

--- a/test/bdd/features/osm2pgsql/import/tags.feature
+++ b/test/bdd/features/osm2pgsql/import/tags.feature
@@ -129,8 +129,8 @@ Feature: Tag evaluation
             """
         Then place contains exactly
             | object | class   | type    | name!dict   | extratags!dict          | categories!set                               |
-            | N7001  | highway | primary | 'name': '1' | -                       | 'osm.highway.primary'                        |
-            | N7002  | bridge  | yes     | 'name': '1' | 'bridge:name': '1'      | 'osm.bridge.yes', 'osm.highway.primary'      |
+            | N7001  | highway | primary | 'name': '1' | 'bridge': 'yes'                | 'osm.highway.primary'                        |
+            | N7002  | bridge  | yes     | 'name': '1' | 'highway': 'primary', 'bridge:name': '1' | 'osm.bridge.yes', 'osm.highway.primary'      |
 
 
     Scenario: Categories are populated and merged for main tags


### PR DESCRIPTION
## summary

When an object carries several main tags, Nominatim converts all of them into categories but only places a single one into class/type. The remaining main tags were dropped entirely, so they were no longer accessible in the results (categories are not returned).

Keep secondary main tags in extratags instead of removing them from the extratags set. Only the winning main tag that became class/type is excluded from extratags. Because extratags are only collected when the Lua style is configured to keep extra tags, the behaviour in the default import (extra tags disabled) is unchanged.

Adds a BDD test covering secondary main tags being kept in extratags, and updates the existing main-with-extra and internally-used-tags tests for the new behaviour.

Fixes https://github.com/osm-search/Nominatim/issues/4173

## AI usage
This pull request was made manually and reviewed by Claude.  The change was verified by running the osm2pgsql BDD import tests (60 passed), and the previously-affected tests were updated accordingly.

## Contributor guidelines (mandatory)
- [x] I have adhered to the [coding style](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#coding-style)
- [x] I have [tested](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#testing) the proposed changes
- [x] I have [disclosed](https://github.com/osm-search/Nominatim/blob/master/CONTRIBUTING.md#using-ai-assisted-code-generators) above any use of AI to generate code, documentation, or the pull request description
