### PR TITLE
Add type and attribute properties to language tagging sanitizer

### DIFF
--- a/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
+++ b/src/nominatim_db/tokenizer/sanitizers/tag_analyzer_by_language.py
@@ -10,6 +10,9 @@ language of the tag. The language is taken from the suffix of the name.
 If a name already has an analyzer tagged, then this is kept.
 
 Arguments:
+    type: Define which type of names should be considered for language tagging:
+          proper names of the object ('name') or names defining the address
+          ('address'). (default: 'name')
     filter-kind: Restrict the names the sanitizer should be applied to
                  the given tags. The parameter expects a list of
                  regular expressions which are matched against 'kind'.
@@ -30,6 +33,7 @@ Arguments:
     mode: Define how the variants are created and may be 'replace' or
           'append'. When set to 'append' the original name (without
           any analyzer tagged) is retained. (default: replace)
+    attribute: Attribute which will be set. (default: analyzer)
 
 """
 from typing import Callable, Dict, Optional, List
@@ -44,9 +48,11 @@ class _AnalyzerByLanguage:
     """
 
     def __init__(self, config: SanitizerConfig) -> None:
+        self.name_type = config.get('type', 'name')
         self.filter_kind = config.get_filter('filter-kind')
         self.replace = config.get('mode', 'replace') != 'append'
         self.suffix_ignore = set(config.get_string_list('suffix-ignore'))
+        self.out_attribute = str(config.get('attribute', 'analyzer'))
         whitelist = config.get('whitelist')
         self.suffix_matcher: Callable[[str], bool]
         if whitelist is None:
@@ -68,13 +74,14 @@ class _AnalyzerByLanguage:
                         self.deflangs[ccode] = clangs
 
     def __call__(self, obj: ProcessInfo) -> None:
-        if not obj.names:
+        to_process = obj.names if self.name_type == 'name' else obj.address
+        if not to_process:
             return
 
         more_names = []
 
-        for name in (n for n in obj.names
-                     if not n.has_attr('analyzer') and self.filter_kind(n.kind)):
+        for name in (n for n in to_process
+                     if not n.has_attr(self.out_attribute) and self.filter_kind(n.kind)):
             if name.suffix and name.suffix not in self.suffix_ignore:
                 langs = [name.suffix] if self.suffix_matcher(name.suffix) else None
             else:
@@ -82,13 +89,13 @@ class _AnalyzerByLanguage:
 
             if langs:
                 if self.replace:
-                    name.set_attr('analyzer', langs[0])
+                    name.set_attr(self.out_attribute, langs[0])
                 else:
-                    more_names.append(name.clone(attr={'analyzer': langs[0]}))
+                    more_names.append(name.clone(attr={self.out_attribute: langs[0]}))
 
-                more_names.extend(name.clone(attr={'analyzer': lg}) for lg in langs[1:])
+                more_names.extend(name.clone(attr={self.out_attribute: lg}) for lg in langs[1:])
 
-        obj.names.extend(more_names)
+        to_process.extend(more_names)
 
 
 def create(config: SanitizerConfig) -> SanitizerFunc:

--- a/test/python/tokenizer/sanitizers/test_tag_analyzer_by_language.py
+++ b/test/python/tokenizer/sanitizers/test_tag_analyzer_by_language.py
@@ -39,8 +39,38 @@ class TestWithDefaults:
 
     @pytest.mark.parametrize('suffix', ['DE', 'asbc'])
     def test_illegal_suffix(self, suffix):
-        assert self.run_sanitizer_on('fr', **{'name_' + suffix: 'Foo'}) \
+        assert self.run_sanitizer_on('fr', **{f"name_{suffix}": 'Foo'}) \
                  == [('Foo', 'name', suffix, {})]
+
+
+class TestWithAddress:
+
+    @pytest.fixture(autouse=True)
+    def setup_country(self, def_config):
+        self.config = def_config
+
+    def run_sanitizer_on(self, country, **kwargs):
+        place = PlaceInfo({'address': {k.replace('_', ':'): v for k, v in kwargs.items()},
+                           'country_code': country})
+        PlaceSanitizer([{'step': 'tag-analyzer-by-language',
+                         'type': 'address'}], self.config).process_names(place)
+
+        return sorted([(p.name, p.kind, p.suffix, p.attr) for p in place.searchable_address])
+
+    def test_no_names(self):
+        assert self.run_sanitizer_on('de') == []
+
+    def test_simple(self):
+        res = self.run_sanitizer_on('fr', street='Foo', street_de='Zoo', city_abc='M')
+
+        assert res == [('Foo', 'street', None, {}),
+                       ('M', 'city', 'abc', {'analyzer': 'abc'}),
+                       ('Zoo', 'street', 'de', {'analyzer': 'de'})]
+
+    @pytest.mark.parametrize('suffix', ['DE', 'asbc'])
+    def test_illegal_suffix(self, suffix):
+        assert self.run_sanitizer_on('fr', **{f"suburb_{suffix}": 'Foo'}) \
+                 == [('Foo', 'suburb', suffix, {})]
 
 
 class TestFilterKind:
@@ -292,3 +322,13 @@ class TestSuffixIgnore:
 
     def test_ignored_suffix_and_whitelisted(self):
         assert self.run_sanitizer_on(['de'], name_de='foo') == [('foo', 'de')]
+
+
+def test_custom_attribute(def_config):
+    place = PlaceInfo({'name': {'name:fr': 'Cité'}, 'country_code': 'de'})
+    PlaceSanitizer([{'step': 'tag-analyzer-by-language', 'attribute': 'lang'}],
+                   def_config).process_names(place)
+
+    assert len(place.searchable_names) == 1
+
+    assert place.searchable_names[0].attr == {'lang': 'fr'}


### PR DESCRIPTION
This adds two more configuration options to the language-tagging sanitizer:

* `type` allows to also use it in address terms
* `attribute` allows to save the language in a different attribut than `analyzer`

Not currently used but will come int handy later.