### PR TITLE
Fix SQL debug output for newer pygments versions

### DIFF
--- a/src/nominatim_api/logging.py
+++ b/src/nominatim_api/logging.py
@@ -216,7 +216,7 @@ class HTMLLogger(BaseLogger):
         sqlstr = self.format_sql(conn, statement, params)
         if CODE_HIGHLIGHT:
             sqlstr = highlight(sqlstr, PostgresLexer(),
-                               HtmlFormatter(nowrap=True, lineseparator='<br />'))
+                               HtmlFormatter(nowrap=True)).replace('\n', '<br />')
             self._write(f'<div class="highlight"><code class="lang-sql">{sqlstr}</code></div>')
         else:
             self._write(f'<code class="lang-sql">{html.escape(sqlstr)}</code>')

--- a/src/nominatim_api/logging.py
+++ b/src/nominatim_api/logging.py
@@ -213,7 +213,7 @@ class HTMLLogger(BaseLogger):
     def sql(self, conn: AsyncConnection, statement: 'sa.Executable',
             params: Union[Mapping[str, Any], Sequence[Mapping[str, Any]], None]) -> None:
         self._timestamp()
-        sqlstr = self.format_sql(conn, statement, params)
+        sqlstr = self.format_sql(conn, statement, params) + ';'
         if CODE_HIGHLIGHT:
             sqlstr = highlight(sqlstr, PostgresLexer(),
                                HtmlFormatter(nowrap=True)).replace('\n', '<br />')
@@ -303,7 +303,7 @@ class TextLogger(BaseLogger):
             params: Union[Mapping[str, Any], Sequence[Mapping[str, Any]], None]) -> None:
         self._timestamp()
         sqlstr = '\n| '.join(textwrap.wrap(self.format_sql(conn, statement, params), width=78))
-        self._write(f"| {sqlstr}\n\n")
+        self._write(f"| {sqlstr};\n\n")
 
     def _python_var(self, var: Any) -> str:
         return str(var)


### PR DESCRIPTION
This works around a regression in recent versions of pygments, where the line separator for the HTML formatter gets html-quoted and thus appears in the SQL output as `<br/>` instead of having the effect of a line break.

Also adds a semicolon at the end of an SQL query to make it easier to spot the end when two SQL queries are printed consecutively.
