### PR TITLE
Increase postcode extent for the US

### DIFF
--- a/settings/country_settings.yaml
+++ b/settings/country_settings.yaml
@@ -1829,6 +1829,7 @@ us:
     postcode:
       pattern: "(ddddd)(?:-dddd)?"
       output: \1
+      extent: 25000
 
 
 # Uruguay (Uruguay)


### PR DESCRIPTION
This increases the extent for postcodes in the US to 25km to cover the rather large rural areas.

Closes #4178.
